### PR TITLE
 Bug 2038272: Create image-customization-controller when metal3 Pod not up

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -1098,11 +1098,16 @@ func getPodHostIP(podClient coreclientv1.PodsGetter, targetNamespace string) (st
 		return "", err
 	}
 
-	// We expect only one pod with the above LabelSelector
-	if len(podList.Items) != 1 {
-		return "", fmt.Errorf("there should be only one pod listed for the given label")
+	var hostIP string
+	switch len(podList.Items) {
+	case 0:
+		// Ironic IP not available yet, just return an empty string
+	case 1:
+		hostIP = podList.Items[0].Status.HostIP
+	default:
+		// We expect only one pod with the above LabelSelector
+		err = fmt.Errorf("there should be only one pod listed for the given label")
 	}
 
-	hostIP := podList.Items[0].Status.HostIP
 	return hostIP, err
 }

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -227,12 +227,6 @@ func getIronicIP(info *ProvisioningInfo) (string, error) {
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		return config.ProvisioningIP, nil
 	} else {
-		// Couple of things can go wrong here:
-		// 1. err != nil could be caused when Pod.List() and hence getPodHostIP() fails due to a temporary
-		// glitch (like a dropped network connection). So, report the error and try again.
-		// 2. hostIP == "" can happen when the metal3 pod is still coming up. The image-customization-controller
-		// has been updated to accept hostIP as ""
-
 		return getPodHostIP(info.Client.CoreV1(), info.Namespace)
 	}
 }


### PR DESCRIPTION
Even if there is no metal3 Pod up and therefore we cannot find its IP
address, we still want to create the image-customization-controller with
an empty ironic IP address.

This is documented in a comment at the site where getPodHostIP() is
called, but not in the implementation, so it was inadvertently broken
by #225.