### PR TITLE
Bug 2034527: Pass IP options to installed CoreOS image

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -316,7 +316,7 @@ func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 	return injectProxyAndCA(initContainers, info.Proxy)
 }
 
-func ipOptionForMachineOsDownloader(info *ProvisioningInfo) string {
+func ipOptionForExternal(info *ProvisioningInfo) string {
 	var optionValue string
 	switch info.NetworkStack {
 	case NetworkStackV4:
@@ -334,7 +334,7 @@ func ipOptionForProvisioning(info *ProvisioningInfo) string {
 	ip := net.ParseIP(info.ProvConfig.Spec.ProvisioningIP)
 	if info.ProvConfig.Spec.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkDisabled || ip == nil {
 		// It ProvisioningNetworkDisabled or no valid IP to check, fallback to the external network
-		return ipOptionForMachineOsDownloader(info)
+		return ipOptionForExternal(info)
 	}
 	if ip.To4() != nil {
 		optionValue = "ip=dhcp"
@@ -343,6 +343,7 @@ func ipOptionForProvisioning(info *ProvisioningInfo) string {
 	}
 	return optionValue
 }
+
 func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs string, useLiveImages, setIpOptions bool) corev1.Container {
 	var command string
 	name := "metal3-machine-os-downloader"
@@ -363,7 +364,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 		env = append(env,
 			corev1.EnvVar{
 				Name:  ipOptions,
-				Value: ipOptionForMachineOsDownloader(info),
+				Value: ipOptionForExternal(info),
 			})
 	}
 	initContainer := corev1.Container{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -479,7 +479,7 @@ func TestProxyAndCAInjection(t *testing.T) {
 	}
 }
 
-func TestIPOptionForMachineOsDownloader(t *testing.T) {
+func TestIPOptionForExternal(t *testing.T) {
 	tests := []struct {
 		ns   NetworkStackType
 		want string
@@ -499,8 +499,8 @@ func TestIPOptionForMachineOsDownloader(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
-			if got := ipOptionForMachineOsDownloader(&ProvisioningInfo{NetworkStack: tt.ns}); got != tt.want {
-				t.Errorf("ipOptionForMachineOsDownloader() = %v, want %v", got, tt.want)
+			if got := ipOptionForExternal(&ProvisioningInfo{NetworkStack: tt.ns}); got != tt.want {
+				t.Errorf("ipOptionForExternal() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -123,6 +123,10 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 				Name:  containerRegistriesEnvVar,
 				Value: containerRegistriesConfPath,
 			},
+			{
+				Name:  ipOptions,
+				Value: ipOptionForExternal(info),
+			},
 			buildSSHKeyEnvVar(info.SSHKey),
 			pullSecret,
 		},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -6,7 +6,7 @@ import (
 )
 
 func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages string, dest corev1.VolumeMount, destPath string) corev1.Container {
-	ipOptionValue := ipOptionForMachineOsDownloader(info)
+	ipOptionValue := ipOptionForExternal(info)
 	if !info.ProvConfig.Spec.VirtualMediaViaExternalNetwork {
 		ipOptionValue = ipOptionForProvisioning(info)
 	}

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -6,6 +6,11 @@ import (
 )
 
 func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages string, dest corev1.VolumeMount, destPath string) corev1.Container {
+	ipOptionValue := ipOptionForMachineOsDownloader(info)
+	if !info.ProvConfig.Spec.VirtualMediaViaExternalNetwork {
+		ipOptionValue = ipOptionForProvisioning(info)
+	}
+
 	container := corev1.Container{
 		Name:    "machine-os-images",
 		Image:   info.Images.MachineOSImages,
@@ -17,7 +22,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 		Env: []corev1.EnvVar{
 			{
 				Name:  ipOptions,
-				Value: ipOptionForMachineOsDownloader(info),
+				Value: ipOptionValue,
 			},
 		},
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
The installed CoreOS that is written to disk needs IP options set such that it can contact the MCO over the external network to obtain the Ignition file for the Machine.
These options may be different from the ones needed for pre-provisioning, when IPA has to contact ironic, usually over the provisioning network.

Pass the option to the image-customization-controller, so it can build it into the IPA ignition (in https://github.com/openshift/image-customization-controller/pull/31)