### PR TITLE
Bug 2024900: Not enable CBO webhook in unsupported platform

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 		klog.ErrorS(err, "unable to create controller", "controller", "Provisioning")
 		os.Exit(1)
 	}
-	if enableWebhook {
+	if controllers.IsEnabled(enabledFeatures) && enableWebhook {
 		info := &provisioning.ProvisioningInfo{
 			Client:        kubeClient,
 			EventRecorder: events.NewLoggingEventRecorder(controllers.ComponentName),


### PR DESCRIPTION
This PR adds additional check to not enable `ValidatingWebhookConfiguration` for non baremetal platforms like AWS, Azure, GCP. Because Cluster Baremetal Operator is already disabled in these platforms.