### PR TITLE
Bug 1940518: Set default resource requests for all containers

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/utils/pointer"
@@ -252,6 +253,12 @@ func createInitContainerIpaDownloader(images *Images) corev1.Container {
 		},
 		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
 		Env:          []corev1.EnvVar{},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
 	}
 	return initContainer
 }
@@ -269,6 +276,12 @@ func createInitContainerMachineOsDownloader(images *Images, config *metal3iov1al
 		Env: []corev1.EnvVar{
 			buildEnvVar(machineImageUrl, config),
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
 	}
 	return initContainer
 }
@@ -285,6 +298,12 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 		Env: []corev1.EnvVar{
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
 		},
 	}
 	return initContainer
@@ -391,6 +410,12 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 				Value: metal3AuthRootDir,
 			},
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -412,6 +437,12 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningInterface, config),
 			buildEnvVar(dhcpRange, config),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("5Mi"),
+			},
 		},
 	}
 	return container
@@ -435,6 +466,12 @@ func createContainerMetal3Mariadb(images *Images) corev1.Container {
 				Name:          "mysql",
 				ContainerPort: 3306,
 				HostPort:      3306,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("15m"),
+				corev1.ResourceMemory: resource.MustParse("80Mi"),
 			},
 		},
 	}
@@ -465,6 +502,12 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 				Name:          httpPortName,
 				ContainerPort: int32(port),
 				HostPort:      int32(port),
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
 	}
@@ -509,6 +552,12 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 				HostPort:      8089,
 			},
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -545,6 +594,12 @@ func createContainerMetal3IronicApi(images *Images, config *metal3iov1alpha1.Pro
 				HostPort:      6385,
 			},
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("150m"),
+				corev1.ResourceMemory: resource.MustParse("300Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -559,6 +614,12 @@ func createContainerIronicDeployRamdiskLogs(images *Images) corev1.Container {
 		},
 		Command:      []string{"/bin/runlogwatch.sh"},
 		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("5Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -593,6 +654,12 @@ func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alph
 				HostPort:      5050,
 			},
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("40m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -607,6 +674,12 @@ func createContainerIronicInspectorRamdiskLogs(images *Images) corev1.Container 
 		},
 		Command:      []string{"/bin/runlogwatch.sh"},
 		VolumeMounts: []corev1.VolumeMount{sharedVolumeMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("5Mi"),
+			},
+		},
 	}
 	return container
 }
@@ -623,6 +696,12 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 		Env: []corev1.EnvVar{
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
 		},
 	}
 	return container


### PR DESCRIPTION
According to the [openshift conventions document][0], all control plane
pods must set memory and cpu resource requests, and must not set limits.
The cluster baremetal operator currently doesn't set either.

The challenge lies less in setting those values but more in determining
suitable values.  The metal3 pod started by the CBO consists of the
following containers:

* metal3-baremetal-operator
* metal3-mariadb
* metal3-httpd
* metal3-ironic-conductor
* ironic-inspector-ramdisk-logs
* metal3-ironic-api
* ironic-deploy-ramdisk-logs
* metal3-ironic-inspector
* metal3-static-ip-manager
* metal3-dnsmasq

In order to determine suitable resource requests, we will query the
in-cluster instance of Prometheus.  The two queries are:

* `container_memory_working_set_bytes`
* `container_cpu_usage_seconds_total`

These queries are already used by the openshift console.

Immediately after deploying a cluster (via dev-scripts), the resource
usage is as follows per container.

Memory:

|           CONTAINER           |     VALUE     |   MB    |
|-------------------------------|---------------|---------|
| ironic-deploy-ramdisk-logs    |       4395008 |    4.19 |
| ironic-inspector-ramdisk-logs |       4546560 |    4.34 |
| metal3-baremetal-operator     |      38772736 |   36.98 |
| metal3-dnsmasq                |       4227072 |    4.03 |
| metal3-httpd                  |      40038400 |   38.18 |
| metal3-ironic-api             |     341344256 |  325.53 |
| metal3-ironic-conductor       |     531693568 |  507.06 |
| metal3-ironic-inspector       |      89608192 |   85.46 |
| metal3-mariadb                |      91709440 |   87.46 |
| metal3-static-ip-manager      |       5963776 |    5.69 |
| Total                         | 1152299008.00 | 1098.92 |

