### PR TITLE
add an owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+ - dhellmann
+ - hardys
+ - markmc
+ - sadasu
+ - stbenjam
+ - zaneb


### PR DESCRIPTION
Populate the OWNERS file so the Prow tests will let us add CI jobs.

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/11103/pull-ci-openshift-release-master-owners/1296115947110666240 is failing on https://github.com/openshift/release/pull/11103