### PR TITLE
Set Baremetal CO to Disabled before Reconciler runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ RUN make cluster-baremetal-operator
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/bin/cluster-baremetal-operator /usr/bin/cluster-baremetal-operator
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/manifests /manifests
-#FIXME:Remove from release payload until CBO works with other platforms
-#LABEL io.openshift.release.operator=true
+LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/cluster-baremetal-operator"]

--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -30,6 +30,9 @@ const (
 	ProvisioningNetworkManaged   ProvisioningNetwork = "Managed"
 	ProvisioningNetworkUnmanaged ProvisioningNetwork = "Unmanaged"
 	ProvisioningNetworkDisabled  ProvisioningNetwork = "Disabled"
+
+	// ProvisioningFinalizer is required for proper handling of deletion
+	ProvisioningFinalizer = "provisioning.metal3.io"
 )
 
 // ProvisioningSpec defines the desired state of Provisioning

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,14 +14,42 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators
   - clusteroperators/status
   verbs:
   - create
+  - delete
   - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -44,6 +72,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - provisionings/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - metal3.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,7 +6,9 @@ metadata:
   creationTimestamp: null
   name: cluster-baremetal-operator
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -108,7 +110,9 @@ metadata:
   name: cluster-baremetal-operator
   namespace: openshift-machine-api
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - create
@@ -118,7 +122,9 @@ rules:
   - patch
   - update
   - watch
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,8 +72,12 @@ rules:
   resources:
   - provisionings
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - metal3.io

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -245,6 +245,7 @@ func SetCOInDisabledState(osClient osclientset.Interface, version string) error 
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c)
 	}
 	co.Status.Versions = operandVersions(version)
+	co.Status.RelatedObjects = relatedObjects()
 
 	_, err = osClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})
 	return err

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -32,7 +32,7 @@ const (
 	// ReasonEmpty is an empty StatusReason
 	ReasonEmpty StatusReason = ""
 
-	// ReasonEmpty is an empty StatusReason
+	// ReasonExpected indicates that the operator is behaving as expected
 	ReasonExpected StatusReason = "AsExpected"
 
 	// ReasonComplete the deployment of required resources is complete

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -32,6 +32,9 @@ const (
 	// ReasonEmpty is an empty StatusReason
 	ReasonEmpty StatusReason = ""
 
+	// ReasonEmpty is an empty StatusReason
+	ReasonExpected StatusReason = "AsExpected"
+
 	// ReasonComplete the deployment of required resources is complete
 	ReasonComplete StatusReason = "DeployComplete"
 
@@ -238,8 +241,8 @@ func SetCOInDisabledState(osClient osclientset.Interface, version string) error 
 	}
 
 	conds := defaultStatusConditions()
-	v1helpers.SetStatusCondition(&conds, setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, "Operator on Standby", "Unsupported Platform"))
-	v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
+	v1helpers.SetStatusCondition(&conds, setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, string(ReasonUnsupported), "Nothing to do on this Platform"))
+	v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonExpected), "Operational"))
 
 	for _, c := range conds {
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c)

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
+	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
@@ -82,13 +83,13 @@ func relatedObjects() []osconfigv1.ObjectReference {
 
 // operandVersions returns the current list of OperandVersions for the
 // ClusterOperator objects's status.
-func (r *ProvisioningReconciler) operandVersions() []osconfigv1.OperandVersion {
+func operandVersions(version string) []osconfigv1.OperandVersion {
 	operandVersions := []osconfigv1.OperandVersion{}
 
-	if r.ReleaseVersion != "" {
+	if version != "" {
 		operandVersions = append(operandVersions, osconfigv1.OperandVersion{
 			Name:    "operator",
-			Version: r.ReleaseVersion,
+			Version: version,
 		})
 	}
 
@@ -144,9 +145,9 @@ func (r *ProvisioningReconciler) ensureClusterOperator(baremetalConfig *metal3io
 		needsUpadate = true
 		co.Status.RelatedObjects = relatedObjects()
 	}
-	if !equality.Semantic.DeepEqual(co.Status.Versions, r.operandVersions()) {
+	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
 		needsUpadate = true
-		co.Status.Versions = r.operandVersions()
+		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 	if len(co.Status.Conditions) == 0 {
 		needsUpadate = true
@@ -190,7 +191,7 @@ func (r *ProvisioningReconciler) syncStatus(co *osconfigv1.ClusterOperator, cond
 
 	if len(co.Status.Versions) < 1 {
 		r.Log.Info("updating ClusterOperator Status Versions field")
-		co.Status.Versions = r.operandVersions()
+		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 
 	_, err := r.OSClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})
@@ -208,7 +209,7 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	switch newReason {
 	case ReasonUnsupported:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, string(newReason), msg))
-		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonExpected), "Operational"))
 	case ReasonSyncing:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))