CPU:

|           CONTAINER           |     VALUE     |
|-------------------------------|---------------|
| ironic-deploy-ramdisk-logs    |   6.934046884 |
| ironic-inspector-ramdisk-logs |   6.848857016 |
| metal3-baremetal-operator     |   15.42667329 |
| metal3-dnsmasq                |   0.970485107 |
| metal3-httpd                  |   1.655474705 |
| metal3-ironic-api             | 184.681458455 |
| metal3-ironic-conductor       |   59.19483495 |
| metal3-ironic-inspector       |  40.280587341 |
| metal3-mariadb                |  16.859681564 |
| metal3-static-ip-manager      |  12.775865755 |
| Total                         |        345.63 |

After that, we shut down the existing CBO, and delete the metal3
deployment.  Then, we take another snapshot:

Memory:

|           CONTAINER           |    VALUE     |   MB   |
|-------------------------------|--------------|--------|
| ironic-deploy-ramdisk-logs    |      2768896 |   2.64 |
| ironic-inspector-ramdisk-logs |      3407872 |   3.25 |
| metal3-baremetal-operator     |     32145408 |  30.66 |
| metal3-dnsmasq                |      3801088 |   3.62 |
| metal3-httpd                  |     35876864 |  34.21 |
| metal3-ironic-api             |    255389696 | 243.56 |
| metal3-ironic-conductor       |    112857088 | 107.63 |
| metal3-ironic-inspector       |     85532672 |  81.57 |
| metal3-mariadb                |     83632128 |  79.76 |
| metal3-static-ip-manager      |      4239360 |   4.04 |
| Total                         | 619651072.00 | 590.95 |

CPU:

|           CONTAINER           |    VALUE    |
|-------------------------------|-------------|
| ironic-deploy-ramdisk-logs    | 0.213621969 |
| ironic-inspector-ramdisk-logs | 0.198890574 |
| metal3-baremetal-operator     | 0.566449491 |
| metal3-dnsmasq                | 0.210304509 |
| metal3-httpd                  | 0.244236922 |
| metal3-ironic-api             | 7.995711211 |
| metal3-ironic-conductor       | 5.867426197 |
| metal3-ironic-inspector       |  3.48515987 |
| metal3-mariadb                | 1.543873499 |
| metal3-static-ip-manager      | 0.354416131 |
| Total                         |       20.68 |

After that, we run the openshift parallel test suite as directed by the
conventions document.

Memory:

|           CONTAINER           |    VALUE     |   MB   |
|-------------------------------|--------------|--------|
| ironic-deploy-ramdisk-logs    |      3862528 |   3.68 |
| ironic-inspector-ramdisk-logs |      3842048 |   3.66 |
| metal3-baremetal-operator     |     34234368 |  32.65 |
| metal3-dnsmasq                |      4034560 |   3.85 |
| metal3-httpd                  |     35532800 |  33.89 |
| metal3-ironic-api             |    339558400 | 323.83 |
| metal3-ironic-conductor       |    115621888 | 110.27 |
| metal3-ironic-inspector       |     86831104 |  82.81 |
| metal3-mariadb                |     88510464 |  84.41 |
| metal3-static-ip-manager      |      6610944 |   6.30 |
| Total                         | 718639104.00 | 685.35 |

CPU:

|           CONTAINER           |     VALUE     |
|-------------------------------|---------------|
| ironic-deploy-ramdisk-logs    |    5.42803145 |
| ironic-inspector-ramdisk-logs |   5.356916845 |
| metal3-baremetal-operator     |  10.200364975 |
| metal3-dnsmasq                |   0.788118735 |
| metal3-httpd                  |   0.417568133 |
| metal3-ironic-api             | 129.832709833 |
| metal3-ironic-conductor       |  43.663922607 |
| metal3-ironic-inspector       |   32.66139269 |
| metal3-mariadb                |  12.353749316 |
| metal3-static-ip-manager      |   9.841018163 |
| Total                         |        250.54 |

Next, we inspect 8 hosts, and take a snapshot while that is in progress.

Memory:

