### PR TITLE
Bug 2035239: Add pod listing permission to extract pod host IP

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,6 +30,13 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -87,6 +87,7 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;list;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;get
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metal3.io,resources=provisionings;provisionings/finalizers,verbs=get;list;watch;create;update;patch;delete

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -85,6 +85,13 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations


### PR DESCRIPTION
To extract pod's host IP address, CBO tries to list pods in here https://github.com/openshift/cluster-baremetal-operator/blob/b7bba707a8d6c3a3e6b63dc75afdf93ec60183a1/provisioning/baremetal_pod.go#L1071

However, CBO does not have allowance to list pods. This PR adds this.