### PR TITLE
Allow ClusterOperator to be set to Degraded state

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -149,3 +149,23 @@ func (r *ProvisioningReconciler) updateCOStatusDisabled() error {
 
 	return r.syncStatus(co, conds)
 }
+
+// updateCOStatusDegraded updates the ClusterOperator's Degraded
+// degradedReason should contain the current reason for the Operator to be marked in that state
+func (r *ProvisioningReconciler) updateCOStatusDegraded(degradedReason string, detailedError string) error {
+	degradedMessage := "Operator is Degraded"
+	progressingMessage := "Operator is Degraded while Progressing"
+
+	co, err := r.getOrCreateClusterOperator()
+	if err != nil {
+		return err
+	}
+
+	conds := []osconfigv1.ClusterOperatorStatusCondition{
+		setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, degradedReason, degradedMessage),
+		setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, detailedError, progressingMessage),
+		setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionFalse, "", ""),
+	}
+
+	return r.syncStatus(co, conds)
+}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -133,6 +134,11 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		// Provisioning configuration is not valid.
 		// Requeue request.
 		r.Log.Error(err, "invalid config in Provisioning CR")
+		err = r.updateCOStatusDegraded("invalid config in Provisioning CR", err.Error())
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %v", clusterOperatorName, err)
+		}
+		// Temporarily not requeuing request
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Set CO to Degraded state when provisioning CR validations fail