|           CONTAINER           |    VALUE     |   MB   |
|-------------------------------|--------------|--------|
| ironic-deploy-ramdisk-logs    |      3862528 |   3.68 |
| ironic-inspector-ramdisk-logs |      3842048 |   3.66 |
| metal3-baremetal-operator     |     35024896 |  33.40 |
| metal3-dnsmasq                |      4067328 |   3.88 |
| metal3-httpd                  |     35532800 |  33.89 |
| metal3-ironic-api             |    342675456 | 326.80 |
| metal3-ironic-conductor       |    117248000 | 111.82 |
| metal3-ironic-inspector       |     88559616 |  84.46 |
| metal3-mariadb                |     91303936 |  87.07 |
| metal3-static-ip-manager      |      6643712 |   6.34 |
| Total                         | 728760320.00 | 695.00 |

CPU:

|           CONTAINER           |     VALUE     |
|-------------------------------|---------------|
| ironic-deploy-ramdisk-logs    |   5.742721272 |
| ironic-inspector-ramdisk-logs |   5.659118896 |
| metal3-baremetal-operator     |  11.124331005 |
| metal3-dnsmasq                |     0.8254892 |
| metal3-httpd                  |   0.429113402 |
| metal3-ironic-api             | 140.739296658 |
| metal3-ironic-conductor       |  49.918508012 |
| metal3-ironic-inspector       |  35.290283355 |
| metal3-mariadb                |  13.480281505 |
| metal3-static-ip-manager      |  10.433466513 |
| Total                         |        273.64 |

Once inspection is finished, and the pod starts to idle again, we take
another snapshot.

Memory:

|           CONTAINER           |     VALUE     |   MB    |
|-------------------------------|---------------|---------|
| ironic-deploy-ramdisk-logs    |       3854336 |    3.68 |
| ironic-inspector-ramdisk-logs |       4767744 |    4.55 |
| metal3-baremetal-operator     |      35389440 |   33.75 |
| metal3-dnsmasq                |       4407296 |    4.20 |
| metal3-httpd                  |      36077568 |   34.41 |
| metal3-ironic-api             |     354717696 |  338.29 |
| metal3-ironic-conductor       |     523468800 |  499.22 |
| metal3-ironic-inspector       |      89538560 |   85.39 |
| metal3-mariadb                |      95035392 |   90.63 |
| metal3-static-ip-manager      |       6549504 |    6.25 |
| Total                         | 1153806336.00 | 1100.36 |

CPU:

|           CONTAINER           |    VALUE     |
|-------------------------------|--------------|
| ironic-deploy-ramdisk-logs    |  6.461437573 |
| ironic-inspector-ramdisk-logs |  6.480350642 |
| metal3-baremetal-operator     | 13.705068458 |
| metal3-dnsmasq                |  1.024745616 |
| metal3-httpd                  |  1.151110614 |
| metal3-ironic-api             | 185.78144393 |
| metal3-ironic-conductor       | 61.869568145 |
| metal3-ironic-inspector       | 42.366485051 |
| metal3-mariadb                | 16.716823269 |
| metal3-static-ip-manager      | 11.793712488 |
| Total                         |       347.35 |

Now we collate our data, and round the numbers, we arrive at the
following values:

Memory:

|           CONTAINER           |   MB    |
|-------------------------------|---------|
| ironic-deploy-ramdisk-logs    |    5    |
| ironic-inspector-ramdisk-logs |    5    |
| metal3-baremetal-operator     |   50    |
| metal3-dnsmasq                |    5    |
| metal3-httpd                  |   50    |
| metal3-ironic-api             |  300    |
| metal3-ironic-conductor       |  500    |
| metal3-ironic-inspector       |  100    |
| metal3-mariadb                |   80    |
| metal3-static-ip-manager      |    5    |

CPU:

|           CONTAINER           |    VALUE     |
|-------------------------------|--------------|
| ironic-deploy-ramdisk-logs    |  10          |
| ironic-inspector-ramdisk-logs |  10          |
| metal3-baremetal-operator     |  20          |
| metal3-dnsmasq                |   5          |
| metal3-httpd                  |   5          |
| metal3-ironic-api             | 150          |
| metal3-ironic-conductor       |  50          |
| metal3-ironic-inspector       |  40          |
| metal3-mariadb                |  15          |
| metal3-static-ip-manager      |  10          |

[0]: https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#resources-and-limits