### PR TITLE
Add default value to BMH errorCount field

### DIFF
--- a/manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_03_baremetalhost.crd.yaml
@@ -311,6 +311,7 @@ spec:
                 description: ErrorCount records how many times the host has encoutered
                   an error since the last successful operation
                 type: integer
+                default: 0
               errorMessage:
                 description: the last error message reported by the provisioning subsystem
                 type: string


### PR DESCRIPTION
Add default value to BMH errorCount field to allow smoother upgrades.

Related to:
[1] https://github.com/metal3-io/baremetal-operator/pull/722
[2] https://github.com/openshift/machine-api-operator/pull/747
