### PR TITLE
Bug 1913716: Use existing libraries instead of rolling our own

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -170,16 +170,6 @@ func (r *ProvisioningReconciler) ensureClusterOperator(baremetalConfig *metal3io
 	return err
 }
 
-func (r *ProvisioningReconciler) getClusterOperator() (*osconfigv1.ClusterOperator, error) {
-	existing, err := r.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to get clusterOperator %q: %v", clusterOperatorName, err)
-	}
-
-	return existing, nil
-}
-
 // setStatusCondition initalizes and returns a ClusterOperatorStatusCondition
 func setStatusCondition(conditionType osconfigv1.ClusterStatusConditionType,
 	conditionStatus osconfigv1.ConditionStatus, reason string,
@@ -209,11 +199,10 @@ func (r *ProvisioningReconciler) syncStatus(co *osconfigv1.ClusterOperator, cond
 }
 
 func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, progressMsg string) error {
-
-	co, err := r.getClusterOperator()
+	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
 	if err != nil {
 		r.Log.Error(err, "failed to get or create ClusterOperator")
-		return err
+		return fmt.Errorf("failed to get clusterOperator %q: %v", clusterOperatorName, err)
 	}
 	conds := defaultStatusConditions()
 	switch newReason {

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -150,21 +150,21 @@ func (r *ProvisioningReconciler) ensureClusterOperator(baremetalConfig *metal3io
 		}
 	}
 
-	needsUpadate := false
+	needsUpdate := false
 	if !equality.Semantic.DeepEqual(co.Status.RelatedObjects, relatedObjects()) {
-		needsUpadate = true
+		needsUpdate = true
 		co.Status.RelatedObjects = relatedObjects()
 	}
 	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
-		needsUpadate = true
+		needsUpdate = true
 		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 	if len(co.Status.Conditions) == 0 {
-		needsUpadate = true
+		needsUpdate = true
 		co.Status.Conditions = defaultStatusConditions()
 	}
 
-	if needsUpadate {
+	if needsUpdate {
 		_, err = r.OSClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})
 	}
 	return err

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -237,7 +237,7 @@ func TestEnsureClusterOperator(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			co, err := reconciler.getClusterOperator()
+			co, err := reconciler.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"github.com/stretchr/stew/slice"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -331,7 +332,7 @@ func (r *ProvisioningReconciler) checkForCRDeletion(info *provisioning.Provision
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
-		if !containsString(info.ProvConfig.ObjectMeta.Finalizers,
+		if !slice.Contains(info.ProvConfig.ObjectMeta.Finalizers,
 			metal3iov1alpha1.ProvisioningFinalizer) {
 			// Add finalizer becasue it doesn't already exist
 			controllerutil.AddFinalizer(info.ProvConfig, metal3iov1alpha1.ProvisioningFinalizer)
@@ -342,7 +343,7 @@ func (r *ProvisioningReconciler) checkForCRDeletion(info *provisioning.Provision
 		return false, nil
 	} else {
 		// The Provisioning object is being deleted
-		if containsString(info.ProvConfig.ObjectMeta.Finalizers, metal3iov1alpha1.ProvisioningFinalizer) {
+		if slice.Contains(info.ProvConfig.ObjectMeta.Finalizers, metal3iov1alpha1.ProvisioningFinalizer) {
 			err := r.deleteMetal3Resources(info)
 			if err != nil {
 				return false, errors.Wrap(err, "failed to delete metal3 resource")
@@ -416,14 +417,3 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&osconfigv1.ClusterOperator{}).
 		Complete(r)
 }
-
-// Helper function to check presence of string in a slice of strings
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/library-go v0.0.0-20200910214143-887092e305c1
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/stew v0.0.0-20130812190256-80ef0842b48b
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	k8s.io/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -787,6 +787,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/stew v0.0.0-20130812190256-80ef0842b48b h1:DmfFjW6pLdaJNVHfKgCxTdKFI6tM+0YbMd0kx7kE78s=
+github.com/stretchr/stew v0.0.0-20130812190256-80ef0842b48b/go.mod h1:yS/5aMz+lfJhykLjlAGbnhUhZIvVapOvtmk0MtzHktE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.3-0.20181224173747-660f15d67dbb/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -23,10 +23,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
@@ -676,10 +676,5 @@ func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace s
 }
 
 func DeleteMetal3Deployment(info *ProvisioningInfo) error {
-	err := info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		// metal3 deployment does not exist. Nothing to delete
-		return nil
-	}
-	return err
+	return client.IgnoreNotFound(info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{}))
 }

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
@@ -13,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -177,22 +177,18 @@ func CreateAllSecrets(client coreclientv1.SecretsGetter, targetNamespace string,
 }
 
 func DeleteAllSecrets(info *ProvisioningInfo) error {
-	var secretErrors []string
+	var secretErrors []error
 	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err.Error())
+		secretErrors = append(secretErrors, err)
 	}
 	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err.Error())
+		secretErrors = append(secretErrors, err)
 	}
 	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err.Error())
