### PR TITLE
Add the image-customization controller to the images configmap

### DIFF
--- a/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_01_images.configmap.yaml
@@ -17,6 +17,7 @@ data:
       "baremetalIpaDownloader": "registry.ci.openshift.org/openshift:ironic-ipa-downloader",
       "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
       "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager",
-      "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent"
+      "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent",
+      "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller"
     }
 

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -35,3 +35,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/openshift:ironic-agent
+  - name: image-customization-controller
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/openshift:image-customization-controller

--- a/provisioning/container_images.go
+++ b/provisioning/container_images.go
@@ -23,12 +23,13 @@ import (
 )
 
 type Images struct {
-	BaremetalOperator   string `json:"baremetalOperator"`
-	Ironic              string `json:"baremetalIronic"`
-	IpaDownloader       string `json:"baremetalIpaDownloader"`
-	MachineOsDownloader string `json:"baremetalMachineOsDownloader"`
-	StaticIpManager     string `json:"baremetalStaticIpManager"`
-	IronicAgent         string `json:"baremetalIronicAgent"`
+	BaremetalOperator            string `json:"baremetalOperator"`
+	Ironic                       string `json:"baremetalIronic"`
+	IpaDownloader                string `json:"baremetalIpaDownloader"`
+	MachineOsDownloader          string `json:"baremetalMachineOsDownloader"`
+	StaticIpManager              string `json:"baremetalStaticIpManager"`
+	IronicAgent                  string `json:"baremetalIronicAgent"`
+	ImageCustomizationController string `json:"imageCustomizationController"`
 }
 
 func GetContainerImages(containerImages *Images, imagesFilePath string) error {

--- a/provisioning/container_images_test.go
+++ b/provisioning/container_images_test.go
@@ -5,12 +5,14 @@ import (
 )
 
 var (
-	TestImagesFile                = "sample_images.json"
-	expectedBaremetalOperator     = "registry.ci.openshift.org/openshift:baremetal-operator"
-	expectedIronic                = "registry.ci.openshift.org/openshift:ironic"
-	expectedIronicIpaDownloader   = "registry.ci.openshift.org/openshift:ironic-ipa-downloader"
-	expectedMachineOsDownloader   = "registry.ci.openshift.org/openshift:ironic-machine-os-downloader"
-	expectedIronicStaticIpManager = "registry.ci.openshift.org/openshift:ironic-static-ip-manager"
+	TestImagesFile                       = "sample_images.json"
+	expectedBaremetalOperator            = "registry.ci.openshift.org/openshift:baremetal-operator"
+	expectedIronic                       = "registry.ci.openshift.org/openshift:ironic"
+	expectedIronicIpaDownloader          = "registry.ci.openshift.org/openshift:ironic-ipa-downloader"
+	expectedMachineOsDownloader          = "registry.ci.openshift.org/openshift:ironic-machine-os-downloader"
+	expectedIronicStaticIpManager        = "registry.ci.openshift.org/openshift:ironic-static-ip-manager"
+	expectedIronicAgent                  = "registry.ci.openshift.org/openshift:ironic-agent"
+	expectedImageCustomizationController = "registry.ci.openshift.org/openshift:image-customization-controller"
 )
 
 func TestGetContainerImages(t *testing.T) {
@@ -46,7 +48,9 @@ func TestGetContainerImages(t *testing.T) {
 					containerImages.Ironic != expectedIronic ||
 					containerImages.IpaDownloader != expectedIronicIpaDownloader ||
 					containerImages.MachineOsDownloader != expectedMachineOsDownloader ||
-					containerImages.StaticIpManager != expectedIronicStaticIpManager {
+					containerImages.StaticIpManager != expectedIronicStaticIpManager ||
+					containerImages.IronicAgent != expectedIronicAgent ||
+					containerImages.ImageCustomizationController != expectedImageCustomizationController {
 					t.Errorf("failed GetContainerImages. One or more Baremetal container images do not match the expected images.")
 				}
 			}

--- a/provisioning/sample_images.json
+++ b/provisioning/sample_images.json
@@ -5,5 +5,6 @@
   "baremetalIpaDownloader": "registry.ci.openshift.org/openshift:ironic-ipa-downloader",
   "baremetalMachineOsDownloader": "registry.ci.openshift.org/openshift:ironic-machine-os-downloader",
   "baremetalStaticIpManager": "registry.ci.openshift.org/openshift:ironic-static-ip-manager",
-  "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent"
+  "baremetalIronicAgent": "registry.ci.openshift.org/openshift:ironic-agent",
+  "imageCustomizationController": "registry.ci.openshift.org/openshift:image-customization-controller"
 }


### PR DESCRIPTION
The image-customization-controller will not be added to the release payload until it is referenced in the images configmap of CBO. (Or alternatively has the label `io.openshift.release.operator=true` applied.)

This patch is part of #208, but we want the installer change https://github.com/openshift/installer/pull/5425 to land first. It cannot do so unless the image-customization-controller is in the release payload.

We have successfully built an image in OSBS:
```
ose-image-customization-controller-container-v4.10.0-202112102123.p0.gfaf44b3.assembly.stream successfully tagged into rhaos-4.10-rhel-8-candidate by osbs
```