### PR TITLE
Bug 1953736: Fix annotations for the ServiceMonitor

### DIFF
--- a/manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
   labels:
     k8s-app: cluster-baremetal-operator
   name: cluster-baremetal-operator-servicemonitor


### PR DESCRIPTION
Adding the include.release.openshift.io/self-managed-high-availability: "true" annotation to the ServiceMonitor manifest so that it is installed by CVO
