### PR TITLE
Add bmh as a relatedobject in the clusteroperator

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -56,6 +56,12 @@ func relatedObjects() []osconfigv1.ObjectReference {
 			Resource: "namespaces",
 			Name:     ComponentNamespace,
 		},
+		{
+			Group:     "metal3.io",
+			Resource:  "baremetalhosts",
+			Name:      "baremetalhosts.metal3.io",
+			Namespace: ComponentNamespace,
+		},
 	}
 }
 

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -60,8 +60,6 @@ func TestUpdateCOStatusDisabled(t *testing.T) {
 }
 
 func TestGetOrCreateClusterOperator(t *testing.T) {
-	var namespace = "openshift-machine-api"
-
 	var defaultConditions = []osconfigv1.ClusterOperatorStatusCondition{
 		setStatusCondition(
 			osconfigv1.OperatorProgressing,
@@ -126,14 +124,8 @@ func TestGetOrCreateClusterOperator(t *testing.T) {
 					Name: clusterOperatorName,
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
-					Conditions: defaultConditions,
-					RelatedObjects: []osconfigv1.ObjectReference{
-						{
-							Group:    "",
-							Resource: "namespaces",
-							Name:     namespace,
-						},
-					},
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds bmh as a relatedobject in the clusteroperator. This will enable the user to run:  `oc get -o yaml clusteroperator baremetal` and view that "baremetalhosts" is in the list of `relatedObjects`. 