### PR TITLE
Allow boot iso source configuration

### DIFF
--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -38,6 +38,16 @@ const (
 	ProvisioningSingletonName = "provisioning-configuration"
 )
 
+// BootIsoSource is the origin of the boot iso image
+// +kubebuilder:validation:Enum=local;http
+type BootIsoSource string
+
+// BootIsoSource values
+const (
+	BootIsoSourceLocal BootIsoSource = "local"
+	BootIsoSourceHttp  BootIsoSource = "http"
+)
+
 // ProvisioningSpec defines the desired state of Provisioning
 type ProvisioningSpec struct {
 	// ProvisioningInterface is the name of the network interface
@@ -110,6 +120,14 @@ type ProvisioningSpec struct {
 	// openshift-machine-api namespace. When set to true, this provisioning
 	// configuration would be used for baremetal hosts across all namespaces.
 	WatchAllNamespaces bool `json:"watchAllNamespaces,omitempty"`
+
+	// BootIsoSource provides a way to set the location where the iso image
+	// to boot the nodes will be served from.
+	// By default the boot iso image is cached locally and served from
+	// the Provisioning service (Ironic) nodes using an auxiliary httpd server.
+	// If the boot iso image is already served by an httpd server, setting
+	// this option to http allows to directly provide the image from there.
+	BootIsoSource BootIsoSource `json:"bootIsoSource,omitempty"`
 }
 
 // ProvisioningStatus defines the observed state of Provisioning

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -31,6 +31,12 @@ spec:
           spec:
             description: ProvisioningSpec defines the desired state of Provisioning
             properties:
+              bootIsoSource:
+                description: BootIsoSource provides a way to set the location where the iso image to boot the nodes will be served from. By default the boot iso image is cached locally and served from the Provisioning service (Ironic) nodes using an auxiliary httpd server. If the boot iso image is already served by an httpd server, setting this option to http allows to directly provide the image from there.
+                enum:
+                - local
+                - http
+                type: string
               provisioningDHCPExternal:
                 description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
                 type: boolean
@@ -51,7 +57,7 @@ spec:
                 - Disabled
                 type: string
               provisioningNetworkCIDR:
-                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. IPv6 networks cannot be larger than a /64.
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network.
                 type: string
               provisioningOSDownloadURL:
                 description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -31,6 +31,12 @@ spec:
           spec:
             description: ProvisioningSpec defines the desired state of Provisioning
             properties:
+              bootIsoSource:
+                description: BootIsoSource provides a way to set the location where the iso image to boot the nodes will be served from. By default the boot iso image is cached locally and served from the Provisioning service (Ironic) nodes using an auxiliary httpd server. If the boot iso image is already served by an httpd server, setting this option to http allows to directly provide the image from there.
+                enum:
+                - local
+                - http
+                type: string
               provisioningDHCPExternal:
                 description: ProvisioningDHCPExternal indicates whether the DHCP server for IP addresses in the provisioning DHCP range is present within the metal3 cluster or external to it. This field is being deprecated in favor of provisioningNetwork.
                 type: boolean

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -41,6 +41,7 @@ var (
 	dhcpRange                      = "DHCP_RANGE"
 	machineImageUrl                = "RHCOS_IMAGE_URL"
 	ipOptions                      = "IP_OPTIONS"
+	bootIsoSource                  = "IRONIC_BOOT_ISO_SOURCE"
 )
 
 func getDHCPRange(config *metal3iov1alpha1.ProvisioningSpec) *string {
@@ -94,6 +95,13 @@ func getProvisioningOSDownloadURL(config *metal3iov1alpha1.ProvisioningSpec) *st
 	return nil
 }
 
+func getBootIsoSource(config *metal3iov1alpha1.ProvisioningSpec) *string {
+	if config.BootIsoSource != "" {
+		return (*string)(&config.BootIsoSource)
+	}
+	return nil
+}
+
 func getMetal3DeploymentConfig(name string, baremetalConfig *metal3iov1alpha1.ProvisioningSpec) *string {
 	switch name {
 	case provisioningIP:
@@ -114,6 +122,8 @@ func getMetal3DeploymentConfig(name string, baremetalConfig *metal3iov1alpha1.Pr
 		return getDHCPRange(baremetalConfig)
 	case machineImageUrl:
 		return getProvisioningOSDownloadURL(baremetalConfig)
+	case bootIsoSource:
+		return getBootIsoSource(baremetalConfig)
 	}
 	return nil
 }


### PR DESCRIPTION
Allow setting the source boot iso parameter to enable or disable local
caching of the boot iso image.