### PR TITLE
Fix ClusterOperator Versions field and enable CBO integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/bin/cluster-baremetal-operator /usr/bin/cluster-baremetal-operator
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/manifests /manifests
 # Uncomment when ready for the release so that CVO could manage the operator
-# LABEL io.openshift.release.operator=true
+LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/cluster-baremetal-operator"]

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -79,6 +79,8 @@ func relatedObjects() []osconfigv1.ObjectReference {
 func (r *ProvisioningReconciler) operandVersions() []osconfigv1.OperandVersion {
 	operandVersions := []osconfigv1.OperandVersion{}
 
+	r.Log.V(1).Info("Release version", "version", r.ReleaseVersion)
+
 	if r.ReleaseVersion != "" {
 		operandVersions = append(operandVersions, osconfigv1.OperandVersion{
 			Name:    "operator",
@@ -148,6 +150,11 @@ func setStatusCondition(conditionType osconfigv1.ClusterStatusConditionType,
 func (r *ProvisioningReconciler) syncStatus(co *osconfigv1.ClusterOperator, conds []osconfigv1.ClusterOperatorStatusCondition) error {
 	for _, c := range conds {
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c)
+	}
+
+	if len(co.Status.Versions) < 1 {
+		r.Log.Info("updating ClusterOperator Status Versions field")
+		co.Status.Versions = r.operandVersions()
 	}
 
 	_, err := r.OSClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -79,8 +79,6 @@ func relatedObjects() []osconfigv1.ObjectReference {
 func (r *ProvisioningReconciler) operandVersions() []osconfigv1.OperandVersion {
 	operandVersions := []osconfigv1.OperandVersion{}
 
-	r.Log.V(1).Info("Release version", "version", r.ReleaseVersion)
-
 	if r.ReleaseVersion != "" {
 		operandVersions = append(operandVersions, osconfigv1.OperandVersion{
 			Name:    "operator",


### PR DESCRIPTION
It looks like that the installation doesn't complete since the CBO ClusterOperator does not have an update Status.Version field, as required by CVO.
Enables also CVO integration