### PR TITLE
Bug 2000445: Set LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE=Never

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -426,6 +426,10 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 				Name:  "METAL3_AUTH_ROOT_DIR",
 				Value: metal3AuthRootDir,
 			},
+			{
+				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
+				Value: "Never",
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
Enable the functionality to set force_persistent_boot_device
to "Never" for live ISO nodes. This will allow nodes to be
booted once to CD then rebooted to HD.