### PR TITLE
Bug 1906935: Delete resources when Provisioning CR is deleted

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -218,7 +218,7 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, err
 	}
 
-	// If Metal3 Deployment already exists and managed by MAO, do nothing.
+	// Check Metal3 Deployment already exists and managed by MAO.
 	metal3DeploymentSelector, maoOwned, err := provisioning.CheckExistingMetal3Deployment(r.KubeClient.AppsV1(), ComponentNamespace)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, errors.Wrap(err, "failed to check for existing Metal3 Deployment")

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/utils/pointer"
@@ -672,4 +673,11 @@ func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace s
 		return appsv1.DeploymentReplicaFailure, nil
 	}
 	return deploymentState, nil
+func DeleteMetal3Deployment(client appsclientv1.DeploymentsGetter, targetNamespace string) error {
+	err := client.Deployments(targetNamespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// metal3 deployment does not exist. Nothing to delete
+		return nil
+	}
+	return err
 }

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -673,8 +673,10 @@ func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace s
 		return appsv1.DeploymentReplicaFailure, nil
 	}
 	return deploymentState, nil
-func DeleteMetal3Deployment(client appsclientv1.DeploymentsGetter, targetNamespace string) error {
-	err := client.Deployments(targetNamespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{})
+}
+
+func DeleteMetal3Deployment(info *ProvisioningInfo) error {
+	err := info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// metal3 deployment does not exist. Nothing to delete
 		return nil

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -169,42 +169,11 @@ password = %s
 	return err
 }
 
-func DeleteMariadbPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
-	err := client.Secrets(targetNamespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{})
+func DeleteAllSecrets(info *ProvisioningInfo) {
+	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{})
+	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{})
+	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{})
+	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{})
 
-	if apierrors.IsNotFound(err) {
-		// mariadb password Secret doesn't exist. Nothing to delete
-		return nil
-	}
-	return err
-}
-
-func DeleteIronicPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
-	err := client.Secrets(targetNamespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{})
-
-	if apierrors.IsNotFound(err) {
-		// ironic password Secret doesn't exist. Nothing to delete
-		return nil
-	}
-	return err
-}
-
-func DeleteInspectorPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
-	err := client.Secrets(targetNamespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{})
-
-	if apierrors.IsNotFound(err) {
-		// ironic password Secret doesn't exist. Nothing to delete
-		return nil
-	}
-	return err
-}
-
-func DeleteIronicRpcPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
-	err := client.Secrets(targetNamespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{})
-
-	if apierrors.IsNotFound(err) {
-		// ironic rpc Secret doesn't exist. Nothing to delete
-		return nil
-	}
-	return err
+	return
 }

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -168,3 +168,43 @@ password = %s
 	_, err = client.Secrets(targetNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	return err
 }
+
+func DeleteMariadbPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
+	err := client.Secrets(targetNamespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{})
+
+	if apierrors.IsNotFound(err) {
+		// mariadb password Secret doesn't exist. Nothing to delete
+		return nil
+	}
+	return err
+}
+
+func DeleteIronicPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
+	err := client.Secrets(targetNamespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{})
+
+	if apierrors.IsNotFound(err) {
+		// ironic password Secret doesn't exist. Nothing to delete
+		return nil
+	}
+	return err
+}
+
+func DeleteInspectorPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
+	err := client.Secrets(targetNamespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{})
+
+	if apierrors.IsNotFound(err) {
+		// ironic password Secret doesn't exist. Nothing to delete
+		return nil
+	}
+	return err
+}
+
+func DeleteIronicRpcPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string) error {
+	err := client.Secrets(targetNamespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{})
+
+	if apierrors.IsNotFound(err) {
+		// ironic rpc Secret doesn't exist. Nothing to delete
+		return nil
+	}
+	return err
+}

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,7 +51,7 @@ func generateRandomPassword() (string, error) {
 }
 
 // CreateMariadbPasswordSecret creates a Secret for Mariadb password
