### PR TITLE
Serve virtual media ISOs over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ affected by this flag.
 - PreprovisioningOSDownloadURLs is set of CoreOS Live URLs that would be necessary to provision a worker
 either using virtual media or PXE.
 
+- DisableVirtualMediaTLS turns off TLS on the virtual media server,
+which may be required for hardware that cannot accept HTTPS links.
+
 
 ## What are its outputs?
 

--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -173,6 +173,10 @@ type ProvisioningSpec struct {
 	// PreprovisioningOSDownloadURLs is set of CoreOS Live URLs that would be necessary to provision a worker
 	// either using virtual media or PXE.
 	PreProvisioningOSDownloadURLs PreProvisioningOSDownloadURLs `json:"preProvisioningOSDownloadURLs,omitempty"`
+
+	// DisableVirtualMediaTLS turns off TLS on the virtual media server,
+	// which may be required for hardware that cannot accept HTTPS links.
+	DisableVirtualMediaTLS bool `json:"disableVirtualMediaTLS,omitempty"`
 }
 
 // ProvisioningStatus defines the observed state of Provisioning

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -55,6 +55,11 @@ spec:
                 - local
                 - http
                 type: string
+              disableVirtualMediaTLS:
+                description: DisableVirtualMediaTLS turns off TLS on the virtual media
+                  server, which may be required for hardware that cannot accept HTTPS
+                  links.
+                type: boolean
               preProvisioningOSDownloadURLs:
                 description: PreprovisioningOSDownloadURLs is set of CoreOS Live URLs
                   that would be necessary to provision a worker either using virtual

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -55,6 +55,11 @@ spec:
                 - local
                 - http
                 type: string
+              disableVirtualMediaTLS:
+                description: DisableVirtualMediaTLS turns off TLS on the virtual media
+                  server, which may be required for hardware that cannot accept HTTPS
+                  links.
+                type: boolean
               preProvisioningOSDownloadURLs:
                 description: PreprovisioningOSDownloadURLs is set of CoreOS Live URLs
                   that would be necessary to provision a worker either using virtual

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	baremetalHttpPort              = "6180"
+	baremetalVmediaHttpsPort       = "6183"
 	baremetalWebhookPort           = "9447"
 	baremetalIronicPort            = "6385"
 	baremetalIronicInspectorPort   = "5050"
@@ -41,6 +42,7 @@ var (
 	ironicEndpoint                 = "IRONIC_ENDPOINT"
 	ironicInspectorEndpoint        = "IRONIC_INSPECTOR_ENDPOINT"
 	httpPort                       = "HTTP_PORT"
+	vmediaHttpsPort                = "VMEDIA_TLS_PORT"
 	dhcpRange                      = "DHCP_RANGE"
 	machineImageUrl                = "RHCOS_IMAGE_URL"
 	ipOptions                      = "IP_OPTIONS"
@@ -150,6 +152,8 @@ func getMetal3DeploymentConfig(name string, baremetalConfig *metal3iov1alpha1.Pr
 		return getIronicInspectorEndpoint()
 	case httpPort:
 		return pointer.StringPtr(baremetalHttpPort)
+	case vmediaHttpsPort:
+		return pointer.StringPtr(baremetalVmediaHttpsPort)
 	case dhcpRange:
 		return getDHCPRange(baremetalConfig)
 	case machineImageUrl:

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -234,6 +234,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "PROVISIONING_INTERFACE", Value: "eth0"},
 				{Name: "IRONIC_RAMDISK_SSH_KEY"},
 				{Name: "PROVISIONING_MACS", Value: "34:b3:2d:81:f8:fb,34:b3:2d:81:f8:fc,34:b3:2d:81:f8:fd"},
+				{Name: "VMEDIA_TLS_PORT", Value: "6183"},
 			},
 		},
 		"metal3-ironic-conductor": {
@@ -249,6 +250,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				envWithSecret("HTTP_BASIC_HTPASSWD", "metal3-ironic-rpc-password", "htpasswd"),
 				{Name: "IRONIC_EXTERNAL_IP"},
 				{Name: "PROVISIONING_MACS", Value: "34:b3:2d:81:f8:fb,34:b3:2d:81:f8:fc,34:b3:2d:81:f8:fd"},
+				{Name: "VMEDIA_TLS_PORT", Value: "6183"},
 			},
 		},
 		"metal3-ironic-api": {
@@ -262,6 +264,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				envWithSecret("HTTP_BASIC_HTPASSWD", "metal3-ironic-password", "htpasswd"),
 				{Name: "IRONIC_EXTERNAL_IP"},
 				{Name: "PROVISIONING_MACS", Value: "34:b3:2d:81:f8:fb,34:b3:2d:81:f8:fc,34:b3:2d:81:f8:fd"},
+				{Name: "VMEDIA_TLS_PORT", Value: "6183"},
 			},
 		},
 		"metal3-ramdisk-logs": {


### PR DESCRIPTION
Especially in the live ISO case, the virtual media images may contain
sensitive information. Now that we've established that Redfish hardware
does not verify TLS certificates, we can use our self-signed certificate
to protect the communication with the BMC.

A knob to turn this feature off is provided for hardware that diverges.

Requires:
- https://github.com/openshift/ironic-image/pull/218
- https://github.com/openshift/enhancements/pull/917
- https://github.com/openshift-metal3/dev-scripts/pull/1301
