### PR TITLE
Bug 1866901: Don't do rolling updates of metal3 Deployment

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -601,6 +601,9 @@ func NewMetal3Deployment(targetNamespace string, images *Images, config *metal3i
 			Replicas: pointer.Int32Ptr(1),
 			Selector: selector,
 			Template: *template,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Up to now we have relied on the ironic-static-ip-manager containers
managing the Provisioning IP to ensure that only one metal3 Pod is
started at a time. However, now that we support configurations without
such an IP, we should take other measures to ensure that we don't create
multiple inconsistent copies of the state (e.g. ironic database).

Changing the Deployment Strategy from the default rolling update to
recreate means that upon any changes to the Pod template, the existing
ReplicaSet will be deleted before an updated one is created.