### PR TITLE
Pass MACs to set-static-ip initContainer

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -254,7 +254,7 @@ func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 	// particular provisioning IP on the machine CIDR, we have nothing for this container
 	// to manage.
 	if info.ProvConfig.Spec.ProvisioningIP != "" && info.ProvConfig.Spec.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
-		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec))
+		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec, info.MasterMacAddresses))
 	}
 
 	initContainers = append(initContainers, createInitContainerMachineOsDownloader(info, true))
@@ -327,7 +327,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, setIpOptions
 	return initContainer
 }
 
-func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.ProvisioningSpec, macs []string) corev1.Container {
 	initContainer := corev1.Container{
 		Name:            "metal3-static-ip-set",
 		Image:           images.StaticIpManager,
@@ -347,6 +347,8 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 			},
 		},
 	}
+
+	initContainer.Env = envWithMasterMacAddresses(initContainer.Env, macs)
 
 	return initContainer
 }


### PR DESCRIPTION
This was added for refresh-static-ips in #149 - but actually
the point where we really need it is the initial setting of the IP
since the underlying script can't detect which interface to use
by IP until it's configured.