### PR TITLE
WIP: controllers: "Unsupported", etc. condition messaging

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -22,8 +22,8 @@ const (
 	// OperatorDisabled represents a Disabled ClusterStatusConditionTypes
 	OperatorDisabled osconfigv1.ClusterStatusConditionType = "Disabled"
 
-	// ReasonEmpty is an empty StatusReason
-	ReasonEmpty StatusReason = ""
+	// ReasonAsExpected is a status reason for the happy state, when we have nothing else to say.
+	ReasonAsExpected StatusReason = "AsExpected"
 
 	// ReasonComplete the deployment of required resources is complete
 	ReasonComplete StatusReason = "DeployComplete"
@@ -170,7 +170,7 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	switch newReason {
 	case ReasonUnsupported:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, string(newReason), msg))
-		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonUnsupported), msg))
 	case ReasonSyncing:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))
@@ -179,7 +179,7 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(newReason), progressMsg))
 	case ReasonInvalidConfiguration, ReasonDeployTimedOut:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, string(newReason), msg))
-		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonAsExpected), "FIXME: are we really available here?"))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))
 	case ReasonDeploymentCrashLooping:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, string(newReason), msg))

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -86,7 +86,7 @@ func TestReconcile(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 
 			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), tc.infra)
-			enabled, err := reconciler.isEnabled()
+			enabled, _, err := reconciler.isEnabled()
 			if tc.expectedError && err == nil {
 				t.Error("should have produced an error")
 				return


### PR DESCRIPTION
"Operator is non-functional" sounds a bit frightening.  This commit pivots to say "Operator has no role on platform {platform-name}" in the cases where we determine we are not needed.

I'm also removing ReasonEmpty, because it's always nice to say *something* about why we picked the state we picked.  In the `ReasonInvalidConfiguration` and `ReasonDeployTimedOut` cases, that makes me wonder if we really intend to be Available then.  Maybe we should just echo whatever we're setting for Degraded in that case?  FIXME/WIP until we decide.