### PR TITLE
Rename workload annotations

### DIFF
--- a/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
+++ b/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/config/profiles/default/manager_webhook_patch.yaml
+++ b/config/profiles/default/manager_webhook_patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: cluster-baremetal-operator

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-baremetal-operator
     spec:

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -57,7 +57,7 @@ const (
 )
 
 var podTemplateAnnotations = map[string]string{
-	"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+	"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 }
 
 var deploymentRolloutStartTime = time.Now()


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please