### PR TITLE
Bug 1905307: cluster-baremetal-operator: add provisioning CR as related object

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -80,6 +80,11 @@ func relatedObjects() []osconfigv1.ObjectReference {
 			Name:      "",
 			Namespace: ComponentNamespace,
 		},
+		{
+			Group:    "metal3.io",
+			Resource: "provisioning",
+			Name:     "",
+		},
 	}
 }
 


### PR DESCRIPTION
Without having the provisioning CRD set as a related resource, we aren't
collecting it in a must-gather.

After applying this PR and running a must-gather, we get the
provisioning CR in the must-gather:

```
./cluster-scoped-resources/metal3.io/provisionings/provisioning-configuration.yaml
```