### PR TITLE
Bug 1946079: Fix network stack calculation

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -62,7 +62,7 @@ type ProvisioningReconciler struct {
 	ReleaseVersion string
 	ImagesFilename string
 	WebHookEnabled bool
-	APIServerHost  string
+	NetworkStack   provisioning.NetworkStackType
 }
 
 type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
@@ -305,20 +305,6 @@ func (r *ProvisioningReconciler) provisioningInfo(provConfig *metal3iov1alpha1.P
 		return nil, err
 	}
 
-	ips, err := net.LookupIP(r.APIServerHost)
-	if err != nil {
-		return nil, err
-	}
-
-	ns := provisioning.NetworkStackType(0)
-	for _, ip := range ips {
-		if len(ip) == net.IPv4len {
-			ns |= provisioning.NetworkStackV4
-		} else if len(ip) == net.IPv6len {
-			ns |= provisioning.NetworkStackV6
-		}
-	}
-
 	return &provisioning.ProvisioningInfo{
 		Client:        r.KubeClient,
 		EventRecorder: events.NewLoggingEventRecorder(ComponentName),
@@ -327,7 +313,7 @@ func (r *ProvisioningReconciler) provisioningInfo(provConfig *metal3iov1alpha1.P
 		Namespace:     ComponentNamespace,
 		Images:        images,
 		Proxy:         clusterWideProxy,
-		NetworkStack:  ns,
+		NetworkStack:  r.NetworkStack,
 	}, nil
 }
 
@@ -385,33 +371,39 @@ func (r *ProvisioningReconciler) deleteMetal3Resources(info *provisioning.Provis
 	return nil
 }
 
