### PR TITLE
Bug 1906105: Annotate existing metal3 deployment

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -49,6 +49,9 @@ const (
 	// ReasonDeploymentCrashLooping indicates that the deployment is crashlooping
 	ReasonDeploymentCrashLooping StatusReason = "DeploymentCrashLooping"
 
+	// ReasonNotFound indicates that the deployment is not found
+	ReasonNotFound StatusReason = "ResourceNotFound"
+
 	// ReasonUnsupported is an unsupported StatusReason
 	ReasonUnsupported StatusReason = "UnsupportedPlatform"
 )
@@ -218,7 +221,7 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	case ReasonComplete:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(newReason), progressMsg))
-	case ReasonInvalidConfiguration, ReasonDeployTimedOut:
+	case ReasonInvalidConfiguration, ReasonDeployTimedOut, ReasonNotFound:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -271,7 +271,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %v", clusterOperatorName, err)
 		}
 	} else if deploymentState == appsv1.DeploymentAvailable {
-		err = r.updateCOStatus(ReasonSyncing, "metal3 pod running; starting other services", "")
+		err = r.updateCOStatus(ReasonSyncing, "metal3 pod running", "starting other metal3 services")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Progressing state: %v", clusterOperatorName, err)
 		}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -31,15 +31,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 	provisioning "github.com/openshift/cluster-baremetal-operator/provisioning"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
 const (
@@ -189,6 +186,14 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, err
 	}
 
+	specChanged := baremetalConfig.Generation != baremetalConfig.Status.ObservedGeneration
+	if specChanged {
+		err = r.updateCOStatus(ReasonSyncing, "", "Applying metal3 resources")
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Syncing state: %v", clusterOperatorName, err)
+		}
+	}
+
 	if err := provisioning.ValidateBaremetalProvisioningConfig(baremetalConfig); err != nil {
 		// Provisioning configuration is not valid.
 		// Requeue request.
@@ -215,7 +220,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, err
 	}
 
-	//Create Secrets needed for Metal3 deployment
+	// Create Secrets needed for Metal3 deployment
 	if err := provisioning.CreateMariadbPasswordSecret(r.KubeClient.CoreV1(), ComponentNamespace, baremetalConfig, r.Scheme); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to create Mariadb password")
 	}
@@ -236,32 +241,21 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 
 	if maoOwned {
-		r.Log.V(1).Info("metal3 deployment already exists")
-		err = r.updateCOStatus(ReasonComplete, "found existing Metal3 deployment", "")
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Available state: %v", clusterOperatorName, err)
-		}
-		return ctrl.Result{}, nil
+		r.Log.V(1).Info("Adding annotation for CBO to take ownership of metal3 deployment created by MAO")
 	}
 
-	specChanged := baremetalConfig.Generation != baremetalConfig.Status.ObservedGeneration
-	if specChanged {
-		err = r.updateCOStatus(ReasonSyncing, "", "Applying the Metal3 deployment")
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Syncing state: %v", clusterOperatorName, err)
-		}
-	}
+	info := r.provisioningInfo(baremetalConfig, &containerImages)
 
 	// Proceed with creating or updating the Metal3 deployment
