### PR TITLE
Bug 1885349: Inject proxy environment variables everywhere

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,6 +92,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts

--- a/manifests/0000_31_cluster-baremetal-operator_01_trusted-ca-configmap.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_01_trusted-ca-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: cbo-trusted-ca
+  namespace: openshift-machine-api

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -180,6 +180,14 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -29,23 +29,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	configv1 "github.com/openshift/api/config/v1"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
 const (
-	metal3AppName              = "metal3"
-	baremetalDeploymentName    = "metal3"
-	baremetalSharedVolume      = "metal3-shared"
-	metal3AuthRootDir          = "/auth"
-	ironicCredentialsVolume    = "metal3-ironic-basic-auth"
-	ironicrpcCredentialsVolume = "metal3-ironic-rpc-basic-auth"
-	inspectorCredentialsVolume = "metal3-inspector-basic-auth"
-	htpasswdEnvVar             = "HTTP_BASIC_HTPASSWD" // #nosec
-	mariadbPwdEnvVar           = "MARIADB_PASSWORD"    // #nosec
-	cboOwnedAnnotation         = "baremetal.openshift.io/owned"
-	cboLabelName               = "baremetal.openshift.io/cluster-baremetal-operator"
+	metal3AppName                    = "metal3"
+	baremetalDeploymentName          = "metal3"
+	baremetalSharedVolume            = "metal3-shared"
+	metal3AuthRootDir                = "/auth"
+	ironicCredentialsVolume          = "metal3-ironic-basic-auth"
+	ironicrpcCredentialsVolume       = "metal3-ironic-rpc-basic-auth"
+	inspectorCredentialsVolume       = "metal3-inspector-basic-auth"
+	htpasswdEnvVar                   = "HTTP_BASIC_HTPASSWD" // #nosec
+	mariadbPwdEnvVar                 = "MARIADB_PASSWORD"    // #nosec
+	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
+	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
+	externalTrustBundleConfigMapName = "cbo-trusted-ca"
 )
 
 var deploymentRolloutStartTime = time.Now()
@@ -133,6 +135,18 @@ var metal3Volumes = []corev1.Volume{
 			},
 		},
 	},
+	{
+		Name: "trusted-ca",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				Items: []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: externalTrustBundleConfigMapName,
+				},
+				Optional: pointer.BoolPtr(true),
+			},
+		},
+	},
 }
 
 func buildEnvVar(name string, baremetalProvisioningConfig *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
@@ -172,7 +186,7 @@ func setIronicHtpasswdHash(name string, secretName string) corev1.EnvVar {
 	}
 }
 
-func newMetal3InitContainers(images *Images, config *metal3iov1alpha1.ProvisioningSpec) []corev1.Container {
+func newMetal3InitContainers(images *Images, config *metal3iov1alpha1.ProvisioningSpec, proxy *configv1.Proxy) []corev1.Container {
 	initContainers := []corev1.Container{
 		createInitContainerIpaDownloader(images),
 		createInitContainerMachineOsDownloader(images, config),
@@ -185,7 +199,7 @@ func newMetal3InitContainers(images *Images, config *metal3iov1alpha1.Provisioni
 		initContainers = append(initContainers, createInitContainerStaticIpSet(images, config))
 	}
 
-	return initContainers
+	return injectProxyAndCA(initContainers, proxy)
 }
 
 func createInitContainerIpaDownloader(images *Images) corev1.Container {
@@ -237,7 +251,7 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 	return initContainer
 }
 
-func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSpec) []corev1.Container {
+func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSpec, proxy *configv1.Proxy) []corev1.Container {
 	containers := []corev1.Container{
 		createContainerMetal3BaremetalOperator(images, config),
 		createContainerMetal3Mariadb(images),
@@ -259,7 +273,8 @@ func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSp
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
 		containers = append(containers, createContainerMetal3Dnsmasq(images, config))
 	}
-	return containers
+
+	return injectProxyAndCA(containers, proxy)
 }
 
 func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
@@ -541,9 +556,10 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 	return container
 }
 
-func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.ProvisioningSpec, labels *map[string]string) *corev1.PodTemplateSpec {
-	initContainers := newMetal3InitContainers(images, config)
-	containers := newMetal3Containers(images, config)
+func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.ProvisioningSpec, labels *map[string]string, proxy *configv1.Proxy) *corev1.PodTemplateSpec {
+	initContainers := newMetal3InitContainers(images, config, proxy)
+	containers := newMetal3Containers(images, config, proxy)
+
 	tolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
@@ -589,7 +605,56 @@ func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.Provision
 	}
 }
 
