### PR TITLE
Revert "Bug 1953795: Set Ironic webserver_verify_ca"

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -52,7 +52,6 @@ const (
 	ironicInsecureEnvVar             = "IRONIC_INSECURE"
 	inspectorInsecureEnvVar          = "IRONIC_INSPECTOR_INSECURE"
 	ironicCertEnvVar                 = "IRONIC_CACERT_FILE"
-	ironicWebserverCertVar           = "WEBSERVER_CACERT_FILE"
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
@@ -497,10 +496,6 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 			{
 				Name:  inspectorInsecureEnvVar,
 				Value: "true",
-			},
-			{
-				Name:  ironicWebserverCertVar,
-				Value: "/etc/pki/ca-trust/extracted/pem/trusted-ca",
 			},
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningIP, config),


### PR DESCRIPTION
Reverts openshift/cluster-baremetal-operator#139

This is the wrong cert to use for the assisted images, it uses the service ca, this needs more investigation in another release to make the service, ingress, and trusted CA bundles available to our containers, as well as investigating using TLS for the httpd hosted by Ironic.