-	updated, err := r.ensureMetal3Deployment(baremetalConfig, &containerImages, metal3DeploymentSelector)
+	updated, err := provisioning.EnsureMetal3Deployment(info, metal3DeploymentSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if updated {
+		err = r.Client.Status().Update(context.Background(), baremetalConfig)
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	info := r.provisioningInfo(baremetalConfig, &containerImages)
 	for _, ensureResource := range []ensureFunc{
 		provisioning.EnsureMetal3StateService,
 		provisioning.EnsureImageCache,
@@ -284,36 +278,25 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		}
 	}
 
-	err = r.updateCOStatus(ReasonComplete, "new Metal3 deployment completed", "")
+	// Determine the status of the deployment
+	deploymentState, err := provisioning.GetDeploymentState(r.KubeClient.AppsV1(), ComponentNamespace, baremetalConfig)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Available state: %v", clusterOperatorName, err)
+		return ctrl.Result{}, errors.Wrap(err, "failed to determine state of metal3 deployment")
+	}
+	if deploymentState == appsv1.DeploymentReplicaFailure {
+		err = r.updateCOStatus(ReasonDeployTimedOut, "metal3 deployment rollout taking too long", "")
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %v", clusterOperatorName, err)
+		}
+	}
+	if deploymentState == appsv1.DeploymentAvailable {
+		err = r.updateCOStatus(ReasonSyncing, "metal3 pod running; starting other services", "")
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Progressing state: %v", clusterOperatorName, err)
+		}
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *ProvisioningReconciler) ensureMetal3Deployment(provConfig *metal3iov1alpha1.Provisioning, images *provisioning.Images, selector *metav1.LabelSelector) (updated bool, err error) {
-	metal3Deployment := provisioning.NewMetal3Deployment(ComponentNamespace, images, &provConfig.Spec, selector)
-	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, provConfig.Status.Generations)
-
-	err = controllerutil.SetControllerReference(provConfig, metal3Deployment, r.Scheme)
-	if err != nil {
-		err = fmt.Errorf("unable to set controllerReference on deployment: %w", err)
-		return
-	}
-
-	deployment, updated, err := resourceapply.ApplyDeployment(r.KubeClient.AppsV1(),
-		events.NewLoggingEventRecorder(ComponentName), metal3Deployment, expectedGeneration)
-	if err != nil {
-		err = fmt.Errorf("unable to apply Metal3 deployment: %w", err)
-		return
-	}
-
-	if updated {
-		resourcemerge.SetDeploymentGeneration(&provConfig.Status.Generations, deployment)
-		err = r.Client.Status().Update(context.Background(), provConfig)
-	}
-	return
 }
 
 func (r *ProvisioningReconciler) provisioningInfo(provConfig *metal3iov1alpha1.Provisioning, images *provisioning.Images) *provisioning.ProvisioningInfo {

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -22,10 +24,13 @@ import (
 )
 
 const (
-	imageCacheSharedVolume = "metal3-shared-image-cache"
-	imageCacheService      = "metal3-image-cache"
-	imageCachePort         = 6181
-	imageCachePortName     = "http"
+	imageCacheSharedVolume                                = "metal3-shared-image-cache"
+	imageCacheService                                     = "metal3-image-cache"
+	imageCachePort                                        = 6181
+	imageCachePortName                                    = "http"
+	DaemonSetProgressing    appsv1.DaemonSetConditionType = "Progressing"
+	DaemonSetReplicaFailure appsv1.DaemonSetConditionType = "ReplicaFailure"
+	DaemonSetAvailable      appsv1.DaemonSetConditionType = "Available"
 )
 
 var fileCompressionSuffix = regexp.MustCompile(`\.[gx]z$`)
@@ -229,4 +234,23 @@ func EnsureImageCache(info *ProvisioningInfo) (updated bool, err error) {
 
 	resourcemerge.SetDaemonSetGeneration(&info.ProvConfig.Status.Generations, daemonSet)
 	return
+}
+
+func getDaemonSetCondition(daemonSet *appsv1.DaemonSet) appsv1.DaemonSetConditionType {
+	for _, cond := range daemonSet.Status.Conditions {
+		if cond.Status == corev1.ConditionTrue {
+			return cond.Type
+		}
+	}
+	return DaemonSetProgressing
+}
+
+// Provide the current state of metal3 deployment
+func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DaemonSetConditionType, error) {
+	existing, err := client.DaemonSets(targetNamespace).Get(context.Background(), imageCacheService, metav1.GetOptions{})
+	if err != nil || existing == nil {
+		// There were errors accessing the deployment.
+		return DaemonSetReplicaFailure, err
+	}
+	return getDaemonSetCondition(existing), nil
 }


### PR DESCRIPTION
- Create a new metal3 Deployment object and merge it with an existing one if available. The "merge" is done by ApplyDeployment(). As result of this, if the existing Deployment object was created by MAO (on upgrade from 4.6), the "cboOwnedAnnotation" would be added to the existing Deployment. If the Provisioning Config changed, then the DeploymentSpec would be updated with the DeploymentSpec of the new Deployment object that was created using the new config.

-  Use the state of the Deployment rollout to set the state in the "baremetal" ClusterOperator.