### PR TITLE
Use hostIP for ironic containers when provisionig network disabled 

### DIFF
--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -172,6 +172,20 @@ func TestValidateDisabledProvisioningConfig(t *testing.T) {
 			expectedMode:  metal3iov1alpha1.ProvisioningNetworkDisabled,
 		},
 		{
+			// All fields are specified, except ProvisioningIP and CIDR
+			name:          "ValidDisabled",
+			spec:          disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
+			expectedError: false,
+			expectedMode:  metal3iov1alpha1.ProvisioningNetworkDisabled,
+		},
+		{
+			name:          "InvalidDisabledNoCIDRWithIP",
+			spec:          disabledProvisioning().ProvisioningNetworkCIDR("").build(),
+			expectedError: true,
+			expectedMode:  metal3iov1alpha1.ProvisioningNetworkDisabled,
+			expectedMsg:   "provisioningNetworkCIDR",
+		},
+		{
 			// Missing ProvisioningOSDownloadURL
 			name:          "InvalidDisabled",
 			spec:          disabledProvisioning().ProvisioningOSDownloadURL("").build(),


### PR DESCRIPTION
This change makes the ironic containers get the hostIP when the
provisioningIP is blank. This removes the requirement for a
provisioningIP in Ironic, but additional work is needed to fix the image
URL's we pass to baremetal-operator.

As we are using an existing IP on an interface, we no longer have a
requirement on the static IP manager when the provisioningIP is blank,
so we do not start the containers in this case.

This also changes baremetal operator to communicate with the ironic
containers on localhost, as they are in the same pod.