### PR TITLE
add -images-json command line option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ IMG ?= controller:latest
 CONTROLLER_GEN ?= go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 BIN_DIR := bin
 
+IMAGES_JSON := /etc/cluster-baremetal-operator/images/images.json
+
 ifeq (/,${HOME})
 GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache/
 else
@@ -29,7 +31,7 @@ cluster-baremetal-operator: generate lint
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate lint manifests
-	go run ./main.go
+	go run ./main.go -images-json $(IMAGES_JSON)
 
 # Install CRDs into a cluster
 install: manifests

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -48,8 +48,6 @@ const (
 	ComponentName = "cluster-baremetal-operator"
 	// BaremetalProvisioningCR is the name of the provisioning resource
 	BaremetalProvisioningCR = "provisioning-configuration"
-	// ContainerImagesFile volume mounted file containing the images configmap
-	ContainerImagesFile = "/etc/cluster-baremetal-operator/images/images.json"
 )
 
 // ProvisioningReconciler reconciles a Provisioning object
@@ -63,6 +61,7 @@ type ProvisioningReconciler struct {
 	EventRecorder  record.EventRecorder
 	KubeClient     kubernetes.Interface
 	ReleaseVersion string
+	ImagesFilename string
 
 	Generations []osoperatorv1.GenerationStatus
 }
@@ -161,7 +160,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	// Read container images from Config Map
 	var containerImages provisioning.Images
-	if err := provisioning.GetContainerImages(&containerImages, ContainerImagesFile); err != nil {
+	if err := provisioning.GetContainerImages(&containerImages, r.ImagesFilename); err != nil {
 		// Images config map is not valid
 		// Provisioning configuration is not valid.
 		// Requeue request.

--- a/main.go
+++ b/main.go
@@ -69,9 +69,13 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var imagesJSONFilename string
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&imagesJSONFilename, "images-json", "/etc/cluster-baremetal-operator/images/images.json",
+		"The location of the file containing the images to use for our operands.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -107,6 +111,7 @@ func main() {
 		EventRecorder:  recorder,
 		KubeClient:     kubeClient,
 		ReleaseVersion: releaseVersion,
+		ImagesFilename: imagesJSONFilename,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Provisioning")
 		os.Exit(1)


### PR DESCRIPTION
Add a command line option to specify the location of the file containing
the image references. This allows developers to use `make run` without
modifying files in /etc.

/cc @sadasu