@@ -226,4 +227,25 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	}
 
 	return r.syncStatus(co, conds)
+}
+
+func SetCOInDisabledState(osClient osclientset.Interface, version string) error {
+	//The CVO should have created the CO
+	co, err := osClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+
+	if err != nil {
+		return fmt.Errorf("failed to get clusterOperator %q: %v", clusterOperatorName, err)
+	}
+
+	conds := defaultStatusConditions()
+	v1helpers.SetStatusCondition(&conds, setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, "Operator on Standby", "Unsupported Platform"))
+	v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
+
+	for _, c := range conds {
+		v1helpers.SetStatusCondition(&co.Status.Conditions, c)
+	}
+	co.Status.Versions = operandVersions(version)
+
+	_, err = osClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})
+	return err
 }

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -30,7 +30,7 @@ func TestUpdateCOStatusDisabled(t *testing.T) {
 			name: "Correct Condition",
 			expectedConditions: []osconfigv1.ClusterOperatorStatusCondition{
 				setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
-				setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, "", ""),
+				setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, "AsExpected", "Operational"),
 				setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, "UnsupportedPlatform", "Operator is non-functional"),
 				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, "", ""),
 				setStatusCondition(osconfigv1.OperatorUpgradeable, osconfigv1.ConditionTrue, "", ""),

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -81,13 +82,10 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get;list;watch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/status,verbs=get;update;patch
 
-func IsEnabled(runtimeClient client.Client) (bool, error) {
+func IsEnabled(osClient osclientset.Interface) (bool, error) {
 	ctx := context.Background()
 
-	infra := &osconfigv1.Infrastructure{}
-	err := runtimeClient.Get(ctx, client.ObjectKey{
-		Name: "cluster",
-	}, infra)
+	infra, err := osClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return false, errors.Wrap(err, "unable to determine Platform")
 	}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -124,13 +124,13 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	enabled, err := IsEnabled(r.OSClient)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "unable to determine Infrastructure Platform type")
