### PR TITLE
improve logging practices

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -63,11 +63,8 @@ func (r *ProvisioningReconciler) isEnabled() (bool, error) {
 		Name: "cluster",
 	}, infra)
 	if err != nil {
-		r.Log.Error(err, "unable to determine Platform")
-		return false, err
+		return false, errors.Wrap(err, "unable to determine Platform")
 	}
-
-	r.Log.V(1).Info("reconciling", "platform", infra.Status.Platform)
 
 	// Disable ourselves on platforms other than bare metal
 	if infra.Status.Platform != osconfigv1.BareMetalPlatformType {
@@ -75,6 +72,7 @@ func (r *ProvisioningReconciler) isEnabled() (bool, error) {
 		return false, nil
 	}
 
+	r.Log.V(1).Info("enabled", "platform", infra.Status.Platform)
 	return true, nil
 }
 
@@ -90,11 +88,9 @@ func (r *ProvisioningReconciler) readProvisioningCR(req ctrl.Request) (*metal3io
 	instance := &metal3iov1alpha1.Provisioning{}
 	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.Log.V(1).Info("Provisioning CR not found")
 			return nil, nil
 		}
-		r.Log.Error(err, "unable to read Provisioning CR")
-		return nil, err
+		return nil, errors.Wrap(err, "unable to read Provisioning CR")
 	}
 	return instance, nil
 }
@@ -127,6 +123,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	if baremetalConfig == nil {
 		// Provisioning configuration not available at this time.
 		// Cannot proceed wtih metal3 deployment.
+		r.Log.V(1).Info("Provisioning CR not found")
 		return ctrl.Result{}, nil
 	}
 	if err := provisioning.ValidateBaremetalProvisioningConfig(baremetalConfig); err != nil {

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -29,7 +29,7 @@ var (
 // ValidateBaremetalProvisioningConfig validates the contents of the provisioning resource
 func ValidateBaremetalProvisioningConfig(prov *metal3iov1alpha1.Provisioning) error {
 	provisioningNetworkMode := getProvisioningNetworkMode(prov)
-	log.V(1).Info("Final Provisioning Network", "Mode", provisioningNetworkMode)
+	log.V(1).Info("provisioning network", "mode", provisioningNetworkMode)
 	switch provisioningNetworkMode {
 	case metal3iov1alpha1.ProvisioningNetworkManaged:
 		return validateManagedConfig(prov)
@@ -47,10 +47,11 @@ func getProvisioningNetworkMode(prov *metal3iov1alpha1.Provisioning) metal3iov1a
 		// Set it to the default Managed mode
 		provisioningNetworkMode = metal3iov1alpha1.ProvisioningNetworkManaged
 		if prov.Spec.ProvisioningDHCPExternal {
-			log.V(1).Info("ProvisioningDHCPExternal is being deprecated in favor of ProvisioningNetwork and will be removed in the next release")
+			log.V(1).Info("provisioningDHCPExternal is deprecated and will be removed in the next release. Use provisioningNetwork instead.")
 			provisioningNetworkMode = metal3iov1alpha1.ProvisioningNetworkUnmanaged
+		} else {
+			log.V(1).Info("provisioningNetwork and provisioningDHCPExternal not set, defaulting to managed network")
 		}
-		log.V(1).Info("ProvisioningNetwork config not provided. Using ProvisioningDHCPExternal to set its value")
 	}
 	return provisioningNetworkMode
 }


### PR DESCRIPTION
Logging and then returning an error produces multiple messages, so
change a few spots to just return and let the caller do the logging.

Tighten up the language in a few log messages so they are shorter.

Wait until an action is done or failed to log, so we have "did action"
or "failed action" messages but no "doing action" messages. This
ensures that all of the information we need to have is in 1 log
message, instead of split across several.