### PR TITLE
[release-4.7] Bug 1972291: Use a cache URL with the .svc.cluster.local suffix

### DIFF
--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -74,7 +74,7 @@ func imageCacheConfig(targetNamespace string, config metal3iov1alpha1.Provisioni
 	// See https://github.com/openshift/ironic-rhcos-downloader for more details
 	cacheURL := url.URL{
 		Scheme: "http",
-		Host: net.JoinHostPort(fmt.Sprintf("%s.%s", stateService, targetNamespace),
+		Host: net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", stateService, targetNamespace),
 			baremetalHttpPort),
 		Path: fmt.Sprintf("/images/%s/%s", imageName, imageName),
 	}


### PR DESCRIPTION
By default cluster.local is part of NoProxy, using the longer
version ensure we match the NoProxy variable and keep the traffic
internal.


Backports:https://github.com/openshift/cluster-baremetal-operator/pull/147
