### PR TITLE
Start image customization controller

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -242,6 +242,8 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		provisioning.EnsureMetal3StateService,
 		provisioning.EnsureImageCache,
 		provisioning.EnsureBaremetalOperatorWebhook,
+		provisioning.EnsureImageCustomizationService,
+		provisioning.EnsureImageCustomizationDeployment,
 	} {
 		updated, err := ensureResource(info)
 		if err != nil {
@@ -380,6 +382,12 @@ func (r *ProvisioningReconciler) deleteMetal3Resources(info *provisioning.Provis
 	}
 	if err := provisioning.DeleteImageCache(info); err != nil {
 		return errors.Wrap(err, "failed to delete metal3 image cache")
+	}
+	if err := provisioning.DeleteImageCustomizationService(info); err != nil {
+		return errors.Wrap(err, "failed to delete metal3 image customization service")
+	}
+	if err := provisioning.DeleteImageCustomizationDeployment(info); err != nil {
+		return errors.Wrap(err, "failed to delete metal3 image customization deployment")
 	}
 	return nil
 }

--- a/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
@@ -18,6 +18,7 @@ data:
       "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
       "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager",
       "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent",
-      "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller"
+      "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller",
+      "machineOSImages": "registry.ci.openshift.org/openshift:machine-os-images"
     }
 

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -39,3 +39,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:image-customization-controller
+  - name: machine-os-images
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:machine-os-images

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -93,33 +93,6 @@ func getProvisioningOSDownloadURL(config *metal3iov1alpha1.ProvisioningSpec) *st
 	return nil
 }
 
