### PR TITLE
Add a second-level image cache

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -130,6 +142,18 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -154,6 +166,18 @@ rules:
   - ""
   resources:
   - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
   verbs:
   - create
   - delete

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -65,12 +65,15 @@ type ProvisioningReconciler struct {
 	ImagesFilename string
 }
 
+type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
+
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=metal3.io,resources=baremetalhosts/status;baremetalhosts/finalizers,verbs=update
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:namespace=openshift-machine-api,groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
@@ -83,6 +86,7 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ProvisioningReconciler) isEnabled() (bool, error) {
@@ -255,12 +259,18 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 
 	info := r.provisioningInfo(baremetalConfig, &containerImages)
-	updated, err = provisioning.EnsureMetal3StateService(info)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	if updated {
-		return ctrl.Result{Requeue: true}, err
+	for _, ensureResource := range []ensureFunc{
+		provisioning.EnsureMetal3StateService,
+		provisioning.EnsureImageCache,
+	} {
+		updated, err := ensureResource(info)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if updated {
+			err = r.Client.Status().Update(context.Background(), baremetalConfig)
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	if specChanged {
@@ -351,6 +361,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&appsv1.DaemonSet{}).
 		Owns(&osconfigv1.ClusterOperator{}).
 		Complete(r)
 }

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -71,6 +71,7 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=metal3.io,resources=baremetalhosts/status;baremetalhosts/finalizers,verbs=update
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:namespace=openshift-machine-api,groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
@@ -82,6 +83,7 @@ type ProvisioningReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ProvisioningReconciler) isEnabled() (bool, error) {
 	ctx := context.Background()
@@ -252,6 +254,15 @@ func (r *ProvisioningReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	info := r.provisioningInfo(baremetalConfig, &containerImages)
+	updated, err = provisioning.EnsureMetal3StateService(info)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if updated {
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	if specChanged {
 		baremetalConfig.Status.ObservedGeneration = baremetalConfig.Generation
 		err = r.Client.Status().Update(context.Background(), baremetalConfig)
@@ -292,6 +303,17 @@ func (r *ProvisioningReconciler) ensureMetal3Deployment(provConfig *metal3iov1al
 	return
 }
 
+func (r *ProvisioningReconciler) provisioningInfo(provConfig *metal3iov1alpha1.Provisioning, images *provisioning.Images) *provisioning.ProvisioningInfo {
+	return &provisioning.ProvisioningInfo{
+		Client:        r.KubeClient,
+		EventRecorder: events.NewLoggingEventRecorder(ComponentName),
+		ProvConfig:    provConfig,
+		Scheme:        r.Scheme,
+		Namespace:     ComponentNamespace,
+		Images:        images,
+	}
+}
+
 // SetupWithManager configures the manager to run the controller
 func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := r.ensureClusterOperator(nil)
@@ -328,6 +350,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&metal3iov1alpha1.Provisioning{}).
 		Owns(&corev1.Secret{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
 		Owns(&osconfigv1.ClusterOperator{}).
 		Complete(r)
 }

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -47,6 +47,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -114,6 +126,18 @@ rules:
   - ""
   resources:
   - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
   verbs:
   - create
   - delete

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -33,6 +33,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -90,6 +102,18 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
   verbs:
   - create
   - delete

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -37,6 +37,7 @@ const (
 	htpasswdEnvVar             = "HTTP_BASIC_HTPASSWD" // #nosec
 	mariadbPwdEnvVar           = "MARIADB_PASSWORD"    // #nosec
 	cboOwnedAnnotation         = "baremetal.openshift.io/owned"
+	cboLabelName               = "baremetal.openshift.io/cluster-baremetal-operator"
 )
 
 var sharedVolumeMount = corev1.VolumeMount{
@@ -340,7 +341,7 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "http",
+				Name:          httpPortName,
 				ContainerPort: int32(port),
 				HostPort:      int32(port),
 			},
@@ -482,8 +483,9 @@ func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.Provision
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"api":     "clusterapi",
-				"k8s-app": "controller",
+				"api":        "clusterapi",
+				"k8s-app":    "controller",
+				cboLabelName: stateService,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -76,6 +76,7 @@ var metal3Volumes = []corev1.Volume{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	},
+	imageVolume(),
 	{
 		Name: ironicCredentialsVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -166,7 +167,7 @@ func createInitContainerIpaDownloader(images *Images) corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
-		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
 		Env:          []corev1.EnvVar{},
 	}
 	return initContainer
@@ -181,7 +182,7 @@ func createInitContainerMachineOsDownloader(images *Images, config *metal3iov1al
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
-		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
 		Env: []corev1.EnvVar{
 			buildEnvVar(machineImageUrl, config),
 		},
@@ -288,8 +289,11 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
-		Command:      []string{"/bin/rundnsmasq"},
-		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		Command: []string{"/bin/rundnsmasq"},
+		VolumeMounts: []corev1.VolumeMount{
+			sharedVolumeMount,
+			imageVolumeMount,
+		},
 		Env: []corev1.EnvVar{
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningInterface, config),
@@ -332,8 +336,11 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
-		Command:      []string{"/bin/runhttpd"},
-		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		Command: []string{"/bin/runhttpd"},
+		VolumeMounts: []corev1.VolumeMount{
+			sharedVolumeMount,
+			imageVolumeMount,
+		},
 		Env: []corev1.EnvVar{
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningIP, config),

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	metal3AppName              = "metal3"
 	baremetalDeploymentName    = "metal3"
 	baremetalSharedVolume      = "metal3-shared"
 	metal3AuthRootDir          = "/auth"

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -17,6 +17,7 @@ package provisioning
 
 import (
 	"context"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -235,6 +236,7 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 			{
 				Name:          "metrics",
 				ContainerPort: 60000,
+				HostPort:      60000,
 			},
 		},
 		Command:         []string{"/baremetal-operator"},
@@ -309,11 +311,19 @@ func createContainerMetal3Mariadb(images *Images) corev1.Container {
 		Env: []corev1.EnvVar{
 			mariadbPassword,
 		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "mysql",
+				ContainerPort: 3306,
+				HostPort:      3306,
+			},
+		},
 	}
 	return container
 }
 
 func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+	port, _ := strconv.Atoi(baremetalHttpPort) // #nosec
 	container := corev1.Container{
 		Name:            "metal3-httpd",
 		Image:           images.Ironic,
@@ -327,6 +337,13 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: int32(port),
+				HostPort:      int32(port),
+			},
 		},
 	}
 	return container
@@ -351,6 +368,13 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
 		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "json-rpc",
+				ContainerPort: 8089,
+				HostPort:      8089,
+			},
+		},
 	}
 	return container
 }
