### PR TITLE
Bug 1900322: Add Toleration OP Exists to metal3 pod

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -531,8 +531,9 @@ func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.Provision
 	containers := newMetal3Containers(images, config)
 	tolerations := []corev1.Toleration{
 		{
-			Key:    "node-role.kubernetes.io/master",
-			Effect: corev1.TaintEffectNoSchedule,
+			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
 		},
 		{
 			Key:      "CriticalAddonsOnly",


### PR DESCRIPTION
The metal3 pod's toleration currently matches on
exact value matches only.

This can be confusing for some people as the vast
majority of our pods we use operator Exists, mean
any value can be specified. This

  tolerations:
  - effect: NoSchedule
    key: node-role.kubernetes.io/master

This patch propose solution to add operator: Exists

  - effect: NoSchedule
    key: node-role.kubernetes.io/master
    operator: Exists

This will make it easier for everyone to use this operator.

Closes BZ: #1900322