-// Check whether the PreProvisionOSDownloadURLs are set. If yes, we
-// construct a comma-separated list of RHCOS live images and return it
-func getPreProvisioningOSDownloadURLs(config *metal3iov1alpha1.ProvisioningSpec) []string {
-	var liveURLs []string
-	if config.PreProvisioningOSDownloadURLs.IsoURL != "" {
-		liveURLs = append(liveURLs, config.PreProvisioningOSDownloadURLs.IsoURL)
-	}
-	if isCoreOSIPAAvailable(config) {
-		liveURLs = append(liveURLs, config.PreProvisioningOSDownloadURLs.InitramfsURL)
-		liveURLs = append(liveURLs, config.PreProvisioningOSDownloadURLs.KernelURL)
-		liveURLs = append(liveURLs, config.PreProvisioningOSDownloadURLs.RootfsURL)
-	}
-
-	return liveURLs
-}
-
-// isCoreOSIPAAvailable is a helper to check whether the CoreOS based IPA URLs are available.
-// Only return true when kernel, rootfs and initramfs URLs are present
-func isCoreOSIPAAvailable(config *metal3iov1alpha1.ProvisioningSpec) bool {
-	if config.PreProvisioningOSDownloadURLs.KernelURL != "" &&
-		config.PreProvisioningOSDownloadURLs.RootfsURL != "" &&
-		config.PreProvisioningOSDownloadURLs.InitramfsURL != "" {
-		return true
-	}
-	return false
-}
-
 func getBootIsoSource(config *metal3iov1alpha1.ProvisioningSpec) *string {
 	if config.BootIsoSource != "" {
 		return (*string)(&config.BootIsoSource)

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -32,13 +32,11 @@ var (
 	baremetalIronicPort            = "6385"
 	baremetalIronicInspectorPort   = "5050"
 	baremetalKernelUrlSubPath      = "images/ironic-python-agent.kernel"
-	baremetalRamdiskUrlSubPath     = "images/ironic-python-agent.initramfs"
 	baremetalIronicEndpointSubpath = "v1/"
 	provisioningIP                 = "PROVISIONING_IP"
 	provisioningInterface          = "PROVISIONING_INTERFACE"
 	provisioningMacAddresses       = "PROVISIONING_MACS"
 	deployKernelUrl                = "DEPLOY_KERNEL_URL"
-	deployRamdiskUrl               = "DEPLOY_RAMDISK_URL"
 	ironicEndpoint                 = "IRONIC_ENDPOINT"
 	ironicInspectorEndpoint        = "IRONIC_INSPECTOR_ENDPOINT"
 	httpPort                       = "HTTP_PORT"
@@ -76,11 +74,6 @@ func getProvisioningIPCIDR(config *metal3iov1alpha1.ProvisioningSpec) *string {
 func getDeployKernelUrl() *string {
 	deployKernelUrl := fmt.Sprintf("http://localhost:%d/%s", imageCachePort, baremetalKernelUrlSubPath)
 	return &deployKernelUrl
-}
-
-func getDeployRamdiskUrl() *string {
-	deployRamdiskUrl := fmt.Sprintf("http://localhost:%d/%s", imageCachePort, baremetalRamdiskUrlSubPath)
-	return &deployRamdiskUrl
 }
 
 func getIronicEndpoint() *string {
@@ -144,8 +137,6 @@ func getMetal3DeploymentConfig(name string, baremetalConfig *metal3iov1alpha1.Pr
 		return pointer.StringPtr(strings.Join(baremetalConfig.ProvisioningMacAddresses, ","))
 	case deployKernelUrl:
 		return getDeployKernelUrl()
-	case deployRamdiskUrl:
-		return getDeployRamdiskUrl()
 	case ironicEndpoint:
 		return getIronicEndpoint()
 	case ironicInspectorEndpoint:

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -57,18 +57,6 @@ func TestGetMetal3DeploymentConfig(t *testing.T) {
 			expectedValue: "http://localhost:6181/images/ironic-python-agent.kernel",
 		},
 		{
-			name:          "Unmanaged DeployRamdiskUrl",
-			configName:    deployRamdiskUrl,
-			spec:          unmanagedProvisioning().build(),
-			expectedValue: "http://localhost:6181/images/ironic-python-agent.initramfs",
-		},
-		{
-			name:          "Disabled DeployRamdiskUrl",
-			configName:    deployRamdiskUrl,
-			spec:          disabledProvisioning().build(),
-			expectedValue: "http://localhost:6181/images/ironic-python-agent.initramfs",
-		},
-		{
 			name:          "Disabled IronicEndpoint",
 			configName:    ironicEndpoint,
 			spec:          disabledProvisioning().build(),

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -533,7 +533,7 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 			},
 		},
 		Command:         []string{"/baremetal-operator"},
-		Args:            []string{"--health-addr", ":9446"},
+		Args:            []string{"--health-addr", ":9446", "-build-preprov-image"},
 		ImagePullPolicy: "IfNotPresent",
 		VolumeMounts: []corev1.VolumeMount{
 			ironicCredentialsMount,
@@ -572,7 +572,6 @@ func createContainerMetal3BaremetalOperator(images *Images, config *metal3iov1al
 				Value: "true",
 			},
 			buildEnvVar(deployKernelUrl, config),
-			buildEnvVar(deployRamdiskUrl, config),
 			buildEnvVar(ironicEndpoint, config),
 			buildEnvVar(ironicInspectorEndpoint, config),
 			{

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -55,6 +54,7 @@ const (
 	mariadbPwdEnvVar                 = "MARIADB_PASSWORD"    // #nosec
 	ironicInsecureEnvVar             = "IRONIC_INSECURE"
 	inspectorInsecureEnvVar          = "IRONIC_INSPECTOR_INSECURE"
+	ironicKernelParamsEnvVar         = "IRONIC_KERNEL_PARAMS"
 	ironicCertEnvVar                 = "IRONIC_CACERT_FILE"
 	sshKeyEnvVar                     = "IRONIC_RAMDISK_SSH_KEY"
 	externalIpEnvVar                 = "IRONIC_EXTERNAL_IP"
@@ -304,44 +304,15 @@ func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec))
 	}
 
-	// If the PreProvisioningOSDownloadURLs are set, we fetch the URLs of either CoreOS ISO and IPA assets or in some
-	// cases only the IPA assets
-	liveURLs := getPreProvisioningOSDownloadURLs(&info.ProvConfig.Spec)
-	if len(liveURLs) > 0 {
-		initContainers = append(initContainers, createInitContainerMachineOsDownloader(info, strings.Join(liveURLs, ","), true, true))
-	}
+	// Extract the pre-provisioning images from a container in the payload
+	initContainers = append(initContainers, createInitContainerMachineOSImages(info, "--all", imageVolumeMount, "/shared/html/images"))
+
 	// If the ProvisioningOSDownloadURL is set, we download the URL specified in it
 	if info.ProvConfig.Spec.ProvisioningOSDownloadURL != "" {
 		initContainers = append(initContainers, createInitContainerMachineOsDownloader(info, info.ProvConfig.Spec.ProvisioningOSDownloadURL, false, true))
 	}
 
-	// If the CoreOS IPA assets are not available we will use the IPA downloader
-	if !isCoreOSIPAAvailable(&info.ProvConfig.Spec) {
-		initContainers = append(initContainers, createInitContainerIpaDownloader(info.Images))
-	}
-
 	return injectProxyAndCA(initContainers, info.Proxy)
-}
-
-func createInitContainerIpaDownloader(images *Images) corev1.Container {
-	initContainer := corev1.Container{
-		Name:            "metal3-ipa-downloader",
-		Image:           images.IpaDownloader,
-		Command:         []string{"/usr/local/bin/get-resource.sh"},
-		ImagePullPolicy: "IfNotPresent",
-		SecurityContext: &corev1.SecurityContext{
-			Privileged: pointer.BoolPtr(true),
-		},
-		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
-		Env:          []corev1.EnvVar{},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-			},
-		},
-	}
-	return initContainer
 }
 
 func ipOptionForMachineOsDownloader(info *ProvisioningInfo) string {
@@ -430,10 +401,10 @@ func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 		createContainerMetal3BaremetalOperator(info.Images, &info.ProvConfig.Spec, info.BaremetalWebhookEnabled),
 		createContainerMetal3Mariadb(info.Images),
 		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec, info.SSHKey),
-		createContainerMetal3IronicConductor(info.Images, &info.ProvConfig.Spec, info.SSHKey),
+		createContainerMetal3IronicConductor(info.Images, info, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3IronicApi(info.Images, &info.ProvConfig.Spec),
 		createContainerMetal3RamdiskLogs(info.Images),
-		createContainerMetal3IronicInspector(info.Images, &info.ProvConfig.Spec),
+		createContainerMetal3IronicInspector(info.Images, info, &info.ProvConfig.Spec),
 	}
 
 	// If the provisioning network is disabled, and the user hasn't requested a
@@ -675,7 +646,7 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 	return container
 }
 
-func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alpha1.ProvisioningSpec, sshKey string) corev1.Container {
+func createContainerMetal3IronicConductor(images *Images, info *ProvisioningInfo, config *metal3iov1alpha1.ProvisioningSpec, sshKey string) corev1.Container {
 	volumes := []corev1.VolumeMount{
 		sharedVolumeMount,
 		imageVolumeMount,
@@ -706,6 +677,10 @@ func createContainerMetal3IronicConductor(images *Images, config *metal3iov1alph
 			{
 				Name:  inspectorInsecureEnvVar,
 				Value: "true",
+			},
+			{
+				Name:  ironicKernelParamsEnvVar,
+				Value: ipOptionForMachineOsDownloader(info),
 			},
 			buildEnvVar(httpPort, config),
 			buildEnvVar(provisioningIP, config),
@@ -805,7 +780,7 @@ func createContainerMetal3RamdiskLogs(images *Images) corev1.Container {
 	return container
 }
 
-func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+func createContainerMetal3IronicInspector(images *Images, info *ProvisioningInfo, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
 	container := corev1.Container{
 		Name:            "metal3-ironic-inspector",
 		Image:           images.Ironic,
@@ -824,6 +799,10 @@ func createContainerMetal3IronicInspector(images *Images, config *metal3iov1alph
 			{
 				Name:  ironicInsecureEnvVar,
 				Value: "true",
+			},
+			{
+				Name:  ironicKernelParamsEnvVar,
+				Value: ipOptionForMachineOsDownloader(info),
 			},
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -145,10 +145,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 			config: configWithPreProvisioningOSDownloadURLs().build(),
 			expectedContainers: []corev1.Container{
 				{
-					Name:  "metal3-configure-coreos-ipa",
-					Image: images.Ironic,
-				},
-				{
 					Name:  "metal3-machine-os-downloader-live-images",
 					Image: images.MachineOsDownloader,
 				},

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -238,6 +238,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				envWithSecret("MARIADB_PASSWORD", "metal3-mariadb-password", "password"),
 				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "IRONIC_INSPECTOR_INSECURE", Value: "true"},
+				{Name: "IRONIC_KERNEL_PARAMS", Value: "ip=dhcp6"},
 				{Name: "HTTP_PORT", Value: "6180"},
 				{Name: "PROVISIONING_IP", Value: "172.30.20.3/24"},
 				{Name: "PROVISIONING_INTERFACE", Value: "eth0"},
@@ -270,6 +271,7 @@ func TestNewMetal3Containers(t *testing.T) {
 			Name: "metal3-ironic-inspector",
 			Env: []corev1.EnvVar{
 				{Name: "IRONIC_INSECURE", Value: "true"},
+				{Name: "IRONIC_KERNEL_PARAMS", Value: "ip=dhcp6"},
 				{Name: "PROVISIONING_IP", Value: "172.30.20.3/24"},
 				{Name: "PROVISIONING_INTERFACE", Value: "eth0"},
 				envWithSecret("HTTP_BASIC_HTPASSWD", "metal3-ironic-inspector-password", "htpasswd"),

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -213,7 +213,6 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6181/images/ironic-python-agent.kernel"},
-				{Name: "DEPLOY_RAMDISK_URL", Value: "http://localhost:6181/images/ironic-python-agent.initramfs"},
 				{Name: "IRONIC_ENDPOINT", Value: "https://localhost:6385/v1/"},
 				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: "https://localhost:5050/v1/"},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},

--- a/provisioning/container_images.go
+++ b/provisioning/container_images.go
@@ -30,6 +30,7 @@ type Images struct {
 	StaticIpManager              string `json:"baremetalStaticIpManager"`
 	IronicAgent                  string `json:"baremetalIronicAgent"`
 	ImageCustomizationController string `json:"imageCustomizationController"`
+	MachineOSImages              string `json:"machineOSImages"`
 }
 
 func GetContainerImages(containerImages *Images, imagesFilePath string) error {

--- a/provisioning/container_images_test.go
+++ b/provisioning/container_images_test.go
@@ -13,6 +13,7 @@ var (
 	expectedIronicStaticIpManager        = "registry.ci.openshift.org/openshift:ironic-static-ip-manager"
 	expectedIronicAgent                  = "registry.ci.openshift.org/openshift:ironic-agent"
 	expectedImageCustomizationController = "registry.ci.openshift.org/openshift:image-customization-controller"
+	expectedMachineOSImages              = "registry.ci.openshift.org/openshift:machine-os-images"
 )
 
 func TestGetContainerImages(t *testing.T) {
@@ -50,7 +51,8 @@ func TestGetContainerImages(t *testing.T) {
 					containerImages.MachineOsDownloader != expectedMachineOsDownloader ||
 					containerImages.StaticIpManager != expectedIronicStaticIpManager ||
 					containerImages.IronicAgent != expectedIronicAgent ||
-					containerImages.ImageCustomizationController != expectedImageCustomizationController {
+					containerImages.ImageCustomizationController != expectedImageCustomizationController ||
+					containerImages.MachineOSImages != expectedMachineOSImages {
 					t.Errorf("failed GetContainerImages. One or more Baremetal container images do not match the expected images.")
 				}
 			}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -106,6 +106,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo) c
 			"-images-publish-addr",
 			fmt.Sprintf("http://%s.%s.svc.cluster.local/",
 				imageCustomizationService, info.Namespace)},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: pointer.BoolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			imageRegistriesVolumeMount,
 			imageVolumeMount,

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -1,0 +1,151 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+const (
+	ironicBaseUrl    = "IRONIC_BASE_URL"
+	ironicAgentImage = "IRONIC_AGENT_IMAGE"
+)
+
+func setIronicBaseUrl(name string, config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
+	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+		return corev1.EnvVar{
+			Name:  name,
+			Value: "http://" + config.ProvisioningIP,
+		}
+	} else {
+		return corev1.EnvVar{
+			Name: name,
+			//Value: "http://" + $(externalIpEnvVar),
+		}
+	}
+}
+
+func createImageCustomizationContainer(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+	container := corev1.Container{
+		Name:            "image-customization-controller",
+		Image:           images.ImageCustomizationController,
+		Command:         []string{"/image-customization-controller"},
+		ImagePullPolicy: "IfNotPresent",
+		Env: []corev1.EnvVar{
+			setIronicBaseUrl(ironicBaseUrl, config),
+			{
+				Name:  ironicAgentImage,
+				Value: images.IronicAgent,
+			},
+			buildSSHKeyEnvVar(info.SSHKey),
+			pullSecret,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+	}
+	return container
+}
+
+func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) *corev1.PodTemplateSpec {
+	containers := []corev1.Container{
+		createImageCustomizationContainer(info.Images, &info.ProvConfig.Spec),
+	}
+
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:               "node.kubernetes.io/not-ready",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+	}
+
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: podTemplateAnnotations,
+			Labels:      *labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers:         containers,
+			HostNetwork:        false,
+			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+			PriorityClassName:  "system-node-critical",
+			NodeSelector:       map[string]string{"node-role.kubernetes.io/master": ""},
+			ServiceAccountName: "cluster-baremetal-operator",
+			Tolerations:        tolerations,
+		},
+	}
+}
+
+func newImageCustomizationDeployment(info *ProvisioningInfo) *appsv1.Deployment {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"k8s-app":    metal3AppName,
+			cboLabelName: stateService,
+		},
+	}
+	podSpecLabels := map[string]string{
+		"k8s-app":    metal3AppName,
+		cboLabelName: stateService,
+	}
+	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "metal3ImageCustomization",
+			Namespace:   info.Namespace,
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"k8s-app":    metal3AppName,
+				cboLabelName: stateService,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Selector: selector,
+			Template: *template,
+		},
+	}
+}
+
+func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
+	_ = newImageCustomizationDeployment(info)
+	return false, nil
+}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -152,12 +152,12 @@ func newImageCustomizationDeployment(info *ProvisioningInfo) *appsv1.Deployment 
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"k8s-app":    metal3AppName,
-			cboLabelName: stateService,
+			cboLabelName: imageCustomizationService,
 		},
 	}
 	podSpecLabels := map[string]string{
 		"k8s-app":    metal3AppName,
-		cboLabelName: stateService,
+		cboLabelName: imageCustomizationService,
 	}
 	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels)
 	return &appsv1.Deployment{
@@ -167,7 +167,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo) *appsv1.Deployment 
 			Annotations: map[string]string{},
 			Labels: map[string]string{
 				"k8s-app":    metal3AppName,
-				cboLabelName: stateService,
+				cboLabelName: imageCustomizationService,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -38,7 +38,7 @@ const (
 	ironicAgentImage                 = "IRONIC_AGENT_IMAGE"
 	imageCustomizationDeploymentName = "metal3-image-customization"
 	imageCustomizationVolume         = "metal3-image-customization-volume"
-	imageBindPort                    = 8084
+	imageCustomizationPort           = 8084
 	containerRegistriesConfPath      = "/etc/containers/registries.conf"
 	containerRegistriesEnvVar        = "REGISTRIES_CONF_PATH"
 	deployISOEnvVar                  = "DEPLOY_ISO"
@@ -102,7 +102,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo) c
 		Name:  "image-customization-controller",
 		Image: images.ImageCustomizationController,
 		Command: []string{"/image-customization-controller",
-			"-images-bind-addr", fmt.Sprintf(":%d", imageBindPort),
+			"-images-bind-addr", fmt.Sprintf(":%d", imageCustomizationPort),
 			"-images-publish-addr",
 			fmt.Sprintf("http://%s.%s.svc.cluster.local/",
 				imageCustomizationService, info.Namespace)},
@@ -131,6 +131,12 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo) c
 			},
 			buildSSHKeyEnvVar(info.SSHKey),
 			pullSecret,
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: imageCustomizationPort,
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -41,8 +41,13 @@ const (
 	imagesPublishAddress             = "images-publish-addr"
 	imageCustomizationDeploymentName = "metal3-image-customization"
 	imageCustomizationVolume         = "metal3-image-customization-volume"
-	imageRegistriesConfPath          = "/etc/containers/registries.conf"
-	containerRegistriesEnvVar            = "REGISTRIES_CONF_PATH"
+	containerRegistriesEnvVar        = "REGISTRIES_CONF_PATH"
+	containerRegistriesConfPath      = "/etc/containers/registries.conf"
+	containerRegistriesEnvVar        = "REGISTRIES_CONF_PATH"
+	deployISOEnvVar                  = "DEPLOY_ISO"
+	deployISOFile                    = "/shared/html/images/ironic-python-agent.iso"
+	deployInitrdEnvVar               = "DEPLOY_INITRD"
+	deployInitrdFile                 = "/shared/html/images/ironic-python-agent.initramfs"
 )
 
 var (
@@ -52,7 +57,6 @@ var (
 	}
 )
 