@@ -372,6 +396,13 @@ func createContainerMetal3IronicApi(images *Images, config *metal3iov1alpha1.Pro
 			buildEnvVar(provisioningInterface, config),
 			setIronicHtpasswdHash(htpasswdEnvVar, ironicSecretName),
 		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "ironic",
+				ContainerPort: 6385,
+				HostPort:      6385,
+			},
+		},
 	}
 	return container
 }
@@ -392,6 +423,13 @@ func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alph
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
 			setIronicHtpasswdHash(htpasswdEnvVar, inspectorSecretName),
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "inspector",
+				ContainerPort: 5050,
+				HostPort:      5050,
+			},
 		},
 	}
 	return container

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -1,0 +1,27 @@
+package provisioning
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	imageCacheSharedVolume = "metal3-shared-image-cache"
+)
+
+func imageVolume() corev1.Volume {
+	volType := corev1.HostPathDirectoryOrCreate
+	return corev1.Volume{
+		Name: imageCacheSharedVolume,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/var/lib/metal3/images",
+				Type: &volType,
+			},
+		},
+	}
+}
+
+var imageVolumeMount = corev1.VolumeMount{
+	Name:      imageCacheSharedVolume,
+	MountPath: "/shared/html/images",
+}

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -1,0 +1,19 @@
+package provisioning
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+type ProvisioningInfo struct {
+	Client        kubernetes.Interface
+	EventRecorder events.Recorder
+	ProvConfig    *metal3iov1alpha1.Provisioning
+	Scheme        *runtime.Scheme
+	Namespace     string
+	Images        *Images
+}

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -1,0 +1,56 @@
+package provisioning
+
+import (
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+)
+
+const (
+	stateService = "metal3-state"
+	httpPortName = "http"
+)
+
+func newMetal3StateService(targetNamespace string) *corev1.Service {
+	port, _ := strconv.Atoi(baremetalHttpPort) // #nosec
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stateService,
+			Namespace: targetNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				cboLabelName: stateService,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name: httpPortName,
+					Port: int32(port),
+				},
+			},
+		},
+	}
+}
+
+func EnsureMetal3StateService(info *ProvisioningInfo) (updated bool, err error) {
+	metal3StateService := newMetal3StateService(info.Namespace)
+
+	err = controllerutil.SetControllerReference(info.ProvConfig, metal3StateService, info.Scheme)
+	if err != nil {
+		err = fmt.Errorf("unable to set controllerReference on service: %w", err)
+		return
+	}
+
+	_, updated, err = resourceapply.ApplyService(info.Client.CoreV1(),
+		info.EventRecorder, metal3StateService)
+	if err != nil {
+		err = fmt.Errorf("unable to apply Metal3-state service: %w", err)
+	}
+	return
+}


### PR DESCRIPTION
Add a cache for OS images accessible on port 6181 on every master node.
This cache downloads the images from the first-level cache in the metal3
Pod (port 6180). The images are kept in shared storage, so even when the
metal3 Pod moves, we'll never need to download them from the Internet
again.

The first few commits here are already proposed in #72.