### PR TITLE
Don't set IP options on kernel command line twice

### DIFF
--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -197,7 +197,7 @@ func newImageCachePodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSp
 				},
 			},
 			InitContainers: injectProxyAndCA([]corev1.Container{
-				createInitContainerMachineOsDownloader(info),
+				createInitContainerMachineOsDownloader(info, false),
 				createInitContainerIpaDownloader(info.Images),
 			}, info.Proxy),
 			Containers:        containers,


### PR DESCRIPTION
We only want to pass the IP_OPTIONS environment variable to the
machine-os-downloader container in the metal3 Deployment, not the ones
in the metal3-image-cache DaemonSet.

If we pass it to both then the options get added twice on some cache
Pods (the ones not running on the Node that has the API VIP), with the
result that the checksum will be different depending where the API VIP
is pointing.