### PR TITLE
[release-4.7] Bug 1973367: Pass IP_OPTIONS=dhcp|dhcp6 down to OS Downloader container

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -18,6 +18,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/stew/slice"
@@ -61,6 +63,7 @@ type ProvisioningReconciler struct {
 	KubeClient     kubernetes.Interface
 	ReleaseVersion string
 	ImagesFilename string
+	NetworkStack   provisioning.NetworkStackType
 }
 
 type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
@@ -371,12 +374,64 @@ func (r *ProvisioningReconciler) deleteMetal3Resources(info *provisioning.Provis
 	return nil
 }
 
+func networkStack(ips []net.IP) provisioning.NetworkStackType {
+	ns := provisioning.NetworkStackType(0)
+	for _, ip := range ips {
+		if ip.IsLoopback() {
+			continue
+		}
+		if ip.To4() != nil {
+			ns |= provisioning.NetworkStackV4
+		} else {
+			ns |= provisioning.NetworkStackV6
+		}
+	}
+	return ns
+}
+
+func (r *ProvisioningReconciler) apiServerInternalHost(ctx context.Context) (string, error) {
+	infra, err := r.OSClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "unable to read Infrastructure CR")
+	}
+
+	if infra.Status.APIServerInternalURL == "" {
+		return "", errors.Wrap(err, "invalid APIServerInternalURL in Infrastructure CR")
+	}
+
+	apiServerInternalURL, err := url.Parse(infra.Status.APIServerInternalURL)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse API Server Internal URL")
+	}
+
+	host, _, err := net.SplitHostPort(apiServerInternalURL.Host)
+	if err != nil {
+		return "", err
+	}
+
+	return host, nil
+}
+
 // SetupWithManager configures the manager to run the controller
 func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	ctx := context.Background()
 	err := r.ensureClusterOperator(nil)
 	if err != nil {
 		return errors.Wrap(err, "unable to set get baremetal ClusterOperator")
 	}
+
+	apiInt, err := r.apiServerInternalHost(ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not get internal APIServer")
+	}
+
+	ips, err := net.LookupIP(apiInt)
+	if err != nil {
+		return errors.Wrap(err, "could not lookupIP for internal APIServer: "+apiInt)
+	}
+
+	r.NetworkStack = networkStack(ips)
+	klog.InfoS("Network stack calculation", "APIServerInternalHost", apiInt, "NetworkStack", r.NetworkStack)
 
 	// Check the Platform Type to determine the state of the CO
 	enabled, err := r.isEnabled()

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -42,6 +42,7 @@ var (
 	httpPort                       = "HTTP_PORT"
 	dhcpRange                      = "DHCP_RANGE"
 	machineImageUrl                = "RHCOS_IMAGE_URL"
+	ipOptions                      = "IP_OPTIONS"
 )
 
 // ValidateBaremetalProvisioningConfig validates the contents of the provisioning resource

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -186,20 +186,20 @@ func setIronicHtpasswdHash(name string, secretName string) corev1.EnvVar {
 	}
 }
 
-func newMetal3InitContainers(images *Images, config *metal3iov1alpha1.ProvisioningSpec, proxy *configv1.Proxy) []corev1.Container {
+func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 	initContainers := []corev1.Container{
-		createInitContainerIpaDownloader(images),
-		createInitContainerMachineOsDownloader(images, config),
+		createInitContainerIpaDownloader(info.Images),
+		createInitContainerMachineOsDownloader(info, true),
 	}
 
 	// If the provisioning network is disabled, and the user hasn't requested a
 	// particular provisioning IP on the machine CIDR, we have nothing for this container
 	// to manage.
-	if config.ProvisioningIP != "" {
-		initContainers = append(initContainers, createInitContainerStaticIpSet(images, config))
+	if info.ProvConfig.Spec.ProvisioningIP != "" {
+		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec))
 	}
 