+		secretErrors = append(secretErrors, err)
 	}
 	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err.Error())
+		secretErrors = append(secretErrors, err)
 	}
-	if len(secretErrors) > 0 {
-		return fmt.Errorf(strings.Join(secretErrors, "\n"))
-	} else {
-		return nil
-	}
+	return utilerrors.NewAggregate(secretErrors)
 }

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -178,17 +178,12 @@ func CreateAllSecrets(client coreclientv1.SecretsGetter, targetNamespace string,
 
 func DeleteAllSecrets(info *ProvisioningInfo) error {
 	var secretErrors []error
-	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), baremetalSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err)
-	}
-	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err)
-	}
-	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err)
-	}
-	if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), ironicrpcSecretName, metav1.DeleteOptions{}); err != nil {
-		secretErrors = append(secretErrors, err)
+	for _, sn := range []string{baremetalSecretName, ironicSecretName, inspectorSecretName, ironicrpcSecretName} {
+		if err := info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), sn, metav1.DeleteOptions{}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				secretErrors = append(secretErrors, err)
+			}
+		}
 	}
 	return utilerrors.NewAggregate(secretErrors)
 }

--- a/provisioning/container_images.go
+++ b/provisioning/container_images.go
@@ -35,10 +35,10 @@ func GetContainerImages(containerImages *Images, imagesFilePath string) error {
 	//read images.json file
 	jsonData, err := ioutil.ReadFile(filepath.Clean(imagesFilePath))
 	if err != nil {
-		return fmt.Errorf("unable to read file %s", imagesFilePath)
+		return fmt.Errorf("unable to read file %s : %w", imagesFilePath, err)
 	}
 	if err := json.Unmarshal(jsonData, containerImages); err != nil {
-		return fmt.Errorf("unable to unmarshal image names from file %s ", imagesFilePath)
+		return fmt.Errorf("unable to unmarshal image names from file %s : %w", imagesFilePath, err)
 	}
 	return nil
 }

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -35,10 +35,15 @@ const (
 	DaemonSetAvailable      appsv1.DaemonSetConditionType = "Available"
 )
 
-var daemonSetRolloutStartTime = time.Now()
-var daemonSetRolloutTimeout = 5 * time.Minute
-
-var fileCompressionSuffix = regexp.MustCompile(`\.[gx]z$`)
+var (
+	daemonSetRolloutStartTime = time.Now()
+	daemonSetRolloutTimeout   = 5 * time.Minute
+	fileCompressionSuffix     = regexp.MustCompile(`\.[gx]z$`)
+	imageVolumeMount          = corev1.VolumeMount{
+		Name:      imageCacheSharedVolume,
+		MountPath: "/shared/html/images",
+	}
+)
 
 func imageVolume() corev1.Volume {
 	volType := corev1.HostPathDirectoryOrCreate
@@ -51,11 +56,6 @@ func imageVolume() corev1.Volume {
 			},
 		},
 	}