+		return ctrl.Result{}, errors.Wrap(err, "could not determine whether to run")
 	}
 	if !enabled {
 		// set ClusterOperator status to disabled=true, available=true
 		err = r.updateCOStatus(ReasonUnsupported, "Nothing to do on this Platform", "")
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Disabled state: %v", clusterOperatorName, err)
 		}
 
 		// We're disabled; don't requeue

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -76,11 +76,14 @@ type ProvisioningReconciler struct {
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=create;get;update
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
 // +kubebuilder:rbac:groups=,resources=events,verbs=create;watch;list;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get;list;watch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=metal3.io,resources=provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 
 func IsEnabled(osClient osclientset.Interface) (bool, error) {
 	ctx := context.Background()

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -79,7 +79,7 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;list;patch
-// +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -67,8 +67,8 @@ type ProvisioningReconciler struct {
 	Generations []osoperatorv1.GenerationStatus
 }
 
-// +kubebuilder:rbac:namespace=openshift-machine-api,groups=,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace=openshift-machine-api,groups=,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=metal3.io,resources=baremetalhosts/status;baremetalhosts/finalizers,verbs=update
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
@@ -78,12 +78,12 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
-// +kubebuilder:rbac:groups=,resources=events,verbs=create;watch;list;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;list;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings,verbs=get;list;watch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 
 func IsEnabled(osClient osclientset.Interface) (bool, error) {
 	ctx := context.Background()

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -34,7 +34,7 @@ func newFakeProvisioningReconciler(scheme *runtime.Scheme, object runtime.Object
 	}
 }
 
-func TestReconcile(t *testing.T) {
+func TestIsEnabled(t *testing.T) {
 	testCases := []struct {
 		name          string
 		infra         *configv1.Infrastructure
@@ -46,7 +46,7 @@ func TestReconcile(t *testing.T) {
 			infra: &configv1.Infrastructure{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Infrastructure",
-					APIVersion: "apps/v1",
+					APIVersion: "config.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
@@ -63,7 +63,7 @@ func TestReconcile(t *testing.T) {
 			infra: &configv1.Infrastructure{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Infrastructure",
-					APIVersion: "apps/v1",
+					APIVersion: "config.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
@@ -86,8 +86,8 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 
-			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), tc.infra)
-			enabled, err := IsEnabled(reconciler.Client)
+			osClient := fakeconfigclientset.NewSimpleClientset(tc.infra)
+			enabled, err := IsEnabled(osClient)
 			if tc.expectedError && err == nil {
 				t.Error("should have produced an error")
 				return

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -87,7 +87,7 @@ func TestReconcile(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 
 			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), tc.infra)
-			enabled, err := reconciler.isEnabled()
+			enabled, err := IsEnabled(reconciler.Client)
 			if tc.expectedError && err == nil {
 				t.Error("should have produced an error")
 				return

--- a/main.go
+++ b/main.go
@@ -100,11 +100,8 @@ func main() {
 	}
 
 	osClient := osclientset.NewForConfigOrDie(rest.AddUserAgent(config, controllers.ComponentName))
-	recorder := record.NewBroadcaster().NewRecorder(clientgoscheme.Scheme, v1.EventSource{Component: controllers.ComponentName})
-	kubeClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(config, controllers.ComponentName))
-
 	// Check the Platform Type to determine the state of the CO
-	enabled, err := controllers.IsEnabled(mgr.GetClient())
+	enabled, err := controllers.IsEnabled(osClient)
 	if err != nil {
 		setupLog.Error(err, "unable to determine Infrastructure Platform type")
 		os.Exit(1)
@@ -117,6 +114,9 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	recorder := record.NewBroadcaster().NewRecorder(clientgoscheme.Scheme, v1.EventSource{Component: controllers.ComponentName})
+	kubeClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(config, controllers.ComponentName))
 
 	if err = (&controllers.ProvisioningReconciler{
 		Client:         mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -103,14 +103,14 @@ func main() {
 	// Check the Platform Type to determine the state of the CO
 	enabled, err := controllers.IsEnabled(osClient)
 	if err != nil {
-		setupLog.Error(err, "unable to determine Infrastructure Platform type")
+		setupLog.Error(err, "could not determine whether to run")
 		os.Exit(1)
 	}
 	if !enabled {
 		//Set ClusterOperator status to disabled=true, available=true
 		err = controllers.SetCOInDisabledState(osClient, releaseVersion)
 		if err != nil {
-			setupLog.Error(err, "unable to set Baremetal CO to disabled")
+			setupLog.Error(err, "unable to set baremetal ClusterOperator to Disabled")
 			os.Exit(1)
 		}
 	}

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -7,7 +7,9 @@ metadata:
   name: cluster-baremetal-operator
   namespace: openshift-machine-api
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - create
@@ -17,7 +19,9 @@ rules:
   - patch
   - update
   - watch
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -71,7 +75,9 @@ metadata:
   creationTimestamp: null
   name: cluster-baremetal-operator
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -141,8 +141,12 @@ rules:
   resources:
   - provisionings
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - metal3.io

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -79,14 +79,42 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators
   - clusteroperators/status
   verbs:
   - create
+  - delete
   - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -109,6 +137,18 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - provisionings/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - metal3.io


### PR DESCRIPTION
Current implementation sets the Baremetal CO to Disabled in Platforms other than BareMetal before starting the Reconciler.

Alternate approach: (re-worded based on @andfasano 's feedback below)
The CO manifest can be defined with the CO in Disabled state. So, when CVO installs all the manifests in the /manifest directory, the Baremetal CO starts in the Disabled state. On the BareMetal platform, the CO resource would be amended within the reconcile loop.