-func newMetal3Deployment(targetNamespace string, images *Images, config *metal3iov1alpha1.ProvisioningSpec, selector *metav1.LabelSelector) *appsv1.Deployment {
+func mountsWithTrustedCA(mounts []corev1.VolumeMount) []corev1.VolumeMount {
+	mounts = append(mounts, corev1.VolumeMount{
+		MountPath: "/etc/pki/ca-trust/extracted/pem",
+		Name:      "trusted-ca",
+		ReadOnly:  true,
+	})
+
+	return mounts
+}
+
+func injectProxyAndCA(containers []corev1.Container, proxy *configv1.Proxy) []corev1.Container {
+	var injectedContainers []corev1.Container
+
+	for _, container := range containers {
+		container.Env = envWithProxy(proxy, container.Env)
+		container.VolumeMounts = mountsWithTrustedCA(container.VolumeMounts)
+		injectedContainers = append(injectedContainers, container)
+	}
+
+	return injectedContainers
+}
+
+func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar) []corev1.EnvVar {
+	if proxy == nil {
+		return envVars
+	}
+
+	if proxy.Status.HTTPProxy != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "HTTP_PROXY",
+			Value: proxy.Status.HTTPProxy,
+		})
+	}
+	if proxy.Status.HTTPSProxy != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: proxy.Status.HTTPSProxy,
+		})
+	}
+	if proxy.Status.NoProxy != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: proxy.Status.NoProxy,
+		})
+	}
+
+	return envVars
+}
+
+func newMetal3Deployment(targetNamespace string, images *Images, config *metal3iov1alpha1.ProvisioningSpec, selector *metav1.LabelSelector, proxy *configv1.Proxy) *appsv1.Deployment {
 	if selector == nil {
 		selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -615,7 +680,7 @@ func newMetal3Deployment(targetNamespace string, images *Images, config *metal3i
 	if apiLabelValue != "" {
 		podSpecLabels["api"] = apiLabelValue
 	}
-	template := newMetal3PodTemplateSpec(images, config, &podSpecLabels)
+	template := newMetal3PodTemplateSpec(images, config, &podSpecLabels, proxy)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      baremetalDeploymentName,
@@ -651,7 +716,7 @@ func CheckExistingMetal3Deployment(client appsclientv1.DeploymentsGetter, target
 func EnsureMetal3Deployment(info *ProvisioningInfo) (updated bool, err error) {
 	// Create metal3 deployment object based on current baremetal configuration
 	// It will be created with the cboOwnedAnnotation
-	metal3Deployment := newMetal3Deployment(info.Namespace, info.Images, &info.ProvConfig.Spec, info.PodLabelSelector)
+	metal3Deployment := newMetal3Deployment(info.Namespace, info.Images, &info.ProvConfig.Spec, info.PodLabelSelector, info.Proxy)
 
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, info.ProvConfig.Status.Generations)
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "github.com/openshift/api/config/v1"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 )
 
@@ -129,7 +131,7 @@ func TestNewMetal3InitContainers(t *testing.T) {
 	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
-			actualContainers := newMetal3InitContainers(&images, tc.config)
+			actualContainers := newMetal3InitContainers(&images, tc.config, nil)
 			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Init Containers : %d Actual number of Init Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
 		})
 	}
@@ -173,8 +175,60 @@ func TestNewMetal3Containers(t *testing.T) {
 	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
-			actualContainers := newMetal3Containers(&images, tc.config)
+			actualContainers := newMetal3Containers(&images, tc.config, nil)
 			assert.Equal(t, tc.expectedContainers, len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, tc.expectedContainers, len(actualContainers)))
+		})
+	}
+}
+
+func TestProxyAndCAInjection(t *testing.T) {
+	images := Images{
+		BaremetalOperator:   expectedBaremetalOperator,
+		Ironic:              expectedIronic,
+		IronicInspector:     expectedIronicInspector,
+		IpaDownloader:       expectedIronicIpaDownloader,
+		MachineOsDownloader: expectedMachineOsDownloader,
+		StaticIpManager:     expectedIronicStaticIpManager,
+	}
+
+	proxy := v1.Proxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: v1.ProxyStatus{
+			HTTPProxy:  "https://172.2.0.1:3128",
+			HTTPSProxy: "https://172.2.0.1:3128",
+			NoProxy:    ".example.com",
+		},
+	}
+
+	tCases := []struct {
+		name       string
+		containers []corev1.Container
+	}{
+		{
+			name:       "init containers have proxy and CA information",
+			containers: newMetal3InitContainers(&images, managedProvisioning().build(), &proxy),
+		},
+		{
+			name:       "metal3 containers have proxy and CA information",
+			containers: newMetal3Containers(&images, managedProvisioning().build(), &proxy),
+		},
+	}
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing tc : %s", tc.name)
+			for _, container := range tc.containers {
+				assert.Contains(t, container.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "https://172.2.0.1:3128"})
+				assert.Contains(t, container.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "https://172.2.0.1:3128"})
+				assert.Contains(t, container.Env, corev1.EnvVar{Name: "NO_PROXY", Value: ".example.com"})
+
+				assert.Contains(t, container.VolumeMounts, corev1.VolumeMount{
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					Name:      "trusted-ca",
+					ReadOnly:  true},
+				)
+			}
 		})
 	}
 }

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
@@ -18,4 +19,5 @@ type ProvisioningInfo struct {
 	Namespace        string
 	Images           *Images
 	PodLabelSelector *metav1.LabelSelector
+	Proxy            *configv1.Proxy
 }


### PR DESCRIPTION
This mounts the trusted CA bundle, and reads and injects the proxy
configuration into all of our containers. This is somewhat based off
what machine-api-operator does. This is because the "cluster-wide" proxy
configuration is not truly clsuter-wide, and we have to inject this
variables ourselves. We also inject the trusted CA bundle, as it's likely
many users have custom CA's in use for their TLS certificates.