### PR TITLE
move logic for managing disabled state back inside the reconciler

### DIFF
--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -361,44 +360,4 @@ func TestUpdateCOStatusAvailable(t *testing.T) {
 			t.Fatal(diff)
 		}
 	}
-}
-
-func TestSetCOInDisabledState(t *testing.T) {
-	tCases := []struct {
-		name               string
-		releaseVersion     string
-		expectedConditions []osconfigv1.ClusterOperatorStatusCondition
-	}{
-		{
-			name:           "Disabled State",
-			releaseVersion: "Test",
-			expectedConditions: []osconfigv1.ClusterOperatorStatusCondition{
-				setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
-				setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonExpected), "Operational"),
-				setStatusCondition(OperatorDisabled, osconfigv1.ConditionTrue, string(ReasonUnsupported), "Nothing to do on this Platform"),
-				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, "", ""),
-				setStatusCondition(osconfigv1.OperatorUpgradeable, osconfigv1.ConditionTrue, "", ""),
-			},
-		},
-	}
-
-	reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
-	co, _ := reconciler.createClusterOperator()
-	reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(co)
-
-	for _, tc := range tCases {
-		err := SetCOInDisabledState(reconciler.OSClient, tc.releaseVersion)
-		if err != nil {
-			t.Error(err)
-		}
-		gotCO, _ := reconciler.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
-
-		diff := getStatusConditionsDiff(tc.expectedConditions, gotCO.Status.Conditions)
-		if diff != "" {
-			t.Fatal(diff)
-		}
-		assert.Equal(t, operandVersions(tc.releaseVersion), gotCO.Status.Versions, fmt.Sprintf("%s : releaseVersion in CO incorrect. Excpected : %s", tc.name, tc.releaseVersion))
-
-	}
-	_ = reconciler.OSClient.ConfigV1().ClusterOperators().Delete(context.Background(), clusterOperatorName, metav1.DeleteOptions{})
 }

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -86,8 +86,10 @@ func TestIsEnabled(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 
-			osClient := fakeconfigclientset.NewSimpleClientset(tc.infra)
-			enabled, err := IsEnabled(osClient)
+			reconciler := ProvisioningReconciler{
+				OSClient: fakeconfigclientset.NewSimpleClientset(tc.infra),
+			}
+			enabled, err := reconciler.isEnabled()
 			if tc.expectedError && err == nil {
 				t.Error("should have produced an error")
 				return

--- a/main.go
+++ b/main.go
@@ -100,20 +100,6 @@ func main() {
 	}
 
 	osClient := osclientset.NewForConfigOrDie(rest.AddUserAgent(config, controllers.ComponentName))
-	// Check the Platform Type to determine the state of the CO
-	enabled, err := controllers.IsEnabled(osClient)
-	if err != nil {
-		setupLog.Error(err, "could not determine whether to run")
-		os.Exit(1)
-	}
-	if !enabled {
-		//Set ClusterOperator status to disabled=true, available=true
-		err = controllers.SetCOInDisabledState(osClient, releaseVersion)
-		if err != nil {
-			setupLog.Error(err, "unable to set baremetal ClusterOperator to Disabled")
-			os.Exit(1)
-		}
-	}
 
 	recorder := record.NewBroadcaster().NewRecorder(clientgoscheme.Scheme, v1.EventSource{Component: controllers.ComponentName})
 	kubeClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(config, controllers.ComponentName))


### PR DESCRIPTION
Avoid duplicating the logic for handling the disabled state by moving
the call to initialize the ClusterOperator from main into
SetupWithManager. That also lets us reuse the existing reconciler
method to set the ClusterOperator status, so we can eliminate
SetCOInDisabledState entirely.

This is a follow-up to #63

/cc @sadasu @asalkeld