-func CreateMariadbPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
+func createMariadbPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
 	existing, err := client.Secrets(targetNamespace).Get(context.Background(), baremetalSecretName, metav1.GetOptions{})
 	if err == nil && len(existing.ObjectMeta.OwnerReferences) == 0 {
 		err = controllerutil.SetControllerReference(baremetalConfig, existing, scheme)
@@ -88,21 +89,6 @@ func CreateMariadbPasswordSecret(client coreclientv1.SecretsGetter, targetNamesp
 	_, err = client.Secrets(targetNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
 
 	return err
-}
-
-// CreateIronicPasswordSecret creates a Secret for the Ironic Password
-func CreateIronicPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
-	return createIronicSecret(client, targetNamespace, ironicSecretName, ironicUsername, "ironic", baremetalConfig, scheme)
-}
-
-// CreateIronicRpcPasswordSecret creates a Secret for the Ironic RPC Password
-func CreateIronicRpcPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
-	return createIronicSecret(client, targetNamespace, ironicrpcSecretName, ironicrpcUsername, "json_rpc", baremetalConfig, scheme)
-}
-
-// CreateInspectorPasswordSecret creates a Secret for the Ironic Inspector Password
-func CreateInspectorPasswordSecret(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
-	return createIronicSecret(client, targetNamespace, inspectorSecretName, inspectorUsername, "inspector", baremetalConfig, scheme)
 }
 
 func createIronicSecret(client coreclientv1.SecretsGetter, targetNamespace string, name string, username string, configSection string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
@@ -169,11 +155,40 @@ password = %s
 	return err
 }
 
-func DeleteAllSecrets(info *ProvisioningInfo) {
-	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{})
-	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{})
-	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{})
-	_ = info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{})
+func CreateAllSecrets(client coreclientv1.SecretsGetter, targetNamespace string, baremetalConfig *metal3iov1alpha1.Provisioning, scheme *runtime.Scheme) error {
+	// Create a Secret for the Mariadb Password
+	if err := createMariadbPasswordSecret(client, targetNamespace, baremetalConfig, scheme); err != nil {
+		return errors.Wrap(err, "failed to create Mariadb password")
+	}
+	// Create a Secret for the Ironic Password
+	if err := createIronicSecret(client, targetNamespace, ironicSecretName, ironicUsername, "ironic", baremetalConfig, scheme); err != nil {
+		return errors.Wrap(err, "failed to create Ironic password")
+	}
+	// Create a Secret for the Ironic RPC Password
+	if err := createIronicSecret(client, targetNamespace, ironicrpcSecretName, ironicrpcUsername, "json_rpc", baremetalConfig, scheme); err != nil {
+		return errors.Wrap(err, "failed to create Ironic rpc password")
+	}
+	// Create a Secret for the Ironic Inspector Password
+	if err := createIronicSecret(client, targetNamespace, inspectorSecretName, inspectorUsername, "inspector", baremetalConfig, scheme); err != nil {
+		return errors.Wrap(err, "failed to create Inspector password")
+	}
+	return nil
+}
 
-	return
+func DeleteAllSecrets(info *ProvisioningInfo) []string {
+	deleteFailures := []string{}
+	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{}); err != nil {
+		deleteFailures = append(deleteFailures, baremetalSecretName)
+	}
+	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{}); err != nil {
+		deleteFailures = append(deleteFailures, ironicSecretName)
+	}
+	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{}); err != nil {
+		deleteFailures = append(deleteFailures, inspectorSecretName)
+	}
+	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{}); err != nil {
+		deleteFailures = append(deleteFailures, ironicrpcSecretName)
+	}
+
+	return deleteFailures
 }

