### PR TITLE
Bug 1975711: Only start static ip set if provisioning net not disabled

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -235,7 +235,7 @@ func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 	// If the provisioning network is disabled, and the user hasn't requested a
 	// particular provisioning IP on the machine CIDR, we have nothing for this container
 	// to manage.
-	if info.ProvConfig.Spec.ProvisioningIP != "" {
+	if info.ProvConfig.Spec.ProvisioningIP != "" && info.ProvConfig.Spec.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
 		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec))
 	}
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -127,6 +127,20 @@ func TestNewMetal3InitContainers(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "disabled with provisioning ip",
+			config: disabledProvisioning().ProvisioningIP("1.2.3.4").ProvisioningNetworkCIDR("").build(),
+			expectedContainers: []corev1.Container{
+				{
+					Name:  "metal3-ipa-downloader",
+					Image: images.IpaDownloader,
+				},
+				{
+					Name:  "metal3-machine-os-downloader",
+					Image: images.MachineOsDownloader,
+				},
+			},
+		},
 	}
 	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Only add metal3-static-ip-set if we have a provisioning ip and
and provisioning network is enabled. This brings the check for
both metal3-static-ip-set and metal3-static-ip-manager inline
with each other. It doesn't make sense to have one without the
other.