### PR TITLE
Make ProvisioningOSDownloadURL optional

### DIFF
--- a/api/v1alpha1/provisioning_validation.go
+++ b/api/v1alpha1/provisioning_validation.go
@@ -116,7 +116,6 @@ func validateProvisioningOSDownloadURL(uri string) []error {
 	var errs []error
 
 	if uri == "" {
-		errs = append(errs, fmt.Errorf("provisioningOSDownloadURL is required but is empty"))
 		return errs
 	}
 

--- a/api/v1alpha1/provisioning_validation_test.go
+++ b/api/v1alpha1/provisioning_validation_test.go
@@ -284,9 +284,8 @@ func TestValidateDisabledProvisioningConfig(t *testing.T) {
 			// Missing ProvisioningOSDownloadURL
 			name:          "InvalidDisabled",
 			spec:          disabledProvisioning().ProvisioningOSDownloadURL("").build(),
-			expectedError: true,
+			expectedError: false,
 			expectedMode:  ProvisioningNetworkDisabled,
-			expectedMsg:   "provisioningOSDownloadURL",
 		},
 		{
 			// IP and CIDR set with bad CIDR

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -287,14 +287,14 @@ func TestUpdateCOStatusDegraded(t *testing.T) {
 			name: "Incorrect Config",
 			spec: metal3iov1alpha1.ProvisioningSpec{
 				ProvisioningInterface:     "eth0",
-				ProvisioningIP:            "172.30.20.3",
+				ProvisioningIP:            "172.30.20.11",
 				ProvisioningNetworkCIDR:   "172.30.20.0/24",
 				ProvisioningDHCPRange:     "172.30.20.11,172.30.20.101",
 				ProvisioningOSDownloadURL: "",
 				ProvisioningNetwork:       "Managed",
 			},
 			expectedConditions: []osconfigv1.ClusterOperatorStatusCondition{
-				setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, "InvalidConfiguration", "provisioningOSDownloadURL is required but is empty"),
+				setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, "InvalidConfiguration", "invalid provisioningIP \"172.30.20.11\", value must be outside of the provisioningDHCPRange \"172.30.20.11,172.30.20.101\""),
 				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, "InvalidConfiguration", "Unable to apply Provisioning CR: invalid configuration"),
 				setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, "", ""),
 				setStatusCondition(osconfigv1.OperatorUpgradeable, osconfigv1.ConditionTrue, "", ""),


### PR DESCRIPTION
In future we will provision with the CoreOS installer, so we won't need
a ProvisioningOSDownloadURL. Stop enforcing its presence in the webhook.