### PR TITLE
Customize metal3 health endpoint to avoid port conflicts

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -411,6 +411,7 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 			},
 		},
 		Command:         []string{"/baremetal-operator"},
+		Args:            []string{"--health-addr", ":9446"},
 		ImagePullPolicy: "IfNotPresent",
 		VolumeMounts: []corev1.VolumeMount{
 			ironicCredentialsMount,


### PR DESCRIPTION
This PR fixes the port conflicts recently discovered on CI between metal3 cluster-cloud-controller-manager-operator: both are using the default port for the health endpoint `9440`, and both are using the host network. Since cccmo is usually deployed first by CVO, when both deployments land on the same node then metal3 won't start.