### PR TITLE
Bug 1986464: Send pull secret data as base64 encoded string

### DIFF
--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -153,7 +154,7 @@ func createRegistryPullSecret(info *ProvisioningInfo) error {
 			Namespace: info.Namespace,
 		},
 		StringData: map[string]string{
-			openshiftConfigSecretKey: string(openshiftConfigSecret.Data[openshiftConfigSecretKey]),
+			openshiftConfigSecretKey: base64.StdEncoding.EncodeToString(openshiftConfigSecret.Data[openshiftConfigSecretKey]),
 		},
 	}
 


### PR DESCRIPTION
Currently we are sending the pull secret as a plain string to the Configure-CoreOS init container. The ironic image expects the data to be in base64 encoded string.

See: https://github.com/openshift/ironic-image/blob/7694a8a2fdadf0e9e303b9d9c9003a70bc7b3753/ironic-config/ironic-python-agent.ign.j2#L53