### PR TITLE
Move the lint exclude rule to the config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,8 +21,6 @@ linters:
 linters-settings:
   goimports:
     local-prefixes: "github.com/openshift"
-  govet:
-    check-shadowing: false
 
 issues:
   max-issues-per-linter: 0
@@ -31,3 +29,6 @@ issues:
    - linters:
      - staticcheck
      text: "SA1019:"
+   - linters:
+     - gosec
+     text: "G101:"

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ fmt:
 # Run go lint against code
 .PHONY: lint
 lint: $(GOBIN)/golangci-lint
-	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOBIN)/golangci-lint run --exclude=G101
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOBIN)/golangci-lint run
 
 $(GOBIN)/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.31.0
@@ -76,7 +76,7 @@ vet: lint
 .PHONY: generate
 generate: $(GOBIN)/golangci-lint
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
-	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOBIN)/golangci-lint run --fix --exclude=G101
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) $(GOBIN)/golangci-lint run --fix
 
 # Build the docker image
 docker-build: test


### PR DESCRIPTION
This is so they are all in one place.

@sadasu note we can also disable rules in the code line-by-line, this is also a nice option if you want that rule checked but just have one instance of it ignored.
```go
thePassword = "srotet" // #nosec
```