### PR TITLE
Bug 1968615: Restrict watches to openshift-machine-api

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
+		Namespace:          controllers.ComponentNamespace,
 		LeaderElection:     enableLeaderElection,
 		Port:               9443,
 		CertDir:            "/etc/cluster-baremetal-operator/tls",


### PR DESCRIPTION
Previously CBO was watching over all the namespaces, thus caching all the resources with an high memory consumption (even those ones that didn't really belong to the component)

This PR fixes the issue by limiting the cache just to the component namespace `openshift-machine-api` (updates on cluster scoped resources as `Provisioning` will be received as usual)

Fixes #1968615