### PR TITLE
Bug 1953795: Set Ironic webserver_verify_ca

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -52,6 +52,7 @@ const (
 	ironicInsecureEnvVar             = "IRONIC_INSECURE"
 	inspectorInsecureEnvVar          = "IRONIC_INSPECTOR_INSECURE"
 	ironicCertEnvVar                 = "IRONIC_CACERT_FILE"
+	ironicWebserverCertVar           = "WEBSERVER_CACERT_FILE"
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
@@ -496,6 +497,10 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 			{
 				Name:  inspectorInsecureEnvVar,
 				Value: "true",
+			},
+			{
+				Name:  ironicWebserverCertVar,
+				Value: "/etc/pki/ca-trust/extracted/pem/trusted-ca",
 			},
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningIP, config),


### PR DESCRIPTION
Set the env variable WEBSERVER_CACERT_FILE which is used by Ironic
for the ironic.conf setting ``webserver_verify_ca``.