### PR TITLE
baremetal_pod: add log watcher containers

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -210,7 +210,9 @@ func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSp
 		createContainerMetal3Mariadb(images),
 		createContainerMetal3Httpd(images, config),
 		createContainerMetal3IronicConductor(images, config),
+		createContainerIronicInspectorRamdiskLogs(images),
 		createContainerMetal3IronicApi(images, config),
+		createContainerIronicDeployRamdiskLogs(images),
 		createContainerMetal3IronicInspector(images, config),
 	}
 
@@ -376,6 +378,20 @@ func createContainerMetal3IronicApi(images *Images, config *metal3iov1alpha1.Pro
 	return container
 }
 
+func createContainerIronicDeployRamdiskLogs(images *Images) corev1.Container {
+	container := corev1.Container{
+		Name:            "ironic-deploy-ramdisk-logs",
+		Image:           images.Ironic,
+		ImagePullPolicy: "IfNotPresent",
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: pointer.BoolPtr(true),
+		},
+		Command:      []string{"/bin/runlogwatch.sh"},
+		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+	}
+	return container
+}
+
 func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
 	container := corev1.Container{
 		Name:            "metal3-ironic-inspector",
@@ -393,6 +409,20 @@ func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alph
 			buildEnvVar(provisioningInterface, config),
 			setIronicHtpasswdHash(htpasswdEnvVar, inspectorSecretName),
 		},
+	}
+	return container
+}
+
+func createContainerIronicInspectorRamdiskLogs(images *Images) corev1.Container {
+	container := corev1.Container{
+		Name:            "ironic-inspector-ramdisk-logs",
+		Image:           images.IronicInspector,
+		ImagePullPolicy: "IfNotPresent",
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: pointer.BoolPtr(true),
+		},
+		Command:      []string{"/bin/runlogwatch.sh"},
+		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
 	}
 	return container
 }

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -154,22 +154,22 @@ func TestNewMetal3Containers(t *testing.T) {
 		{
 			name:               "ManagedSpec",
 			config:             managedProvisioning().build(),
-			expectedContainers: 8,
+			expectedContainers: 10,
 		},
 		{
 			name:               "UnmanagedSpec",
 			config:             unmanagedProvisioning().build(),
-			expectedContainers: 8,
+			expectedContainers: 10,
 		},
 		{
 			name:               "DisabledSpec",
 			config:             disabledProvisioning().build(),
-			expectedContainers: 7,
+			expectedContainers: 9,
 		},
 		{
 			name:               "DisabledSpecWithoutProvisioningIP",
 			config:             disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
-			expectedContainers: 6,
+			expectedContainers: 8,
 		},
 	}
 	for _, tc := range tCases {


### PR DESCRIPTION
This adds the Ironic and Inspector log watching containers to the Metal3
deployment.  These are used to make the logs that baremetal hosts upload
to Ironic visible and collectable by OCP tools like `oc` and
`must-gather`.
