### PR TITLE
Bug 2011824: Fix CO message when Provisioning CR is not present

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -52,7 +52,7 @@ const (
 	ReasonResourceNotFound StatusReason = "ResourceNotFound"
 
 	// ReasonProvisioningCRNotFound indicates that the provsioning CR is not found
-	ReasonProvisioningCRNotFound StatusReason = "ProvisioningCRNotFound"
+	ReasonProvisioningCRNotFound StatusReason = "WaitingForProvisioningCR"
 
 	// ReasonUnsupported is an unsupported StatusReason
 	ReasonUnsupported StatusReason = "UnsupportedPlatform"

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -50,8 +50,11 @@ const (
 	// ReasonDeploymentCrashLooping indicates that the deployment is crashlooping
 	ReasonDeploymentCrashLooping StatusReason = "DeploymentCrashLooping"
 
-	// ReasonNotFound indicates that the deployment is not found
-	ReasonNotFound StatusReason = "ResourceNotFound"
+	// ReasonResourceNotFound indicates that the deployment is not found
+	ReasonResourceNotFound StatusReason = "ResourceNotFound"
+
+	// ReasonProvisioningCRNotFound indicates that the provsioning CR is not found
+	ReasonProvisioningCRNotFound StatusReason = "ProvisioningCRNotFound"
 
 	// ReasonUnsupported is an unsupported StatusReason
 	ReasonUnsupported StatusReason = "UnsupportedPlatform"
@@ -213,10 +216,10 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	case ReasonSyncing:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))
-	case ReasonComplete:
+	case ReasonComplete, ReasonProvisioningCRNotFound:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(newReason), progressMsg))
-	case ReasonInvalidConfiguration, ReasonDeployTimedOut, ReasonNotFound:
+	case ReasonInvalidConfiguration, ReasonDeployTimedOut, ReasonResourceNotFound:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osconfigv1 "github.com/openshift/api/config/v1"
@@ -157,15 +155,6 @@ func TestEnsureClusterOperator(t *testing.T) {
 						"include.release.openshift.io/self-managed-high-availability": "true",
 						"include.release.openshift.io/single-node-developer":          "true",
 					},
-					OwnerReferences: []v1.OwnerReference{
-						{
-							APIVersion:         "metal3.io/v1alpha1",
-							Kind:               "Provisioning",
-							Name:               "provisioning-configuration",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
-						},
-					},
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
 					Conditions:     defaultConditions,
@@ -195,15 +184,6 @@ func TestEnsureClusterOperator(t *testing.T) {
 						"include.release.openshift.io/self-managed-high-availability": "true",
 						"include.release.openshift.io/single-node-developer":          "true",
 					},
-					OwnerReferences: []v1.OwnerReference{
-						{
-							APIVersion:         "metal3.io/v1alpha1",
-							Kind:               "Provisioning",
-							Name:               "provisioning-configuration",
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
-						},
-					},
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
 					Conditions:     conditions,
@@ -225,15 +205,7 @@ func TestEnsureClusterOperator(t *testing.T) {
 			reconciler.OSClient = osClient
 			reconciler.ReleaseVersion = "test-version"
 
-			err := reconciler.ensureClusterOperator(&metal3iov1alpha1.Provisioning{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Provisioning",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: metal3iov1alpha1.ProvisioningSingletonName,
-				},
-			})
+			err := reconciler.ensureClusterOperator()
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -190,7 +190,9 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Provisioning configuration not available at this time.
 		// Cannot proceed wtih metal3 deployment.
 		klog.Info("Provisioning CR not found")
-		return result, nil
+		return result, errors.Wrapf(
+			r.updateCOStatus(ReasonProvisioningCRNotFound, "Provisioning CR not found", ""),
+			"unable to put %q ClusterOperator in Available state", clusterOperatorName)
 	}
 
 	// Make sure ClusterOperator's ownership is updated
