### PR TITLE
Bug 1906102: Add standard metrics support for CBO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ RBAC_LIST = rbac.authorization.k8s.io_v1_role_cluster-baremetal-operator.yaml \
 	rbac.authorization.k8s.io_v1_rolebinding_cluster-baremetal-operator.yaml \
 	rbac.authorization.k8s.io_v1_clusterrolebinding_cluster-baremetal-operator.yaml
 
+PROMETHEUS_RBAC_LIST = rbac.authorization.k8s.io_v1_rolebinding_prometheus-k8s-cluster-baremetal-operator.yaml \
+	rbac.authorization.k8s.io_v1_role_prometheus-k8s-cluster-baremetal-operator.yaml
+
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests: generate
@@ -68,10 +71,17 @@ manifests: generate
 	mv $(TMP_DIR)/monitoring.coreos.com_v1_prometheusrule_cluster-baremetal-operator-prometheus-rules.yaml manifests/0000_90_cluster-baremetal-operator_04_alertrules.yaml
 	mv $(TMP_DIR)/v1_service_cluster-baremetal-operator-service.yaml manifests/0000_31_cluster-baremetal-operator_03_service.yaml
 	mv $(TMP_DIR)/v1_configmap_kube-rbac-proxy.yaml manifests/0000_31_cluster-baremetal-operator_05_kube-rbac-proxy-config.yaml
+	# cluster-baremetal-operator rbacs
 	rm -f manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
 	for rbac in $(RBAC_LIST) ; do \
 	cat $(TMP_DIR)/$${rbac} >> manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml ;\
 	echo '---' >> manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml ;\
