### PR TITLE
Update the provisioning CRD generated by vendored controller-gen

### DIFF
--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -19,14 +19,10 @@ spec:
       description: Provisioning is the Schema for the provisionings API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -34,61 +30,25 @@ spec:
           description: ProvisioningSpec defines the desired state of Provisioning
           properties:
             provisioningDHCPExternal:
-              description: ProvisioningDHCPExternal indicates whether the DHCP server
-                for IP addresses in the provisioning DHCP range is present within
-                the metal3 cluster or external to it. This field is being deprecated
-                in favor of provisioningNetwork.
+              description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
               type: boolean
             provisioningDHCPRange:
-              description: ProvisioningDHCPRange needs to be interpreted along with
-                ProvisioningDHCPExternal. If the value of provisioningDHCPExternal
-                is set to False, then ProvisioningDHCPRange represents the range of
-                IP addresses that the DHCP server running within the metal3 cluster
-                can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal
-                is set to True, then the value of ProvisioningDHCPRange will be ignored.
-                When the value of ProvisioningDHCPExternal is set to False, indicating
-                an internal DHCP server and the value of ProvisioningDHCPRange is
-                not set, then the DHCP range is taken to be the default range which
-                goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the
-                only value in all of the Provisioning configuration that can be changed
-                after the installer has created the CR. This value needs to be two
-                comma sererated IP addresses within the ProvisioningNetworkCIDR where
-                the 1st address represents the start of the range and the 2nd address
-                represents the last usable address in the  range.
+              description: ProvisioningDHCPRange needs to be interpreted along with ProvisioningDHCPExternal. If the value of provisioningDHCPExternal is set to False, then ProvisioningDHCPRange represents the range of IP addresses that the DHCP server running within the metal3 cluster can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal is set to True, then the value of ProvisioningDHCPRange will be ignored. When the value of ProvisioningDHCPExternal is set to False, indicating an internal DHCP server and the value of ProvisioningDHCPRange is not set, then the DHCP range is taken to be the default range which goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the only value in all of the Provisioning configuration that can be changed after the installer has created the CR. This value needs to be two comma sererated IP addresses within the ProvisioningNetworkCIDR where the 1st address represents the start of the range and the 2nd address represents the last usable address in the  range.
               type: string
             provisioningIP:
-              description: ProvisioningIP is the IP address assigned to the provisioningInterface
-                of the baremetal server. This IP address should be within the provisioning
-                subnet, and outside of the DHCP range.
+              description: ProvisioningIP is the IP address assigned to the provisioningInterface of the baremetal server. This IP address should be within the provisioning subnet, and outside of the DHCP range.
               type: string
             provisioningInterface:
-              description: ProvisioningInterface is the name of the network interface
-                on a baremetal server to the provisioning network. It can have values
-                like eth1 or ens3.
+              description: ProvisioningInterface is the name of the network interface on a baremetal server to the provisioning network. It can have values like eth1 or ens3.
               type: string
             provisioningNetwork:
-              description: ProvisioningNetwork provides a way to indicate the state
-                of the underlying network configuration for the provisioning network.
-                This field can have one of the following values - `Managed`- when
-                the provisioning network is completely managed by the Baremetal IPI
-                solution. `Unmanaged`- when the provsioning network is present and
-                used but the user is responsible for managing DHCP. Virtual media
-                provisioning is recommended but PXE is still available if required.
-                `Disabled`- when the provisioning network is fully disabled. User
-                can bring up the baremetal cluster using virtual media or assisted
-                installation. If using metal3 for power management, BMCs must be accessible
-                from the machine networks. User should provide two IPs on the external
-                network that would be used for provisioning services.
+              description: ProvisioningNetwork provides a way to indicate the state of the underlying network configuration for the provisioning network. This field can have one of the following values - `Managed`- when the provisioning network is completely managed by the Baremetal IPI solution. `Unmanaged`- when the provsioning network is present and used but the user is responsible for managing DHCP. Virtual media provisioning is recommended but PXE is still available if required. `Disabled`- when the provisioning network is fully disabled. User can bring up the baremetal cluster using virtual media or assisted installation. If using metal3 for power management, BMCs must be accessible from the machine networks. User should provide two IPs on the external network that would be used for provisioning services.
               type: string
             provisioningNetworkCIDR:
-              description: ProvisioningNetworkCIDR is the network on which the baremetal
-                nodes are provisioned. The provisioningIP and the IPs in the dhcpRange
-                all come from within this network.
+              description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
               type: string
             provisioningOSDownloadURL:
-              description: ProvisioningOSDownloadURL is the location from which the
-                OS Image used to boot baremetal host machines can be downloaded by
-                the metal3 cluster.
+              description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.
               type: string
           type: object
         status:
@@ -113,22 +73,18 @@ spec:
                 type: object
               type: array
             generations:
-              description: generations are used to determine when an item needs to
-                be reconciled or has changed in a way that needs a reaction.
+              description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
               items:
-                description: GenerationStatus keeps track of the generation for a
-                  given resource so that decisions about forced updates can be made.
+                description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
                 properties:
                   group:
                     description: group is the group of the thing you're tracking
                     type: string
                   hash:
-                    description: hash is an optional field set for resources without
-                      generation that are content sensitive like secrets and configmaps
+                    description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
                     type: string
                   lastGeneration:
-                    description: lastGeneration is the last generation of the workload
-                      controller involved
+                    description: lastGeneration is the last generation of the workload controller involved
                     format: int64
                     type: integer
                   name:
@@ -138,19 +94,16 @@ spec:
                     description: namespace is where the thing you're tracking is
                     type: string
                   resource:
-                    description: resource is the resource type of the thing you're
-                      tracking
+                    description: resource is the resource type of the thing you're tracking
                     type: string
                 type: object
               type: array
             observedGeneration:
-              description: observedGeneration is the last generation change you've
-                dealt with
+              description: observedGeneration is the last generation change you've dealt with
               format: int64
               type: integer
             readyReplicas:
-              description: readyReplicas indicates how many replicas are ready and
-                at the desired state
+              description: readyReplicas indicates how many replicas are ready and at the desired state
               format: int32
               type: integer
             version:


### PR DESCRIPTION
We need to re-generate the provisioning CRD before CI's generate-check passes.