### PR TITLE
The bmh relatedobject name should be an empty string.

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -77,7 +77,7 @@ func relatedObjects() []osconfigv1.ObjectReference {
 		{
 			Group:     "metal3.io",
 			Resource:  "baremetalhosts",
-			Name:      "baremetalhosts.metal3.io",
+			Name:      "",
 			Namespace: ComponentNamespace,
 		},
 	}


### PR DESCRIPTION
The BMH relatedobject name should be an empty string. The relatedobject will be referenced like so:

Name.Resource.Group 

which can result in referencing an incorrect object.