### PR TITLE
Add create and delete verbs for hfs rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,8 @@ rules:
   resources:
   - firmwareschemas
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -121,6 +123,8 @@ rules:
   resources:
   - hostfirmwaresettings
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -91,9 +91,9 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts/status;baremetalhosts/finalizers,verbs=update
-// +kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings,verbs=get;create;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=hostfirmwaresettings/status,verbs=update
-// +kubebuilder:rbac:groups=metal3.io,resources=firmwareschemas,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=metal3.io,resources=firmwareschemas,verbs=get;create;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;update;patch;create
 
 func (r *ProvisioningReconciler) isEnabled() (bool, error) {

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -166,6 +166,8 @@ rules:
   resources:
   - firmwareschemas
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch
@@ -176,6 +178,8 @@ rules:
   resources:
   - hostfirmwaresettings
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
Since the hostfirmwaresetting reconciler creates the resource the `create` verb should be added, otherwise the following error occurs:
{"level":"error","ts":1634220169.1340642,"logger":"controller.hostfirmwaresettings","msg":"Reconciler error","reconciler group":"metal3.io","reconciler kind":"HostFirmwareSettings","name":"ostest-master-1","namespace":"openshift-machine-api","error":"could not create firmware settings: failure creating hostFirmwareSettings resource: hostfirmwaresettings.metal3.io is forbidden: User \"system:serviceaccount:openshift-machine-api:cluster-baremetal-operator\" cannot create resource \"hostfirmwaresettings\" in API group \"metal3.io\" in the namespace \"openshift-machine-api\"","errorVerbose":"hostfirmwaresettings.metal3.io is forbidden: User \"system:serviceaccount:openshift-machine-api:cluster-baremetal-operator\" cannot create resource \"hostfirmwaresettings\" in API group \"metal3.io\" in the namespace \"openshift-machine-api\"\nfailure creating hostFirmwareSettings resource

Update - once the create issue was resolved, another problem was seen which appears to also require the delete verb
021-10-14T17:01:47.767685949Z {"level":"error","ts":1634230907.7674577,"logger":"controller.hostfirmwaresettings","msg":"Reconciler error","reconciler group":"metal3.io","reconciler kind":"HostFirmwareSettings","name":"ostest-worker-2","namespace":"openshift-machine-api","error":"Could not update hostFirmwareSettings: could not get/create firmware schema: firmwareschemas.metal3.io \"schema-a2d66ab8\" is forbidden: cannot set an ownerRef on a resource you can't delete: 
