### PR TITLE
Remove CBO from the release payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN make cluster-baremetal-operator
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/bin/cluster-baremetal-operator /usr/bin/cluster-baremetal-operator
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/manifests /manifests
-# Uncomment when ready for the release so that CVO could manage the operator
-LABEL io.openshift.release.operator=true
+#FIXME:Remove from release payload until CBO works with other platforms
+#LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/cluster-baremetal-operator"]


### PR DESCRIPTION
CBO wasn't tested with other platforms, which are now failing as CBO
doesn't become available. We need to fix that before reinstating the
label.

See: https://search.ci.openshift.org/?search=.*Cluster+operator+baremetal+is+still+updating.*&maxAge=48h&context=1&type=bug%2Bjunit&name=&maxMatches=5&maxBytes=20971520&groupBy=job