### PR TITLE
Bug 1997993: Set LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE=Never

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -534,6 +534,10 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 			buildEnvVar(ironicEndpoint, config),
 			buildEnvVar(ironicInspectorEndpoint, config),
 			{
+				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
+				Value: "Never",
+			},
+			{
 				Name:  "METAL3_AUTH_ROOT_DIR",
 				Value: metal3AuthRootDir,
 			},

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -218,6 +218,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "DEPLOY_RAMDISK_URL", Value: "http://localhost:6181/images/ironic-python-agent.initramfs"},
 				{Name: "IRONIC_ENDPOINT", Value: "https://localhost:6385/v1/"},
 				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: "https://localhost:5050/v1/"},
+				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
 				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
 			},
 		},


### PR DESCRIPTION
Enable the functionality to set force_persistent_boot_device
to "Never" for live ISO nodes. This will allow nodes to be
booted once to CD then rebooted to HD.