### PR TITLE
Bug 1986462: Separate the names of machine os downloader when two copies are started 

### DIFF
--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -176,6 +176,25 @@ func disabledProvisioning() *provisioningBuilder {
 	}
 }
 
+func configWithPreProvisioningOSDownloadURLs() *provisioningBuilder {
+	return &provisioningBuilder{
+		metal3iov1alpha1.ProvisioningSpec{
+			ProvisioningInterface:     "eth0",
+			ProvisioningIP:            "172.30.20.3",
+			ProvisioningNetworkCIDR:   "172.30.20.0/24",
+			ProvisioningDHCPRange:     "172.30.20.11,172.30.20.101",
+			ProvisioningOSDownloadURL: "http://172.22.0.1/images/rhcos-44.81.202001171431.0-openstack.x86_64.qcow2.gz?sha256=e98f83a2b9d4043719664a2be75fe8134dc6ca1fdbde807996622f8cc7ecd234",
+			ProvisioningNetwork:       "Managed",
+			PreProvisioningOSDownloadURLs: metal3iov1alpha1.PreProvisioningOSDownloadURLs{
+				KernelURL:    "http://172.22.0.1/images/rhcos-49.84.202107010027-0-live-kernel-x86_64",
+				InitramfsURL: "http://172.22.0.1/images/rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
+				RootfsURL:    "http://172.22.0.1/images/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
+				IsoURL:       "http://172.22.0.1/images/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso",
+			},
+		},
+	}
+}
+
 func (pb *provisioningBuilder) build() *metal3iov1alpha1.ProvisioningSpec {
 	return &pb.ProvisioningSpec
 }

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -365,8 +365,10 @@ func ipOptionForMachineOsDownloader(info *ProvisioningInfo) string {
 
 func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs string, useLiveImages, setIpOptions bool) corev1.Container {
 	var command string
+	name := "metal3-machine-os-downloader"
 	if useLiveImages {
 		command = "/usr/local/bin/get-live-images.sh"
+		name = name + "-live-images"
 	} else {
 		command = "/usr/local/bin/get-resource.sh"
 	}
@@ -385,7 +387,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 			})
 	}
 	initContainer := corev1.Container{
-		Name:            "metal3-machine-os-downloader",
+		Name:            name,
 		Image:           info.Images.MachineOsDownloader,
 		Command:         []string{command},
 		ImagePullPolicy: "IfNotPresent",

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -142,6 +142,28 @@ func TestNewMetal3InitContainers(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "valid config with pre provisioning os download urls set",
+			config: configWithPreProvisioningOSDownloadURLs().build(),
+			expectedContainers: []corev1.Container{
+				{
+					Name:  "metal3-configure-coreos-ipa",
+					Image: images.Ironic,
+				},
+				{
+					Name:  "metal3-machine-os-downloader-live-images",
+					Image: images.MachineOsDownloader,
+				},
+				{
+					Name:  "metal3-machine-os-downloader",
+					Image: images.MachineOsDownloader,
+				},
+				{
+					Name:  "metal3-static-ip-set",
+					Image: images.StaticIpManager,
+				},
+			},
+		},
 	}
 	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
When specifying both PreProvisioningOSDownloadURLs and ProvisioningOSDownloadURL in the provisioning config CR, CBO will fail to reconcile becasuse two copies of machine-os-downloader init containers with the same name are started. The names of these initcontainers should be different when both of them are spawned together.