### PR TITLE
Add correct condition states

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -112,7 +112,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 	if !enabled {
 		// set ClusterOperator status to disabled=true, available=true
-		err = r.updateCOStatusDisabled()
+		err = r.updateCOStatus(ReasonUnsupported, "Operator is non-functional", "")
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -136,7 +136,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		// Provisioning configuration is not valid.
 		// Requeue request.
 		r.Log.Error(err, "invalid config in Provisioning CR")
-		err = r.updateCOStatusDegraded("invalid config in Provisioning CR", err.Error())
+		err = r.updateCOStatus(ReasonInvalidConfiguration, err.Error(), "Unable to apply Provisioning CR: invalid configuration")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %v", clusterOperatorName, err)
 		}
@@ -151,7 +151,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		// Provisioning configuration is not valid.
 		// Requeue request.
 		r.Log.Error(err, "invalid contents in images Config Map")
-		co_err := r.updateCOStatusDegraded("invalid contents in images Config Map", err.Error())
+		co_err := r.updateCOStatus(ReasonInvalidConfiguration, err.Error(), "invalid contents in images Config Map")
 		if co_err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %v", clusterOperatorName, co_err)
 		}


### PR DESCRIPTION
This PR aims to implement the following logic.
```
0. When the cluster platform is NOT "baremetal", the ClusterOperator has status Progressing=false, Available=true, Disabled=true, Upgradeable=true, Degraded=false

When the cluster platform is "baremetal" and...
1. the Provisioning CR is valid and metal3 is being deployed, the ClusterOperator has status Progressing=true, Available=false, Disabled=false, Upgradeable=true, Degraded=false
2. the Provisioning CR is valid and metal3 is running, the ClusterOperator has status Progressing=false, Available=true, Disabled=false, Upgradeable=true, Degraded=false
3. the Provisioning CR is valid and metal3 has not successfully launched after 20 minutes, the ClusterOperator has status Progressing=true, Available=false, Disabled=false, Upgradeable=true, Degraded=true
4. the Provisioning CR is valid and metal3 has not successfully launched and is in a crash loop, the ClusterOperator has status Progressing=false, Available=false, Disabled=false, Upgradeable=true, Degraded=true
```
the above reasons for state changes are made to match the condition reason as well.
One function updateCOStatus() is used to implement the status changes.