-	return injectProxyAndCA(initContainers, proxy)
+	return injectProxyAndCA(initContainers, info.Proxy)
 }
 
 func createInitContainerIpaDownloader(images *Images) corev1.Container {
@@ -217,19 +217,40 @@ func createInitContainerIpaDownloader(images *Images) corev1.Container {
 	return initContainer
 }
 
-func createInitContainerMachineOsDownloader(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+func ipOptionForMachineOsDownloader(info *ProvisioningInfo) string {
+	var optionValue string
+	switch info.NetworkStack {
+	case NetworkStackV4:
+		optionValue = "ip=dhcp"
+	case NetworkStackV6:
+		optionValue = "ip=dhcp6"
+	case NetworkStackDual:
+		optionValue = ""
+	}
+	return optionValue
+}
+
+func createInitContainerMachineOsDownloader(info *ProvisioningInfo, setIpOptions bool) corev1.Container {
+	env := []corev1.EnvVar{
+		buildEnvVar(machineImageUrl, &info.ProvConfig.Spec),
+	}
+	if setIpOptions {
+		env = append(env,
+			corev1.EnvVar{
+				Name:  ipOptions,
+				Value: ipOptionForMachineOsDownloader(info),
+			})
+	}
 	initContainer := corev1.Container{
 		Name:            "metal3-machine-os-downloader",
-		Image:           images.MachineOsDownloader,
+		Image:           info.Images.MachineOsDownloader,
 		Command:         []string{"/usr/local/bin/get-resource.sh"},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointer.BoolPtr(true),
 		},
 		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
-		Env: []corev1.EnvVar{
-			buildEnvVar(machineImageUrl, config),
-		},
+		Env:          env,
 	}
 	return initContainer
 }
@@ -251,30 +272,30 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 	return initContainer
 }
 
-func newMetal3Containers(images *Images, config *metal3iov1alpha1.ProvisioningSpec, proxy *configv1.Proxy) []corev1.Container {
+func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 	containers := []corev1.Container{
-		createContainerMetal3BaremetalOperator(images, config),
-		createContainerMetal3Mariadb(images),
-		createContainerMetal3Httpd(images, config),
-		createContainerMetal3IronicConductor(images, config),
-		createContainerIronicInspectorRamdiskLogs(images),
-		createContainerMetal3IronicApi(images, config),
-		createContainerIronicDeployRamdiskLogs(images),
-		createContainerMetal3IronicInspector(images, config),
+		createContainerMetal3BaremetalOperator(info.Images, &info.ProvConfig.Spec),
+		createContainerMetal3Mariadb(info.Images),
+		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec),
+		createContainerMetal3IronicConductor(info.Images, &info.ProvConfig.Spec),
+		createContainerIronicInspectorRamdiskLogs(info.Images),
+		createContainerMetal3IronicApi(info.Images, &info.ProvConfig.Spec),
+		createContainerIronicDeployRamdiskLogs(info.Images),
+		createContainerMetal3IronicInspector(info.Images, &info.ProvConfig.Spec),
 	}
 
 	// If the provisioning network is disabled, and the user hasn't requested a
 	// particular provisioning IP on the machine CIDR, we have nothing for this container
 	// to manage.
-	if config.ProvisioningIP != "" {
-		containers = append(containers, createContainerMetal3StaticIpManager(images, config))
+	if info.ProvConfig.Spec.ProvisioningIP != "" {
+		containers = append(containers, createContainerMetal3StaticIpManager(info.Images, &info.ProvConfig.Spec))
 	}
 
-	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
-		containers = append(containers, createContainerMetal3Dnsmasq(images, config))
+	if info.ProvConfig.Spec.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
+		containers = append(containers, createContainerMetal3Dnsmasq(info.Images, &info.ProvConfig.Spec))
 	}
 
-	return injectProxyAndCA(containers, proxy)
+	return injectProxyAndCA(containers, info.Proxy)
 }
 
 func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
@@ -541,10 +562,9 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 	return container
 }
 
-func newMetal3PodTemplateSpec(images *Images, config *metal3iov1alpha1.ProvisioningSpec, labels *map[string]string, proxy *configv1.Proxy) *corev1.PodTemplateSpec {
-	initContainers := newMetal3InitContainers(images, config, proxy)
-	containers := newMetal3Containers(images, config, proxy)
-
+func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) *corev1.PodTemplateSpec {
+	initContainers := newMetal3InitContainers(info)
+	containers := newMetal3Containers(info)
 	tolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
@@ -639,9 +659,9 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar) []corev1.EnvVa
 	return envVars
 }
 
