### PR TITLE
Bug 1893832: add missing ErrorCount field

### DIFF
--- a/manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
@@ -307,6 +307,10 @@ spec:
           status:
             description: BareMetalHostStatus defines the observed state of BareMetalHost
             properties:
+              errorCount:
+                description: ErrorCount records how many times the host has encoutered
+                  an error since the last successful operation
+                type: integer
               errorMessage:
                 description: the last error message reported by the provisioning subsystem
                 type: string
@@ -706,6 +710,7 @@ spec:
                     type: string
                 type: object
             required:
+            - errorCount
             - errorMessage
             - hardwareProfile
             - operationHistory


### PR DESCRIPTION
The BareMetalHost CRD is missing the ErrorCount field, currently required by the BareMetal Operator