### PR TITLE
Set external IP env var for ironic conductor too.

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -607,6 +607,7 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 			buildEnvVar(provisioningInterface, config),
 			buildSSHKeyEnvVar(sshKey),
 			setIronicHtpasswdHash(htpasswdEnvVar, ironicrpcSecretName),
+			setIronicExternalIp(externalIpEnvVar, config),
 		},
 		Ports: []corev1.ContainerPort{
 			{


### PR DESCRIPTION
We need to set this for ironic conductor also as it is the thing
responsible for setting up the callback.