### PR TITLE
Bug 1952448: Fix condition for starting the metal3StaticIpManager container

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -305,7 +305,7 @@ func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSp
 	// If the provisioning network is disabled, and the user hasn't requested a
 	// particular provisioning IP on the machine CIDR, we have nothing for this container
 	// to manage.
-	if config.ProvisioningIP != "" || config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
+	if config.ProvisioningIP != "" && config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
 		containers = append(containers, createContainerMetal3StaticIpManager(images, config))
 	}
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -164,7 +164,7 @@ func TestNewMetal3Containers(t *testing.T) {
 		{
 			name:               "DisabledSpec",
 			config:             disabledProvisioning().build(),
-			expectedContainers: 9,
+			expectedContainers: 8,
 		},
 		{
 			name:               "DisabledSpecWithoutProvisioningIP",


### PR DESCRIPTION
The staticIPManager container should be run when the Provisioning
Network is not Disabled and the ProvisioningIP is provided.