### PR TITLE
Generate the CRD with v1 (not v1alpha1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@
 IMG ?= controller:latest
 # Controller-gen tool
 CONTROLLER_GEN ?= go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -14,114 +14,113 @@ spec:
     plural: provisionings
     singular: provisioning
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Provisioning contains configuration used by the Provisioning service (Ironic) to provision baremetal hosts. Provisioning is created by the OpenShift installer using admin or user provided information about the provisioning network and the NIC on the server that can be used to PXE boot it. This CR is a singleton, created by the installer and currently only consumed by the cluster-baremetal-operator to bring up and update containers in a metal3 cluster.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProvisioningSpec defines the desired state of Provisioning
-          properties:
-            provisioningDHCPExternal:
-              description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
-              type: boolean
-            provisioningDHCPRange:
-              description: ProvisioningDHCPRange needs to be interpreted along with ProvisioningDHCPExternal. If the value of provisioningDHCPExternal is set to False, then ProvisioningDHCPRange represents the range of IP addresses that the DHCP server running within the metal3 cluster can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal is set to True, then the value of ProvisioningDHCPRange will be ignored. When the value of ProvisioningDHCPExternal is set to False, indicating an internal DHCP server and the value of ProvisioningDHCPRange is not set, then the DHCP range is taken to be the default range which goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the only value in all of the Provisioning configuration that can be changed after the installer has created the CR. This value needs to be two comma sererated IP addresses within the ProvisioningNetworkCIDR where the 1st address represents the start of the range and the 2nd address represents the last usable address in the  range.
-              type: string
-            provisioningIP:
-              description: ProvisioningIP is the IP address assigned to the provisioningInterface of the baremetal server. This IP address should be within the provisioning subnet, and outside of the DHCP range.
-              type: string
-            provisioningInterface:
-              description: ProvisioningInterface is the name of the network interface on a baremetal server to the provisioning network. It can have values like eth1 or ens3.
-              type: string
-            provisioningNetwork:
-              description: ProvisioningNetwork provides a way to indicate the state of the underlying network configuration for the provisioning network. This field can have one of the following values - `Managed`- when the provisioning network is completely managed by the Baremetal IPI solution. `Unmanaged`- when the provsioning network is present and used but the user is responsible for managing DHCP. Virtual media provisioning is recommended but PXE is still available if required. `Disabled`- when the provisioning network is fully disabled. User can bring up the baremetal cluster using virtual media or assisted installation. If using metal3 for power management, BMCs must be accessible from the machine networks. User should provide two IPs on the external network that would be used for provisioning services.
-              enum:
-              - Managed
-              - Unmanaged
-              - Disabled
-              type: string
-            provisioningNetworkCIDR:
-              description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
-              type: string
-            provisioningOSDownloadURL:
-              description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.
-              type: string
-          type: object
-        status:
-          description: ProvisioningStatus defines the observed state of Provisioning
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            generations:
-              description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-              items:
-                description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                properties:
-                  group:
-                    description: group is the group of the thing you're tracking
-                    type: string
-                  hash:
-                    description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                    type: string
-                  lastGeneration:
-                    description: lastGeneration is the last generation of the workload controller involved
-                    format: int64
-                    type: integer
-                  name:
-                    description: name is the name of the thing you're tracking
-                    type: string
-                  namespace:
-                    description: namespace is where the thing you're tracking is
-                    type: string
-                  resource:
-                    description: resource is the resource type of the thing you're tracking
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change you've dealt with
-              format: int64
-              type: integer
-            readyReplicas:
-              description: readyReplicas indicates how many replicas are ready and at the desired state
-              format: int32
-              type: integer
-            version:
-              description: version is the level this availability applies to
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Provisioning contains configuration used by the Provisioning service (Ironic) to provision baremetal hosts. Provisioning is created by the OpenShift installer using admin or user provided information about the provisioning network and the NIC on the server that can be used to PXE boot it. This CR is a singleton, created by the installer and currently only consumed by the cluster-baremetal-operator to bring up and update containers in a metal3 cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProvisioningSpec defines the desired state of Provisioning
+            properties:
+              provisioningDHCPExternal:
+                description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
+                type: boolean
+              provisioningDHCPRange:
+                description: ProvisioningDHCPRange needs to be interpreted along with ProvisioningDHCPExternal. If the value of provisioningDHCPExternal is set to False, then ProvisioningDHCPRange represents the range of IP addresses that the DHCP server running within the metal3 cluster can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal is set to True, then the value of ProvisioningDHCPRange will be ignored. When the value of ProvisioningDHCPExternal is set to False, indicating an internal DHCP server and the value of ProvisioningDHCPRange is not set, then the DHCP range is taken to be the default range which goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the only value in all of the Provisioning configuration that can be changed after the installer has created the CR. This value needs to be two comma sererated IP addresses within the ProvisioningNetworkCIDR where the 1st address represents the start of the range and the 2nd address represents the last usable address in the  range.
+                type: string
+              provisioningIP:
+                description: ProvisioningIP is the IP address assigned to the provisioningInterface of the baremetal server. This IP address should be within the provisioning subnet, and outside of the DHCP range.
+                type: string
+              provisioningInterface:
+                description: ProvisioningInterface is the name of the network interface on a baremetal server to the provisioning network. It can have values like eth1 or ens3.
+                type: string
+              provisioningNetwork:
+                description: ProvisioningNetwork provides a way to indicate the state of the underlying network configuration for the provisioning network. This field can have one of the following values - `Managed`- when the provisioning network is completely managed by the Baremetal IPI solution. `Unmanaged`- when the provsioning network is present and used but the user is responsible for managing DHCP. Virtual media provisioning is recommended but PXE is still available if required. `Disabled`- when the provisioning network is fully disabled. User can bring up the baremetal cluster using virtual media or assisted installation. If using metal3 for power management, BMCs must be accessible from the machine networks. User should provide two IPs on the external network that would be used for provisioning services.
+                enum:
+                - Managed
+                - Unmanaged
+                - Disabled
+                type: string
+              provisioningNetworkCIDR:
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
+                type: string
+              provisioningOSDownloadURL:
+                description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.
+                type: string
+            type: object
+          status:
+            description: ProvisioningStatus defines the observed state of Provisioning
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              generations:
+                description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're tracking
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/patches/cainjection_in_provisionings.yaml
+++ b/config/crd/patches/cainjection_in_provisionings.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_provisionings.yaml
+++ b/config/crd/patches/webhook_in_provisionings.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: provisionings.metal3.io

--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -4,11 +4,14 @@ set -euo pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 source $REPO_ROOT/hack/utils.sh
 
+# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
+CRD_OPTIONS="crd:trivialVersions=true,crdVersions=v1"
+
 # Generate manifests
-go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases
+go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go $CRD_OPTIONS rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases
 sed -i '/^    controller-gen.kubebuilder.io\/version: (devel)/d' config/crd/bases/*
 
 # Copy crds into the manifests
 install_crd \
   "config/crd/bases/metal3.io_provisionings.yaml" \
-  "manifests/0000_31_cluster-baremetal-operator_00_metal3provisioning.crd.yaml"
+  "manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml"

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -14,114 +14,113 @@ spec:
     plural: provisionings
     singular: provisioning
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Provisioning contains configuration used by the Provisioning service (Ironic) to provision baremetal hosts. Provisioning is created by the OpenShift installer using admin or user provided information about the provisioning network and the NIC on the server that can be used to PXE boot it. This CR is a singleton, created by the installer and currently only consumed by the cluster-baremetal-operator to bring up and update containers in a metal3 cluster.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProvisioningSpec defines the desired state of Provisioning
-          properties:
-            provisioningDHCPExternal:
-              description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
-              type: boolean
-            provisioningDHCPRange:
-              description: ProvisioningDHCPRange needs to be interpreted along with ProvisioningDHCPExternal. If the value of provisioningDHCPExternal is set to False, then ProvisioningDHCPRange represents the range of IP addresses that the DHCP server running within the metal3 cluster can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal is set to True, then the value of ProvisioningDHCPRange will be ignored. When the value of ProvisioningDHCPExternal is set to False, indicating an internal DHCP server and the value of ProvisioningDHCPRange is not set, then the DHCP range is taken to be the default range which goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the only value in all of the Provisioning configuration that can be changed after the installer has created the CR. This value needs to be two comma sererated IP addresses within the ProvisioningNetworkCIDR where the 1st address represents the start of the range and the 2nd address represents the last usable address in the  range.
-              type: string
-            provisioningIP:
-              description: ProvisioningIP is the IP address assigned to the provisioningInterface of the baremetal server. This IP address should be within the provisioning subnet, and outside of the DHCP range.
-              type: string
-            provisioningInterface:
-              description: ProvisioningInterface is the name of the network interface on a baremetal server to the provisioning network. It can have values like eth1 or ens3.
-              type: string
-            provisioningNetwork:
-              description: ProvisioningNetwork provides a way to indicate the state of the underlying network configuration for the provisioning network. This field can have one of the following values - `Managed`- when the provisioning network is completely managed by the Baremetal IPI solution. `Unmanaged`- when the provsioning network is present and used but the user is responsible for managing DHCP. Virtual media provisioning is recommended but PXE is still available if required. `Disabled`- when the provisioning network is fully disabled. User can bring up the baremetal cluster using virtual media or assisted installation. If using metal3 for power management, BMCs must be accessible from the machine networks. User should provide two IPs on the external network that would be used for provisioning services.
-              enum:
-              - Managed
-              - Unmanaged
-              - Disabled
-              type: string
-            provisioningNetworkCIDR:
-              description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
-              type: string
-            provisioningOSDownloadURL:
-              description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.
-              type: string
-          type: object
-        status:
-          description: ProvisioningStatus defines the observed state of Provisioning
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            generations:
-              description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-              items:
-                description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                properties:
-                  group:
-                    description: group is the group of the thing you're tracking
-                    type: string
-                  hash:
-                    description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                    type: string
-                  lastGeneration:
-                    description: lastGeneration is the last generation of the workload controller involved
-                    format: int64
-                    type: integer
-                  name:
-                    description: name is the name of the thing you're tracking
-                    type: string
-                  namespace:
-                    description: namespace is where the thing you're tracking is
-                    type: string
-                  resource:
-                    description: resource is the resource type of the thing you're tracking
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change you've dealt with
-              format: int64
-              type: integer
-            readyReplicas:
-              description: readyReplicas indicates how many replicas are ready and at the desired state
-              format: int32
-              type: integer
-            version:
-              description: version is the level this availability applies to
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Provisioning contains configuration used by the Provisioning service (Ironic) to provision baremetal hosts. Provisioning is created by the OpenShift installer using admin or user provided information about the provisioning network and the NIC on the server that can be used to PXE boot it. This CR is a singleton, created by the installer and currently only consumed by the cluster-baremetal-operator to bring up and update containers in a metal3 cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProvisioningSpec defines the desired state of Provisioning
+            properties:
+              provisioningDHCPExternal:
+                description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
+                type: boolean
+              provisioningDHCPRange:
+                description: ProvisioningDHCPRange needs to be interpreted along with ProvisioningDHCPExternal. If the value of provisioningDHCPExternal is set to False, then ProvisioningDHCPRange represents the range of IP addresses that the DHCP server running within the metal3 cluster can use while provisioning baremetal servers. If the value of ProvisioningDHCPExternal is set to True, then the value of ProvisioningDHCPRange will be ignored. When the value of ProvisioningDHCPExternal is set to False, indicating an internal DHCP server and the value of ProvisioningDHCPRange is not set, then the DHCP range is taken to be the default range which goes from .10 to .100 of the ProvisioningNetworkCIDR. This is the only value in all of the Provisioning configuration that can be changed after the installer has created the CR. This value needs to be two comma sererated IP addresses within the ProvisioningNetworkCIDR where the 1st address represents the start of the range and the 2nd address represents the last usable address in the  range.
+                type: string
+              provisioningIP:
+                description: ProvisioningIP is the IP address assigned to the provisioningInterface of the baremetal server. This IP address should be within the provisioning subnet, and outside of the DHCP range.
+                type: string
+              provisioningInterface:
+                description: ProvisioningInterface is the name of the network interface on a baremetal server to the provisioning network. It can have values like eth1 or ens3.
+                type: string
+              provisioningNetwork:
+                description: ProvisioningNetwork provides a way to indicate the state of the underlying network configuration for the provisioning network. This field can have one of the following values - `Managed`- when the provisioning network is completely managed by the Baremetal IPI solution. `Unmanaged`- when the provsioning network is present and used but the user is responsible for managing DHCP. Virtual media provisioning is recommended but PXE is still available if required. `Disabled`- when the provisioning network is fully disabled. User can bring up the baremetal cluster using virtual media or assisted installation. If using metal3 for power management, BMCs must be accessible from the machine networks. User should provide two IPs on the external network that would be used for provisioning services.
+                enum:
+                - Managed
+                - Unmanaged
+                - Disabled
+                type: string
+              provisioningNetworkCIDR:
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
+                type: string
+              provisioningOSDownloadURL:
+                description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.
+                type: string
+            type: object
+          status:
+            description: ProvisioningStatus defines the observed state of Provisioning
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              generations:
+                description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're tracking
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Originally done to get "oc explain Provisioning" to print more information.
(https://bugzilla.redhat.com/show_bug.cgi?id=1880787)

Update:
So I think we should merge this, just because v1alpha1 is deprecated.. 

However this is not helping 'oc explain Provisioning'.
if I "oc apply -f manifests/0000_30_cluster-baremetal-operator_00_metal3provisioning.crd.yaml"
then 'oc explain Provisioning', I still get the same <empty> response.