### PR TITLE
Bring the CRD closer to what it should be

### DIFF
--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -100,10 +100,10 @@ type ProvisioningStatus struct {
 // This CR is a singleton, created by the installer and currently only
 // consumed by the cluster-baremetal-operator to bring up and update
 // containers in a metal3 cluster.
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:path=provisionings,scope=Cluster
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:path=provisionings,scope=Cluster
+// +kubebuilder:subresource:status
 
 // Provisioning is the Schema for the provisionings API
 type Provisioning struct {

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -13,7 +13,9 @@ spec:
     listKind: ProvisioningList
     plural: provisionings
     singular: provisioning
-  scope: Namespaced
+  scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Provisioning is the Schema for the provisionings API


### PR DESCRIPTION
The grouping of the +kubebuilder comments was
causing the scope and subresource to not work.