### PR TITLE
Bug 2040671: Pass ip=dhcp,dhcp6 for dual-stack

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -324,7 +324,7 @@ func ipOptionForExternal(info *ProvisioningInfo) string {
 	case NetworkStackV6:
 		optionValue = "ip=dhcp6"
 	case NetworkStackDual:
-		optionValue = ""
+		optionValue = "ip=dhcp,dhcp6"
 	}
 	return optionValue
 }

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -494,7 +494,7 @@ func TestIPOptionForExternal(t *testing.T) {
 		},
 		{
 			ns:   NetworkStackDual,
-			want: "",
+			want: "ip=dhcp,dhcp6",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Ensure that on the external interface, we wait for both IPv4 and IPv6
addresses on dual-stack deployments.