### PR TITLE
Add management workload annotations

### DIFF
--- a/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
+++ b/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
@@ -14,6 +14,8 @@ spec:
       k8s-app: cluster-baremetal-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -14,6 +14,8 @@ spec:
       k8s-app: cluster-baremetal-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/config/profiles/default/manager_webhook_patch.yaml
+++ b/config/profiles/default/manager_webhook_patch.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: openshift-machine-api
 spec:
   template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: cluster-baremetal-operator

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -56,6 +56,10 @@ const (
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
 )
 
+var podTemplateAnnotations = map[string]string{
+	"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+}
+
 var deploymentRolloutStartTime = time.Now()
 var deploymentRolloutTimeout = 5 * time.Minute
 
@@ -653,7 +657,8 @@ func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.Provision
 
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: *labels,
+			Annotations: podTemplateAnnotations,
+			Labels:      *labels,
 		},
 		Spec: corev1.PodSpec{
 			Volumes:           metal3Volumes,

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -153,6 +153,7 @@ func newImageCachePodTemplateSpec(targetNamespace string, images *Images, provis
 
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: podTemplateAnnotations,
 			Labels: map[string]string{
 				"k8s-app":    metal3AppName,
 				cboLabelName: imageCacheService,


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.