->>>>>>> 5cd6cfb... Set REGISTRIES_CONF_PATH env var and mount registries.conf file
 func imageRegistriesVolume() corev1.Volume {
 	// TODO: Should this be corev1.HostPathFile?
 	volType := corev1.HostPathFileOrCreate
@@ -106,12 +110,23 @@ func setImagePublishUrl(imageCustomizationService string, imagesBindAddress stri
 
 func createImageCustomizationContainer(images *Images, info *ProvisioningInfo) corev1.Container {
 	container := corev1.Container{
-		Name:            "image-customization-controller",
-		Image:           images.ImageCustomizationController,
-		Command:         []string{"/image-customization-controller"},
-		VolumeMounts:    []corev1.VolumeMount{imageRegistriesVolumeMount},
+		Name:    "image-customization-controller",
+		Image:   images.ImageCustomizationController,
+		Command: []string{"/image-customization-controller"},
+		VolumeMounts: []corev1.VolumeMount{
+			imageRegistriesVolumeMount,
+			imageVolumeMount,
+		},
 		ImagePullPolicy: "IfNotPresent",
 		Env: []corev1.EnvVar{
+			{
+				Name:  deployISOEnvVar,
+				Value: deployISOFile,
+			},
+			{
+				Name:  deployInitrdEnvVar,
+				Value: deployInitrdFile,
+			},
 			{
 				Name:  imagesBindAddress,
 				Value: imagesBindAddressDefault,
@@ -123,8 +138,8 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo) c
 				Value: images.IronicAgent,
 			},
 			{
-				Name:  imageRegistriesEnvVar,
-				Value: imageRegistriesConfPath,
+				Name:  containerRegistriesEnvVar,
+				Value: containerRegistriesConfPath,
 			},
 			buildSSHKeyEnvVar(info.SSHKey),
 			pullSecret,
@@ -183,6 +198,7 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 			Tolerations:        tolerations,
 			Volumes: []corev1.Volume{
 				imageRegistriesVolume(),
+				imageVolume(),
 			},
 		},
 	}

--- a/provisioning/image_customization_service.go
+++ b/provisioning/image_customization_service.go
@@ -1,0 +1,65 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+)
+
+const (
+	imageCustomizationService = "metal3-image-customization-service"
+	customizedImagePortName   = "customized-image-port"
+	imageCustomizationPort    = "6184"
+)
+
+func newImageCustomizationService(targetNamespace string) *corev1.Service {
+	port, _ := strconv.Atoi(imageCustomizationPort) // #nosec
+
+	ports := []corev1.ServicePort{
+		{
+			Name: customizedImagePortName,
+			Port: int32(port),
+		},
+	}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imageCustomizationService,
+			Namespace: targetNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Selector: map[string]string{
+				cboLabelName: imageCustomizationService,
+			},
+			Ports: ports,
+		},
+	}
+}
+
+func EnsureImageCustomizationService(info *ProvisioningInfo) (updated bool, err error) {
+	imageCustomizationService := newImageCustomizationService(info.Namespace)
+
+	err = controllerutil.SetControllerReference(info.ProvConfig, imageCustomizationService, info.Scheme)
+	if err != nil {
+		err = fmt.Errorf("unable to set controllerReference on %s service: %w", imageCustomizationService, err)
+		return
+	}
+
+	_, updated, err = resourceapply.ApplyService(info.Client.CoreV1(),
+		info.EventRecorder, imageCustomizationService)
+	if err != nil {
+		err = fmt.Errorf("unable to apply %s service: %w", imageCustomizationService, err)
+	}
+	return
+}
+
+func DeleteImageCustomizationService(info *ProvisioningInfo) error {
+	return client.IgnoreNotFound(info.Client.CoreV1().Services(info.Namespace).Delete(context.Background(), imageCustomizationService, metav1.DeleteOptions{}))
+}