-func (r *ProvisioningReconciler) apiServerHost() (string, error) {
-	ctx := context.Background()
+func networkStack(ips []net.IP) provisioning.NetworkStackType {
+	ns := provisioning.NetworkStackType(0)
+	for _, ip := range ips {
+		if ip.IsLoopback() {
+			continue
+		}
+		if ip.To4() != nil {
+			ns |= provisioning.NetworkStackV4
+		} else {
+			ns |= provisioning.NetworkStackV6
+		}
+	}
+	return ns
+}
 
+func (r *ProvisioningReconciler) apiServerInternalHost(ctx context.Context) (string, error) {
 	infra, err := r.OSClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read Infrastructure CR")
 	}
 
-	if infra.Status.APIServerInternalURL != "" {
-		//TODO: Present only for debugging purposes. Remove before merge
-		klog.Info("Infrastructure API Server ", "Internal URL ", infra.Status.APIServerInternalURL)
-	} else {
+	if infra.Status.APIServerInternalURL == "" {
 		return "", errors.Wrap(err, "invalid APIServerInternalURL in Infrastructure CR")
 	}
+
 	apiServerInternalURL, err := url.Parse(infra.Status.APIServerInternalURL)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to parse API Server Internal URL")
-	} else {
-		//TODO: Present only for debugging purposes. Remove before merge
-		klog.Info("API Server Internal URL : ", apiServerInternalURL)
 	}
+
 	host, _, err := net.SplitHostPort(apiServerInternalURL.Host)
 	if err != nil {
 		return "", err
-	} else {
-		//TODO: Present only for debugging purposes. Remove before merge
-		klog.Info("API Server Host : ", host)
 	}
 
 	return host, nil
@@ -419,15 +411,24 @@ func (r *ProvisioningReconciler) apiServerHost() (string, error) {
 
 // SetupWithManager configures the manager to run the controller
 func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	ctx := context.Background()
 	err := r.ensureClusterOperator(nil)
 	if err != nil {
 		return errors.Wrap(err, "unable to set get baremetal ClusterOperator")
 	}
 
-	r.APIServerHost, err = r.apiServerHost()
+	apiInt, err := r.apiServerInternalHost(ctx)
 	if err != nil {
-		return errors.Wrap(err, "could not get APIServer")
+		return errors.Wrap(err, "could not get internal APIServer")
 	}
+
+	ips, err := net.LookupIP(apiInt)
+	if err != nil {
+		return errors.Wrap(err, "could not lookupIP for internal APIServer: "+apiInt)
+	}
+
+	r.NetworkStack = networkStack(ips)
+	klog.InfoS("Network stack calculation", "APIServerInternalHost", apiInt, "NetworkStack", r.NetworkStack)
 
 	// Check the Platform Type to determine the state of the CO
 	enabled, err := r.isEnabled()

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"net"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +15,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	"github.com/openshift/cluster-baremetal-operator/provisioning"
 )
 
 func setUpSchemeForReconciler() *runtime.Scheme {
@@ -142,5 +145,77 @@ func TestProvisioning(t *testing.T) {
 			assert.Equal(t, tc.expectedConfig, baremetalconfig != nil, "baremetal config results did not match")
 			return
 		})
+	}
+}
+
+func TestNetworkStack(t *testing.T) {
+	tests := []struct {
+		name    string
+		ips     []net.IP
+		want    provisioning.NetworkStackType
+		wantErr bool
+	}{
+		{
+			name: "v4 basic",
+			ips:  []net.IP{net.ParseIP("192.168.0.1")},
+			want: provisioning.NetworkStackV4,
+		},
+		{
+			name: "v4 in v6 format: basic",
+			ips:  []net.IP{net.ParseIP("::FFFF:192.168.0.1")},
+			want: provisioning.NetworkStackV4,
+		},
+		{
+			name: "v6: basic",
+			ips:  []net.IP{net.ParseIP("2001:db8::68")},
+			want: provisioning.NetworkStackV6,
+		},
+		{
+			name: "dual: basic",
+			ips:  []net.IP{net.ParseIP("2001:db8::68"), net.ParseIP("192.168.0.1")},
+			want: provisioning.NetworkStackDual,
+		},
+		{
+			name: "v6: with v4 local",
+			ips:  []net.IP{net.ParseIP("2001:db8::68"), net.ParseIP("127.0.0.1")},
+			want: provisioning.NetworkStackV6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := networkStack(tt.ips)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("networkStack() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIServerInternalHost(t *testing.T) {
+	infra := &configv1.Infrastructure{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Infrastructure",
+			APIVersion: "config.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			APIServerInternalURL: "https://api-int.ostest.test.metalkube.org:6443",
+		},
+	}
+	want := "api-int.ostest.test.metalkube.org"
+
+	r := &ProvisioningReconciler{
+		Scheme:   setUpSchemeForReconciler(),
+		OSClient: fakeconfigclientset.NewSimpleClientset(infra),
+	}
+	got, err := r.apiServerInternalHost(context.TODO())
+	if err != nil {
+		t.Errorf("ProvisioningReconciler.apiServerInternalHost() error = %v", err)
+		return
+	}
+	if got != want {
+		t.Errorf("ProvisioningReconciler.apiServerInternalHost() = %v, want %v", got, want)
 	}
 }

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -263,15 +263,20 @@ func createInitContainerIpaDownloader(images *Images) corev1.Container {
 	return initContainer
 }
 
-func createInitContainerMachineOsDownloader(info *ProvisioningInfo) corev1.Container {
-	optionValue := ""
+func ipOptionForMachineOsDownloader(info *ProvisioningInfo) string {
+	var optionValue string
 	switch info.NetworkStack {
 	case NetworkStackV4:
 		optionValue = "ip=dhcp"
 	case NetworkStackV6:
 		optionValue = "ip=dhcp6"
+	case NetworkStackDual:
+		optionValue = ""
 	}
+	return optionValue
+}
 
+func createInitContainerMachineOsDownloader(info *ProvisioningInfo) corev1.Container {
 	initContainer := corev1.Container{
 		Name:            "metal3-machine-os-downloader",
 		Image:           info.Images.MachineOsDownloader,
@@ -285,7 +290,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo) corev1.Conta
 			buildEnvVar(machineImageUrl, &info.ProvConfig.Spec),
 			{
 				Name:  ipOptions,
-				Value: optionValue,
+				Value: ipOptionForMachineOsDownloader(info),
 			},
 		},
 		Resources: corev1.ResourceRequirements{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -236,3 +236,30 @@ func TestProxyAndCAInjection(t *testing.T) {
 		})
 	}
 }
+
+func TestIPOptionForMachineOsDownloader(t *testing.T) {
+	tests := []struct {
+		ns   NetworkStackType
+		want string
+	}{
+		{
+			ns:   NetworkStackV4,
+			want: "ip=dhcp",
+		},
+		{
+			ns:   NetworkStackV6,
+			want: "ip=dhcp6",
+		},
+		{
+			ns:   NetworkStackDual,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := ipOptionForMachineOsDownloader(&ProvisioningInfo{NetworkStack: tt.ns}); got != tt.want {
+				t.Errorf("ipOptionForMachineOsDownloader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -14,7 +14,7 @@ type NetworkStackType int
 const (
 	NetworkStackV4   NetworkStackType = 1 << iota
 	NetworkStackV6   NetworkStackType = 1 << iota
-	NetworkStackDual NetworkStackType = (NetworkStackV4 & NetworkStackV6)
+	NetworkStackDual NetworkStackType = (NetworkStackV4 | NetworkStackV6)
 )
 
 type ProvisioningInfo struct {


### PR DESCRIPTION
There was at least 3 things wrong with how we figure out the NetworkStack

1. the NetworkStack enum was broken - blush
2. we were assuming that when len(ip) == IPv6Len it was an actual ipv6 address (you can have an embedded ipv4 address in a v6 one - news to me)
3. this is now using the internal apiserver url not, the public one

See https://github.com/openshift/ironic-rhcos-downloader/pull/40#issuecomment-858206600
This PR supersedes https://github.com/openshift/cluster-baremetal-operator/pull/154
and includes @sadasu commit in her PR https://github.com/openshift/cluster-baremetal-operator/pull/157
/cc @sadasu @honza @andfasano 
