### PR TITLE
Bug 1948787: secret.StringData is a WriteOnly convience field, stop using it to read

### DIFF
--- a/provisioning/baremetal_crypto.go
+++ b/provisioning/baremetal_crypto.go
@@ -27,8 +27,8 @@ import (
 )
 
 type TlsCertificate struct {
-	privateKey  string
-	certificate string
+	privateKey  []byte
+	certificate []byte
 }
 
 const (
@@ -82,13 +82,13 @@ func generateTlsCertificate(provisioningIP string) (TlsCertificate, error) {
 	}
 
 	return TlsCertificate{
-		privateKey:  string(keyBytes),
-		certificate: string(certBytes),
+		privateKey:  keyBytes,
+		certificate: certBytes,
 	}, nil
 }
 
-func IsTlsCertificateExpired(certificate string) (bool, error) {
-	certs, err := cert.ParseCertsPEM([]byte(certificate))
+func IsTlsCertificateExpired(certificate []byte) (bool, error) {
+	certs, err := cert.ParseCertsPEM(certificate)
 	if err != nil {
 		return false, err
 	}

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -371,7 +371,7 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 			},
 			{
 				Name:  ironicCertEnvVar,
-				Value: metal3TlsRootDir + "/ironic/" + tlsCertificateKey,
+				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
 			},
 			{
 				Name:  ironicInsecureEnvVar,


### PR DESCRIPTION
In updateTlsSecret() we do the following check:
```
	existingCert := secret.StringData[corev1.TLSCertKey]
	if existingCert != "" {
```
This should always fail as StringData is WriteOnly. This will result in continuous writes to the secret (that we are watching).

Note: from the godoc
```
	// stringData allows specifying non-binary secret data in string form.
	// It is provided as a write-only convenience method.
	// All keys and values are merged into the data field on write, overwriting any existing values.
	// It is never output when reading from the API.
	// +k8s:conversion-gen=false
	// +optional
	StringData map[string]string `json:"stringData,omitempty" protobuf:"bytes,4,rep,name=stringData"`
```
/cc @stbenjam 
This maybe contributing to the secret watch issue.
