### PR TITLE
Use ironic image for ironic-inspector

### DIFF
--- a/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
@@ -14,7 +14,6 @@ data:
       "kubeRBACProxy": "registry.ci.openshift.org/openshift:kube-rbac-proxy",
       "baremetalOperator": "registry.ci.openshift.org/openshift:baremetal-operator",
       "baremetalIronic": "registry.ci.openshift.org/openshift:ironic",
-      "baremetalIronicInspector": "registry.ci.openshift.org/openshift:ironic-inspector",
       "baremetalIpaDownloader": "registry.ci.openshift.org/openshift:ironic-ipa-downloader",
       "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
       "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager"

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -678,11 +678,12 @@ func createContainerIronicDeployRamdiskLogs(images *Images) corev1.Container {
 func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alpha1.ProvisioningSpec, macs []string) corev1.Container {
 	container := corev1.Container{
 		Name:            "metal3-ironic-inspector",
-		Image:           images.IronicInspector,
+		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
+		Command: []string{"/bin/runironic-inspector"},
 		VolumeMounts: []corev1.VolumeMount{
 			sharedVolumeMount,
 			ironicCredentialsMount,
@@ -721,7 +722,7 @@ func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alph
 func createContainerIronicInspectorRamdiskLogs(images *Images) corev1.Container {
 	container := corev1.Container{
 		Name:            "ironic-inspector-ramdisk-logs",
-		Image:           images.IronicInspector,
+		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -87,7 +87,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 	images := Images{
 		BaremetalOperator:   expectedBaremetalOperator,
 		Ironic:              expectedIronic,
-		IronicInspector:     expectedIronicInspector,
 		IpaDownloader:       expectedIronicIpaDownloader,
 		MachineOsDownloader: expectedMachineOsDownloader,
 		StaticIpManager:     expectedIronicStaticIpManager,
@@ -158,7 +157,6 @@ func TestNewMetal3Containers(t *testing.T) {
 	images := Images{
 		BaremetalOperator:   expectedBaremetalOperator,
 		Ironic:              expectedIronic,
-		IronicInspector:     expectedIronicInspector,
 		IpaDownloader:       expectedIronicIpaDownloader,
 		MachineOsDownloader: expectedMachineOsDownloader,
 		StaticIpManager:     expectedIronicStaticIpManager,
@@ -226,7 +224,6 @@ func TestProxyAndCAInjection(t *testing.T) {
 		Images: &Images{
 			BaremetalOperator:   expectedBaremetalOperator,
 			Ironic:              expectedIronic,
-			IronicInspector:     expectedIronicInspector,
 			IpaDownloader:       expectedIronicIpaDownloader,
 			MachineOsDownloader: expectedMachineOsDownloader,
 			StaticIpManager:     expectedIronicStaticIpManager,

--- a/provisioning/container_images.go
+++ b/provisioning/container_images.go
@@ -25,7 +25,6 @@ import (
 type Images struct {
 	BaremetalOperator   string `json:"baremetalOperator"`
 	Ironic              string `json:"baremetalIronic"`
-	IronicInspector     string `json:"baremetalIronicInspector"`
 	IpaDownloader       string `json:"baremetalIpaDownloader"`
 	MachineOsDownloader string `json:"baremetalMachineOsDownloader"`
 	StaticIpManager     string `json:"baremetalStaticIpManager"`

--- a/provisioning/container_images_test.go
+++ b/provisioning/container_images_test.go
@@ -8,7 +8,6 @@ var (
 	TestImagesFile                = "sample_images.json"
 	expectedBaremetalOperator     = "registry.ci.openshift.org/openshift:baremetal-operator"
 	expectedIronic                = "registry.ci.openshift.org/openshift:ironic"
-	expectedIronicInspector       = "registry.ci.openshift.org/openshift:ironic-inspector"
 	expectedIronicIpaDownloader   = "registry.ci.openshift.org/openshift:ironic-ipa-downloader"
 	expectedMachineOsDownloader   = "registry.ci.openshift.org/openshift:ironic-machine-os-downloader"
 	expectedIronicStaticIpManager = "registry.ci.openshift.org/openshift:ironic-static-ip-manager"
@@ -45,7 +44,6 @@ func TestGetContainerImages(t *testing.T) {
 			if tc.expectedImages {
 				if containerImages.BaremetalOperator != expectedBaremetalOperator ||
 					containerImages.Ironic != expectedIronic ||
-					containerImages.IronicInspector != expectedIronicInspector ||
 					containerImages.IpaDownloader != expectedIronicIpaDownloader ||
 					containerImages.MachineOsDownloader != expectedMachineOsDownloader ||
 					containerImages.StaticIpManager != expectedIronicStaticIpManager {


### PR DESCRIPTION
This PR prepares CBO to accomodate the migration of Ironic Inspector into the Ironic image. 

Requires https://github.com/metal3-io/ironic-image/pull/253, https://github.com/openshift/ironic-image/pull/179