--- a/provisioning/baremetal_secrets_test.go
+++ b/provisioning/baremetal_secrets_test.go
@@ -105,7 +105,7 @@ func TestCreateMariadbPasswordSecret(t *testing.T) {
 
 			switch tc.name {
 			case "new-mariadb-secret":
-				err := CreateMariadbPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
+				err := createMariadbPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
 				assert.Equal(t, tc.expectedError, err)
 
 				if tc.expectedError == nil {
@@ -115,7 +115,7 @@ func TestCreateMariadbPasswordSecret(t *testing.T) {
 					// created and the old one returned.
 					if tc.testRecreate {
 						original := secret.(*v1.Secret).StringData[baremetalSecretKey]
-						err := CreateMariadbPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
+						err := createMariadbPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
 						assert.Equal(t, tc.expectedError, err)
 						newSecret, _ := kubeClient.Tracker().Get(secretsResource, testNamespace, "metal3-mariadb-password")
 						recreated := newSecret.(*v1.Secret).StringData[baremetalSecretKey]
@@ -123,7 +123,7 @@ func TestCreateMariadbPasswordSecret(t *testing.T) {
 					}
 				}
 			case "new-ironic-secret":
-				err := CreateIronicPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
+				err := createIronicSecret(kubeClient.CoreV1(), testNamespace, ironicSecretName, ironicUsername, "ironic", baremetalCR, scheme)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 					return
@@ -135,7 +135,7 @@ func TestCreateMariadbPasswordSecret(t *testing.T) {
 				}
 				assert.True(t, strings.Compare(secret.(*v1.Secret).StringData[ironicUsernameKey], ironicUsername) == 0, "ironic password created incorrectly")
 			case "new-inspector-secret":
-				err := CreateInspectorPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
+				err := createIronicSecret(kubeClient.CoreV1(), testNamespace, inspectorSecretName, inspectorUsername, "inspector", baremetalCR, scheme)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 					return
@@ -147,7 +147,7 @@ func TestCreateMariadbPasswordSecret(t *testing.T) {
 				}
 				assert.True(t, strings.Compare(secret.(*v1.Secret).StringData[ironicUsernameKey], inspectorUsername) == 0, "inspector password created incorrectly")
 			case "new-ironic-rpc-secret":
-				err := CreateIronicRpcPasswordSecret(kubeClient.CoreV1(), testNamespace, baremetalCR, scheme)
+				err := createIronicSecret(kubeClient.CoreV1(), testNamespace, ironicrpcSecretName, ironicrpcUsername, "json_rpc", baremetalCR, scheme)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 					return

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -12,6 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -254,4 +255,13 @@ func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace str
 		return DaemonSetReplicaFailure, nil
 	}
 	return DaemonSetProgressing, nil
+}
+
+func DeleteImageCache(info *ProvisioningInfo) error {
+	err := info.Client.AppsV1().DaemonSets(info.Namespace).Delete(context.Background(), imageCacheService, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// metal3 image cache does not exist. Nothing to delete
+		return nil
+	}
+	return err
 }

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -241,7 +241,7 @@ func EnsureImageCache(info *ProvisioningInfo) (updated bool, err error) {
 	return
 }
 
-// Provide the current state of metal3 deployment
+// Provide the current state of metal3 image-cache daemonset
 func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DaemonSetConditionType, error) {
 	existing, err := client.DaemonSets(targetNamespace).Get(context.Background(), imageCacheService, metav1.GetOptions{})
 	if err != nil || existing == nil {

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -1,10 +1,12 @@
 package provisioning
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -53,4 +55,13 @@ func EnsureMetal3StateService(info *ProvisioningInfo) (updated bool, err error) 
 		err = fmt.Errorf("unable to apply Metal3-state service: %w", err)
 	}
 	return
+}
+
+func DeleteMetal3StateService(info *ProvisioningInfo) error {
+	err := info.Client.CoreV1().Services(info.Namespace).Delete(context.Background(), stateService, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// metal3-state service does not exist. Nothing to delete
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
Delete all Secrets and the metal3 Deployment object created by the CBO when the Provisioning CR is deleted.