@@ -234,7 +236,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	if deleted {
 		return result, errors.Wrapf(
-			r.updateCOStatus(ReasonComplete, "all Metal3 resources deleted", ""),
+			r.updateCOStatus(ReasonResourceNotFound, "all Metal3 resources deleted", ""),
 			"unable to put %q ClusterOperator in Available state", clusterOperatorName)
 	}
 
@@ -287,7 +289,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Determine the status of the deployment
 	deploymentState, err := provisioning.GetDeploymentState(r.KubeClient.AppsV1(), ComponentNamespace, baremetalConfig)
 	if err != nil {
-		err = r.updateCOStatus(ReasonNotFound, "metal3 deployment inaccessible", "")
+		err = r.updateCOStatus(ReasonResourceNotFound, "metal3 deployment inaccessible", "")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %w", clusterOperatorName, err)
 		}
@@ -303,7 +305,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Determine the status of the DaemonSet
 	daemonSetState, err := provisioning.GetDaemonSetState(r.KubeClient.AppsV1(), ComponentNamespace, baremetalConfig)
 	if err != nil {
-		err = r.updateCOStatus(ReasonNotFound, "metal3 image cache daemonset inaccessible", "")
+		err = r.updateCOStatus(ReasonResourceNotFound, "metal3 image cache daemonset inaccessible", "")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %w", clusterOperatorName, err)
 		}
@@ -497,7 +499,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if enabled {
 		baremetalConfig, err := r.readProvisioningCR(context.Background())
 		if err != nil || baremetalConfig == nil {
-			err = r.updateCOStatus(ReasonComplete, "Provisioning CR not found on BareMetal Platform; marking operator as available", "")
+			err = r.updateCOStatus(ReasonProvisioningCRNotFound, "Provisioning CR not found on BareMetal Platform", "")
 			if err != nil {
 				return fmt.Errorf("unable to put %q ClusterOperator in Available state: %w", clusterOperatorName, err)
 			}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -191,7 +191,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Cannot proceed wtih metal3 deployment.
 		klog.Info("Provisioning CR not found")
 		return result, errors.Wrapf(
-			r.updateCOStatus(ReasonProvisioningCRNotFound, "Provisioning CR not found", ""),
+			r.updateCOStatus(ReasonProvisioningCRNotFound, "Waiting for Provisioning CR", ""),
 			"unable to put %q ClusterOperator in Available state", clusterOperatorName)
 	}
 
@@ -493,7 +493,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if enabled {
 		baremetalConfig, err := r.readProvisioningCR(context.Background())
 		if err != nil || baremetalConfig == nil {
-			err = r.updateCOStatus(ReasonProvisioningCRNotFound, "Provisioning CR not found on BareMetal Platform", "")
+			err = r.updateCOStatus(ReasonProvisioningCRNotFound, "Waiting for Provisioning CR on BareMetal Platform", "")
 			if err != nil {
 				return fmt.Errorf("unable to put %q ClusterOperator in Available state: %w", clusterOperatorName, err)
 			}

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -153,7 +153,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Make sure ClusterOperator exists
-	err := r.ensureClusterOperator(nil)
+	err := r.ensureClusterOperator()
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -193,12 +193,6 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return result, errors.Wrapf(
 			r.updateCOStatus(ReasonProvisioningCRNotFound, "Provisioning CR not found", ""),
 			"unable to put %q ClusterOperator in Available state", clusterOperatorName)
-	}
-
-	// Make sure ClusterOperator's ownership is updated
-	err = r.ensureClusterOperator(baremetalConfig)
-	if err != nil {
-		return ctrl.Result{}, err
 	}
 
 	// Read container images from Config Map
@@ -464,7 +458,7 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 // SetupWithManager configures the manager to run the controller
 func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
-	err := r.ensureClusterOperator(nil)
+	err := r.ensureClusterOperator()
 	if err != nil {
 		return errors.Wrap(err, "unable to set get baremetal ClusterOperator")
 	}


### PR DESCRIPTION
This is a backport of https://github.com/openshift/cluster-baremetal-operator/pull/191 and https://github.com/openshift/cluster-baremetal-operator/pull/214 that together improved the CO handling especially the status reported when the Provisioning CR is not present.