### PR TITLE
Bug: 1947293 Add managed provisioning network size validation

### DIFF
--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -63,8 +63,9 @@ type ProvisioningSpec struct {
 
 	// ProvisioningNetworkCIDR is the network on which the
 	// baremetal nodes are provisioned. The provisioningIP and the
-	// IPs in the dhcpRange all come from within this network.
-	// IPv6 networks cannot be larger than a /64.
+	// IPs in the dhcpRange all come from within this network. When using IPv6
+	// and in a network managed by the Baremetal IPI solution this cannot be a
+	// network larger than a /64.
 	ProvisioningNetworkCIDR string `json:"provisioningNetworkCIDR,omitempty"`
 
 	// ProvisioningDHCPExternal indicates whether the DHCP server

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -57,7 +57,7 @@ spec:
                 - Disabled
                 type: string
               provisioningNetworkCIDR:
-                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. Managed IPv6 networks cannot be larger than a /64.
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. When using IPv6 and in a network managed by the Baremetal IPI solution this cannot be a network larger than a /64.
                 type: string
               provisioningOSDownloadURL:
                 description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -57,7 +57,7 @@ spec:
                 - Disabled
                 type: string
               provisioningNetworkCIDR:
-                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. IPv6 networks cannot be larger than a /64.
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. Managed IPv6 networks cannot be larger than a /64.
                 type: string
               provisioningOSDownloadURL:
                 description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -57,7 +57,7 @@ spec:
                 - Disabled
                 type: string
               provisioningNetworkCIDR:
-                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. Managed IPv6 networks cannot be larger than a /64.
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. When using IPv6 and in a network managed by the Baremetal IPI solution this cannot be a network larger than a /64.
                 type: string
               provisioningOSDownloadURL:
                 description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -57,7 +57,7 @@ spec:
                 - Disabled
                 type: string
               provisioningNetworkCIDR:
-                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. IPv6 networks cannot be larger than a /64.
+                description: ProvisioningNetworkCIDR is the network on which the baremetal nodes are provisioned. The provisioningIP and the IPs in the dhcpRange all come from within this network. Managed IPv6 networks cannot be larger than a /64.
                 type: string
               provisioningOSDownloadURL:
                 description: ProvisioningOSDownloadURL is the location from which the OS Image used to boot baremetal host machines can be downloaded by the metal3 cluster.


### PR DESCRIPTION
Validate that managed ipv6 provisioning networks are no larger than a
/64 due to a dnsmasq limitation, also add some relevant documentation.