-}
-
-var imageVolumeMount = corev1.VolumeMount{
-	Name:      imageCacheSharedVolume,
-	MountPath: "/shared/html/images",
 }
 
 func imageCacheConfig(targetNamespace string, config metal3iov1alpha1.ProvisioningSpec) (*metal3iov1alpha1.ProvisioningSpec, error) {

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -12,11 +12,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -258,10 +258,5 @@ func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace str
 }
 
 func DeleteImageCache(info *ProvisioningInfo) error {
-	err := info.Client.AppsV1().DaemonSets(info.Namespace).Delete(context.Background(), imageCacheService, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		// metal3 image cache does not exist. Nothing to delete
-		return nil
-	}
-	return err
+	return client.IgnoreNotFound(info.Client.AppsV1().DaemonSets(info.Namespace).Delete(context.Background(), imageCacheService, metav1.DeleteOptions{}))
 }

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -58,10 +58,5 @@ func EnsureMetal3StateService(info *ProvisioningInfo) (updated bool, err error) 
 }
 
 func DeleteMetal3StateService(info *ProvisioningInfo) error {
-	err := info.Client.CoreV1().Services(info.Namespace).Delete(context.Background(), stateService, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		// metal3-state service does not exist. Nothing to delete
-		return nil
-	}
-	return err
+	return client.IgnoreNotFound(info.Client.CoreV1().Services(info.Namespace).Delete(context.Background(), stateService, metav1.DeleteOptions{}))
 }

--- a/vendor/github.com/stretchr/stew/slice/README.md
+++ b/vendor/github.com/stretchr/stew/slice/README.md
@@ -1,0 +1,6 @@
+slice
+=====
+
+Slice provides lovely helpful slice methods for Go
+
+  * This project is in its very early stages, and will be built out as needed.

--- a/vendor/github.com/stretchr/stew/slice/common.go
+++ b/vendor/github.com/stretchr/stew/slice/common.go
@@ -1,0 +1,16 @@
+package slice
+
+// CommonStrings gets a new []string that contains strings that are
+// present in both specified slices.
+func CommonStrings(s1, s2 []string) []string {
+
+	var common []string
+	for _, v := range s1 {
+		if ContainsString(s2, v) {
+			common = append(common, v)
+		}
+	}
+
+	return common
+
+}