+	done
+	# prometheus rbacs
+	rm -rf manifests/0000_31_cluster-baremetal-operator_05_prometheus_rbac.yaml
+	for rbac in $(PROMETHEUS_RBAC_LIST) ; do \
+	cat $(TMP_DIR)/$${rbac} >> manifests/0000_31_cluster-baremetal-operator_05_prometheus_rbac.yaml ;\
+	echo '---' >> manifests/0000_31_cluster-baremetal-operator_05_prometheus_rbac.yaml ;\
 	done
 	rm -rf $(TMP_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ manifests: generate
 	# now rename/join the output files into the files we expect
 	mv $(TMP_DIR)/apiextensions.k8s.io_v1_customresourcedefinition_provisionings.metal3.io.yaml manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
 	mv $(TMP_DIR)/apps_v1_deployment_cluster-baremetal-operator.yaml manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+	# manifests needed for monitoring
+	mv $(TMP_DIR)/monitoring.coreos.com_v1_servicemonitor_cluster-baremetal-operator-servicemonitor.yaml manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
+	mv $(TMP_DIR)/monitoring.coreos.com_v1_prometheusrule_cluster-baremetal-operator-prometheus-rules.yaml manifests/0000_90_cluster-baremetal-operator_04_alertrules.yaml
+	mv $(TMP_DIR)/v1_service_cluster-baremetal-operator-service.yaml manifests/0000_31_cluster-baremetal-operator_03_service.yaml
+	mv $(TMP_DIR)/v1_configmap_kube-rbac-proxy.yaml manifests/0000_31_cluster-baremetal-operator_05_kube-rbac-proxy-config.yaml
 	rm -f manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
 	for rbac in $(RBAC_LIST) ; do \
 	cat $(TMP_DIR)/$${rbac} >> manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml ;\

--- a/config/cluster-baremetal-operator/kustomization.yaml
+++ b/config/cluster-baremetal-operator/kustomization.yaml
@@ -1,2 +1,6 @@
+commonAnnotations:
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+
 resources:
 - cluster-baremetal-operator.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,7 @@
+commonAnnotations:
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default

--- a/config/profiles/default/kustomization.yaml
+++ b/config/profiles/default/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../../prometheus
+- ../../prometheus
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.

--- a/config/profiles/default/kustomization.yaml
+++ b/config/profiles/default/kustomization.yaml
@@ -1,7 +1,3 @@
-commonAnnotations:
-  include.release.openshift.io/self-managed-high-availability: "true"
-  include.release.openshift.io/single-node-developer: "true"
-
 bases:
 - ../../crd
 - ../../rbac

--- a/config/profiles/default/kustomization.yaml
+++ b/config/profiles/default/kustomization.yaml
@@ -9,11 +9,11 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../../prometheus
 
-#patchesStrategicMerge:
+patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_auth_proxy_patch.yaml
+- manager_auth_proxy_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.

--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -3,23 +3,50 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: cluster-baremetal-operator
+  namespace: openshift-machine-api
+  labels:
+    k8s-app: cluster-baremetal-operator
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: cluster-baremetal-operator
   template:
+    metadata:
+      labels:
+        k8s-app: cluster-baremetal-operator
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
+        - "--upstream=http://localhost:8080/"
+        - "--tls-cert-file=/etc/tls/private/tls.crt"
+        - "--tls-private-key-file=/etc/tls/private/tls.key"
+        - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
         - "--logtostderr=true"
         - "--v=10"
         ports:
-        - containerPort: 8443
-          name: https
-      - name: manager
-        args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kube-rbac-proxy
+        - name: cluster-baremetal-operator-tls
+          mountPath: /etc/tls/private
+      volumes:
+        - name: config
+          configMap:
+            name: kube-rbac-proxy
+            defaultMode: 420
+        - name: cluster-baremetal-operator-tls
+          secret:
+            secretName: cluster-baremetal-operator-tls
+            defaultMode: 420

--- a/config/prometheus/alertrules.yaml
+++ b/config/prometheus/alertrules.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: cluster-baremetal-operator-prometheus-rules
+  namespace: openshift-machine-api
+spec:
+  groups:
+    - name: cluster-baremetal-operator-down
+      rules:
+        - alert: ClusterBaremetalOperatorDown
+          expr: |
+             absent(up{job="cluster-baremetal-operator"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            message: "cluster baremetal operator is down"

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - service.yaml
 - alertrules.yaml
 - proxyconfig.yaml
+- rbac.yaml

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - monitor.yaml
+- service.yaml
+- alertrules.yaml
+- proxyconfig.yaml

--- a/config/prometheus/proxyconfig.yaml
+++ b/config/prometheus/proxyconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-machine-api
+

--- a/config/prometheus/rbac.yaml
+++ b/config/prometheus/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s-cluster-baremetal-operator
+  namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s-cluster-baremetal-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+
+---
+# Roles needed by prometheus to scrape Cluster Baremetal Operator metrics endpoint
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s-cluster-baremetal-operator
+  namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespace/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---

--- a/config/prometheus/service.yaml
+++ b/config/prometheus/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-baremetal-operator-service
+  namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls
+  labels:
+    k8s-app: cluster-baremetal-operator
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    k8s-app: cluster-baremetal-operator
+  sessionAffinity: None

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,7 @@
+commonAnnotations:
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+
 resources:
 - role.yaml
 - role_binding.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -216,6 +216,16 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -73,6 +73,7 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:namespace=openshift-machine-api,groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;watch;get;list;patch
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use

--- a/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
@@ -11,6 +11,7 @@ data:
   images.json: >
     {
       "clusterBaremetalOperator": "registry.svc.ci.openshift.org/openshift:cluster-baremetal-operator",
+      "kubeRBACProxy": "registry.svc.ci.openshift.org/openshift:kube-rbac-proxy",
       "baremetalOperator": "registry.svc.ci.openshift.org/openshift:baremetal-operator",
       "baremetalIronic": "registry.svc.ci.openshift.org/openshift:ironic",
       "baremetalIronicInspector": "registry.svc.ci.openshift.org/openshift:ironic-inspector",

--- a/manifests/0000_31_cluster-baremetal-operator_03_service.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_03_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls
+  labels:
+    k8s-app: cluster-baremetal-operator
+  name: cluster-baremetal-operator-service
+  namespace: openshift-machine-api
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    k8s-app: cluster-baremetal-operator
+  sessionAffinity: None
+  type: ClusterIP

--- a/manifests/0000_31_cluster-baremetal-operator_05_kube-rbac-proxy-config.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_kube-rbac-proxy-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-machine-api
+
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: kube-rbac-proxy
+  namespace: openshift-machine-api

--- a/manifests/0000_31_cluster-baremetal-operator_05_prometheus_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_prometheus_rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: prometheus-k8s-cluster-baremetal-operator
+  namespace: openshift-machine-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s-cluster-baremetal-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: prometheus-k8s-cluster-baremetal-operator
+  namespace: openshift-machine-api
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespace/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -86,6 +86,16 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -23,6 +23,29 @@ spec:
         k8s-app: cluster-baremetal-operator
     spec:
       containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://localhost:8080/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --logtostderr=true
+        - --v=10
+        image: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: config
+        - mountPath: /etc/tls/private
+          name: cluster-baremetal-operator-tls
       - command:
         - /usr/bin/cluster-baremetal-operator
         env:
@@ -66,6 +89,14 @@ spec:
         operator: Exists
         tolerationSeconds: 120
       volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy
+        name: config
+      - name: cluster-baremetal-operator-tls
+        secret:
+          defaultMode: 420
+          secretName: cluster-baremetal-operator-tls
       - configMap:
           name: cluster-baremetal-operator-images
         name: images

--- a/manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
@@ -1,4 +1,3 @@
-# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -10,16 +9,16 @@ metadata:
   namespace: openshift-machine-api
 spec:
   endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 30s
-      port: https
-      scheme: https
-      tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: cluster-baremetal-operator.openshift-machine-api.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: cluster-baremetal-operator.openshift-machine-api.svc
   namespaceSelector:
     matchNames:
-      - openshift-machine-api
+    - openshift-machine-api
   selector:
     matchLabels:
       k8s-app: cluster-baremetal-operator

--- a/manifests/0000_90_cluster-baremetal-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cluster-baremetal-operator_04_alertrules.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: cluster-baremetal-operator-prometheus-rules
+  namespace: openshift-machine-api
+spec:
+  groups:
+  - name: cluster-baremetal-operator-down
+    rules:
+    - alert: ClusterBaremetalOperatorDown
+      annotations:
+        message: cluster baremetal operator is down
+      expr: |
+        absent(up{job="cluster-baremetal-operator"} == 1)
+      for: 5m
+      labels:
+        severity: critical

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -31,3 +31,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy


### PR DESCRIPTION
According to https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/operators.md#how-do-i-get-added-as-a-special-run-level, the certificate authority service is started at run level 09 and hence CBO's service monitor manifest should be created at that run level also.

For Prometheus to be able to scrape CBO metrics:
1. Added kubeProxyContainer to the CBO deployment
2. Created a ClusterIP Service (cluster-baremetal-operator-service) to expose CMO metrics port
3. Created a Service Monitor (cluster-baremetal-operator-servicemonitor) in order to be discovered automatically by the prometheus operator
4. Created ServiceAccount and Role with appropriate RBACs for prometheus to scrape CBO metrics endpoint