-func newMetal3Deployment(targetNamespace string, images *Images, config *metal3iov1alpha1.ProvisioningSpec, selector *metav1.LabelSelector, proxy *configv1.Proxy) *appsv1.Deployment {
-	if selector == nil {
-		selector = &metav1.LabelSelector{
+func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
+	if info.PodLabelSelector == nil {
+		info.PodLabelSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"k8s-app":    metal3AppName,
 				cboLabelName: stateService,
@@ -650,7 +670,7 @@ func newMetal3Deployment(targetNamespace string, images *Images, config *metal3i
 	}
 	k8sAppLabel := metal3AppName
 	apiLabelValue := ""
-	for k, v := range selector.MatchLabels {
+	for k, v := range info.PodLabelSelector.MatchLabels {
 		if k == "k8s-app" {
 			k8sAppLabel = v
 		}
@@ -665,11 +685,11 @@ func newMetal3Deployment(targetNamespace string, images *Images, config *metal3i
 	if apiLabelValue != "" {
 		podSpecLabels["api"] = apiLabelValue
 	}
-	template := newMetal3PodTemplateSpec(images, config, &podSpecLabels, proxy)
+	template := newMetal3PodTemplateSpec(info, &podSpecLabels)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      baremetalDeploymentName,
-			Namespace: targetNamespace,
+			Namespace: info.Namespace,
 			Annotations: map[string]string{
 				cboOwnedAnnotation: "",
 			},
@@ -680,7 +700,7 @@ func newMetal3Deployment(targetNamespace string, images *Images, config *metal3i
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(1),
-			Selector: selector,
+			Selector: info.PodLabelSelector,
 			Template: *template,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
@@ -701,8 +721,8 @@ func CheckExistingMetal3Deployment(client appsclientv1.DeploymentsGetter, target
 func EnsureMetal3Deployment(info *ProvisioningInfo) (updated bool, err error) {
 	// Create metal3 deployment object based on current baremetal configuration
 	// It will be created with the cboOwnedAnnotation
-	metal3Deployment := newMetal3Deployment(info.Namespace, info.Images, &info.ProvConfig.Spec, info.PodLabelSelector, info.Proxy)
 
+	metal3Deployment := newMetal3Deployment(info)
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, info.ProvConfig.Status.Generations)
 
 	err = controllerutil.SetControllerReference(info.ProvConfig, metal3Deployment, info.Scheme)

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -11,6 +11,14 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
+type NetworkStackType int
+
+const (
+	NetworkStackV4   NetworkStackType = 1 << iota
+	NetworkStackV6   NetworkStackType = 1 << iota
+	NetworkStackDual NetworkStackType = (NetworkStackV4 | NetworkStackV6)
+)
+
 type ProvisioningInfo struct {
 	Client           kubernetes.Interface
 	EventRecorder    events.Recorder
@@ -20,4 +28,5 @@ type ProvisioningInfo struct {
 	Images           *Images
 	PodLabelSelector *metav1.LabelSelector
 	Proxy            *configv1.Proxy
+	NetworkStack     NetworkStackType
 }


### PR DESCRIPTION
This is a squashed backport of the following commits
- https://github.com/openshift/cluster-baremetal-operator/commit/da0fdb5627d71ed60bcc1a5dfac8e9360b0d33a1
- https://github.com/openshift/cluster-baremetal-operator/commit/126f94f94e0d2720a49e149f57a6e2ec31e0bf33
- https://github.com/openshift/cluster-baremetal-operator/commit/5d37ad30322b511361c352ade461c96f5540190b
- https://github.com/openshift/cluster-baremetal-operator/commit/4589e4c490154ea20d6b28c69283ce3a6efd278f
- https://github.com/openshift/cluster-baremetal-operator/commit/9073a729a3a90d94d84be3f5baa8e0449c29aa41
- https://github.com/openshift/cluster-baremetal-operator/commit/392448754b540c995f13b05884d22ab0fc75428c