--- a/vendor/github.com/stretchr/stew/slice/contains.go
+++ b/vendor/github.com/stretchr/stew/slice/contains.go
@@ -1,0 +1,329 @@
+package slice
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// objectsAreEqual uses multiple methods of testing equality between two
+// interface{} objects. So far, it always succeeds with no false positives.
+// This function is very quick if the first path is taken, otherwise it gets
+// extremely slow. Up to 200 to 300 times slower.
+func objectsAreEqual(left, right interface{}) bool {
+
+	// Test for simple equality. This will not succeed for all types
+	if left == right {
+		return true
+	}
+
+	// Deep equality check. This will almost always succeed.
+	if reflect.DeepEqual(left, right) {
+		return true
+	}
+
+	// Last ditch effort. This will always succeed where the others fail
+	// (at least so far)
+	return fmt.Sprintf("%#v", left) == fmt.Sprintf("%#v", right)
+
+}
+
+// Contains determines if the "contains" argument is contained within the
+// "slice" argument. The slice argument must be a slice or array.
+//
+// This function is performant for builtin types such as int, string, etc, though
+// it is not quite as fast as a direct comparison loop would be, due to some
+// type assertion necessary to make it generic.
+//
+// If the type passed is not a builtin type, it is significantly slower due to
+// deep equality checks.
+//
+// This function is practically equal in performance to a a direct comparison loop
+// for large arrays as the type assertion becomes a miniscule part of the overall
+// time spent. For small arrays, it is about 7 times slower than using the
+// equivalent direct call function.
+//
+// If you need bleeding edge performance, use one of the direct
+// functions provided.
+func Contains(slice, contains interface{}) bool {
+
+	// Determine what type the "contains" variable is, then act on it
+	switch slice.(type) {
+	case []bool:
+		return ContainsBool(slice.([]bool), contains.(bool))
+	case []int:
+		return ContainsInt(slice.([]int), contains.(int))
+	case []int8:
+		var typedContains int8
+		if _, ok := contains.(int); ok {
+			typedContains = int8(contains.(int))
+		} else {
+			typedContains = contains.(int8)
+		}
+		return ContainsInt8(slice.([]int8), typedContains)
+	case []int16:
+		var typedContains int16
+		if _, ok := contains.(int); ok {
+			typedContains = int16(contains.(int))
+		} else {
+			typedContains = contains.(int16)
+		}
+		return ContainsInt16(slice.([]int16), typedContains)
+	case []int32:
+		var typedContains int32
+		if _, ok := contains.(int); ok {
+			typedContains = int32(contains.(int))
+		} else {
+			typedContains = contains.(int32)
+		}
+		return ContainsInt32(slice.([]int32), typedContains)
+	case []int64:
+		var typedContains int64
+		if _, ok := contains.(int); ok {
+			typedContains = int64(contains.(int))
+		} else {
+			typedContains = contains.(int64)
+		}
+		return ContainsInt64(slice.([]int64), typedContains)
+	case []uint:
+		var typedContains uint
+		if _, ok := contains.(int); ok {
+			typedContains = uint(contains.(int))
+		} else {
+			typedContains = contains.(uint)
+		}
+		return ContainsUInt(slice.([]uint), typedContains)
+	case []uint8:
+		var typedContains uint8
+		if _, ok := contains.(int); ok {
+			typedContains = uint8(contains.(int))
+		} else {
+			typedContains = contains.(uint8)
+		}
+		return ContainsUInt8(slice.([]uint8), typedContains)
+	case []uint16:
+		var typedContains uint16
+		if _, ok := contains.(int); ok {
+			typedContains = uint16(contains.(int))
+		} else {
+			typedContains = contains.(uint16)
+		}
+		return ContainsUInt16(slice.([]uint16), typedContains)
+	case []uint32:
+		var typedContains uint32
+		if _, ok := contains.(int); ok {
+			typedContains = uint32(contains.(int))
+		} else {
+			typedContains = contains.(uint32)
+		}
+		return ContainsUInt32(slice.([]uint32), typedContains)
+	case []uint64:
+		var typedContains uint64
+		if _, ok := contains.(int); ok {
+			typedContains = uint64(contains.(int))
+		} else {
+			typedContains = contains.(uint64)
+		}
+		return ContainsUInt64(slice.([]uint64), typedContains)
+	case []float32:
+		var typedContains float32
+		if _, ok := contains.(float64); ok {
+			typedContains = float32(contains.(float64))
+		} else {
+			typedContains = contains.(float32)
+		}
+		return ContainsFloat32(slice.([]float32), typedContains)
+	case []float64:
+		if typedSlice, ok := slice.([]float64); ok {
+			return ContainsFloat64(typedSlice, contains.(float64))
+		}
+	case []complex64:
+		var typedContains complex64
+		if _, ok := contains.(complex128); ok {
+			typedContains = complex64(contains.(complex128))
+		} else {
+			typedContains = contains.(complex64)
+		}
+		return ContainsComplex64(slice.([]complex64), typedContains)
+	case []complex128:
+		return ContainsComplex128(slice.([]complex128), contains.(complex128))
+	case []string:
+		return ContainsString(slice.([]string), contains.(string))
+	default:
+		return ContainsObject(slice, contains)
+
+	}
+
+	return false
+
+}
+
+// ContainsBool checks if the slice has the contains value in it.
+func ContainsBool(slice []bool, contains bool) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt checks if the slice has the contains value in it.
+func ContainsInt(slice []int, contains int) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt8 checks if the slice has the contains value in it.
+func ContainsInt8(slice []int8, contains int8) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt16 checks if the slice has the contains value in it.
+func ContainsInt16(slice []int16, contains int16) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt32 checks if the slice has the contains value in it.
+func ContainsInt32(slice []int32, contains int32) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt64 checks if the slice has the contains value in it.
+func ContainsInt64(slice []int64, contains int64) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsUInt checks if the slice has the contains value in it.
+func ContainsUInt(slice []uint, contains uint) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsUInt8 checks if the slice has the contains value in it.
+func ContainsUInt8(slice []uint8, contains uint8) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsUInt16 checks if the slice has the contains value in it.
+func ContainsUInt16(slice []uint16, contains uint16) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsUInt32 checks if the slice has the contains value in it.
+func ContainsUInt32(slice []uint32, contains uint32) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsUInt64 checks if the slice has the contains value in it.
+func ContainsUInt64(slice []uint64, contains uint64) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsFloat32 checks if the slice has the contains value in it.
+func ContainsFloat32(slice []float32, contains float32) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsFloat64 checks if the slice has the contains value in it.
+func ContainsFloat64(slice []float64, contains float64) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsComplex64 checks if the slice has the contains value in it.
+func ContainsComplex64(slice []complex64, contains complex64) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsComplex128 checks if the slice has the contains value in it.
+func ContainsComplex128(slice []complex128, contains complex128) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsString checks if the slice has the contains value in it.
+func ContainsString(slice []string, contains string) bool {
+	for _, value := range slice {
+		if value == contains {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsObject checks if the slice has the contains value in it.
+func ContainsObject(slice interface{}, contains interface{}) bool {
+	reflectedSlice := reflect.ValueOf(slice)
+	for i := 0; i < reflectedSlice.Len(); i++ {
+		if objectsAreEqual(reflectedSlice.Index(i).Interface(), contains) {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/stretchr/stew/slice/doc.go
+++ b/vendor/github.com/stretchr/stew/slice/doc.go
@@ -1,0 +1,2 @@
+// Slice provides high-performance slice management utilities.
+package slice

--- a/vendor/github.com/stretchr/stew/slice/minus.go
+++ b/vendor/github.com/stretchr/stew/slice/minus.go
@@ -1,0 +1,17 @@
+package slice
+
+// MinusStrings gets a new []string containing all items in s, that
+// no not appear in minus.
+func MinusStrings(s, minus []string) []string {
+
+	a := []string{}
+
+	l := len(s)
+	for i := 0; i < l; i++ {
+		if !ContainsString(minus, s[i]) {
+			a = append(a, s[i])
+		}
+	}
+
+	return a
+}

--- a/vendor/github.com/stretchr/stew/slice/plus.go
+++ b/vendor/github.com/stretchr/stew/slice/plus.go
@@ -1,0 +1,22 @@
+package slice
+
+// PlusStrings adds two []string arrays together, returning a new []string.
+func PlusStrings(s, plus []string) []string {
+
+	var l int
+
+	a := []string{}
+
+	l = len(s)
+	for i := 0; i < l; i++ {
+		a = append(a, s[i])
+	}
+
+	l = len(plus)
+	for i := 0; i < l; i++ {
+		a = append(a, plus[i])
+	}
+
+	return a
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -458,6 +458,9 @@ github.com/spf13/viper
 github.com/ssgreg/nlreturn/v2/pkg/nlreturn
 # github.com/stretchr/objx v0.2.0
 github.com/stretchr/objx
+# github.com/stretchr/stew v0.0.0-20130812190256-80ef0842b48b
+## explicit
+github.com/stretchr/stew/slice
 # github.com/stretchr/testify v1.6.1
 ## explicit
 github.com/stretchr/testify/assert


### PR DESCRIPTION
@sadasu I hope you don't mind me tweaking code you have just written
- This only adds one dependency (stretchr/stew/slice - note we already use stretchr/testify)
- the other functions we already have vendored

/cc @sadasu 