### PR TITLE
Remove ironic-inspector reference in CBO

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -15,10 +15,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:ironic
-  - name: ironic-inspector
-    from:
-      kind: DockerImage
-      name: registry.ci.openshift.org/openshift:ironic-inspector
   - name: ironic-ipa-downloader
     from:
       kind: DockerImage

--- a/provisioning/sample_images.json
+++ b/provisioning/sample_images.json
@@ -2,7 +2,6 @@
   "clusterBaremetalOperator": "registry.ci.openshift.org/openshift:cluster-baremetal-operator",
   "baremetalOperator": "registry.ci.openshift.org/openshift:baremetal-operator",
   "baremetalIronic": "registry.ci.openshift.org/openshift:ironic",
-  "baremetalIronicInspector": "registry.ci.openshift.org/openshift:ironic-inspector",
   "baremetalIpaDownloader": "registry.ci.openshift.org/openshift:ironic-ipa-downloader",
   "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
   "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager"


### PR DESCRIPTION
The ironic-inspector service was deprecated in 4.9 and removed
in 4.10, we need to use the ironic image as reference.
In #132 we switched to use use the ironic image, now we need to remove the old reference.