### PR TITLE
Bug 2036848: Delete Metal3 ValidatingWebhookConfiguration when CBO starts

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -1059,8 +1059,8 @@ func getDeploymentCondition(deployment *appsv1.Deployment) appsv1.DeploymentCond
 	return appsv1.DeploymentProgressing
 }
 
-// Provide the current state of metal3 deployment
-func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DeploymentConditionType, error) {
+// GetDeploymentState provides the current state of metal3 deployment
+func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace string) (appsv1.DeploymentConditionType, error) {
 	existing, err := client.Deployments(targetNamespace).Get(context.Background(), baremetalDeploymentName, metav1.GetOptions{})
 	if err != nil || existing == nil {
 		// There were errors accessing the deployment.

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -23,8 +23,6 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
-
-	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 )
 
 const (
@@ -287,8 +285,8 @@ func EnsureImageCache(info *ProvisioningInfo) (updated bool, err error) {
 	return
 }
 
-// Provide the current state of metal3 image-cache daemonset
-func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DaemonSetConditionType, error) {
+// GetDaemonSetState provides the current state of metal3 image-cache daemonset
+func GetDaemonSetState(client appsclientv1.DaemonSetsGetter, targetNamespace string) (appsv1.DaemonSetConditionType, error) {
 	existing, err := client.DaemonSets(targetNamespace).Get(context.Background(), imageCacheService, metav1.GetOptions{})
 	if err != nil || existing == nil {
 		// There were errors accessing the deployment.


### PR DESCRIPTION
When Metal3 pods are rolled out in upgrade, Metal3 ValidatingWebhookConfiguration remains
and becomes stale. API Server continues to ping ValidatingWebhook API and expects it's healthy and
expectedly it becomes degraded.

This PR also deletes ValidatingWebhookConfiguration and it's dependent Service resource to better
align with the API Server webhook check.