--- a/provisioning/image_customization_service.go
+++ b/provisioning/image_customization_service.go
@@ -3,10 +3,10 @@ package provisioning
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -15,17 +15,14 @@ import (
 
 const (
 	imageCustomizationService = "metal3-image-customization-service"
-	customizedImagePortName   = "customized-image-port"
-	imageCustomizationPort    = "6184"
 )
 
 func newImageCustomizationService(targetNamespace string) *corev1.Service {
-	port, _ := strconv.Atoi(imageCustomizationPort) // #nosec
-
 	ports := []corev1.ServicePort{
 		{
-			Name: customizedImagePortName,
-			Port: int32(port),
+			Name:       "http",
+			Port:       80,
+			TargetPort: intstr.FromInt(imageCustomizationPort),
 		},
 	}
 	return &corev1.Service{
@@ -34,7 +31,7 @@ func newImageCustomizationService(targetNamespace string) *corev1.Service {
 			Namespace: targetNamespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
+			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
 				cboLabelName: imageCustomizationService,
 			},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -1,0 +1,31 @@
+package provisioning
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages string, dest corev1.VolumeMount, destPath string) corev1.Container {
+	container := corev1.Container{
+		Name:    "machine-os-images",
+		Image:   info.Images.MachineOSImages,
+		Command: []string{"/bin/copy-metal", whichImages, destPath},
+		VolumeMounts: []corev1.VolumeMount{
+			dest,
+		},
+		ImagePullPolicy: "IfNotPresent",
+		Env: []corev1.EnvVar{
+			{
+				Name:  ipOptions,
+				Value: ipOptionForMachineOsDownloader(info),
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+	}
+	return container
+}

--- a/provisioning/sample_images.json
+++ b/provisioning/sample_images.json
@@ -6,5 +6,6 @@
   "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
   "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager",
   "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent",
-  "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller"
+  "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller",
+  "machineOSImages": "registry.ci.openshift.org/openshift:machine-os-images"
 }


### PR DESCRIPTION
When the Provisioning Network is not being used (ProvisioningNetwork=Disabled or ProvisioningNetwork=Enabled and VirtualMediaViaExternalNetwork = true), the image customization controller deployment uses the host IP of the master on which metal3 deployment is running as the IP address of Ironic.
When the metal3 deployment moves to a different master, we need to make sure that the metal3-image-customization deployment uses this new host IP as Ironic's IP address.
 
CBO already watches for changes in the Deployment() resource and when the metal3 deployment moves, a reconcile loop would be triggered, Ironic's IP will once again be evaluated and the metal3-image-customization deployment will be updated with this new IP. 

Co-Authored-By: Zane Bitter zbitter@redhat.com