### PR TITLE
Bug 2045927: Add proxy for image-customization-controller

### DIFF
--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -83,6 +83,7 @@ func getUrlFromIP(ipAddr string) string {
 }
 
 func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIP string) corev1.Container {
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{})
 	container := corev1.Container{
 		Name:  "image-customization-controller",
 		Image: images.ImageCustomizationController,
@@ -102,34 +103,32 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 			imageVolumeMount,
 		},
 		ImagePullPolicy: "IfNotPresent",
-		Env: []corev1.EnvVar{
-			{
-				Name:  deployISOEnvVar,
-				Value: deployISOFile,
-			},
-			{
+		Env: append(envVars, corev1.EnvVar{
+			Name:  deployISOEnvVar,
+			Value: deployISOFile,
+		},
+			corev1.EnvVar{
 				Name:  deployInitrdEnvVar,
 				Value: deployInitrdFile,
 			},
-			{
+			corev1.EnvVar{
 				Name:  ironicBaseUrl,
 				Value: getUrlFromIP(ironicIP),
 			},
-			{
+			corev1.EnvVar{
 				Name:  ironicAgentImage,
 				Value: images.IronicAgent,
 			},
-			{
+			corev1.EnvVar{
 				Name:  containerRegistriesEnvVar,
 				Value: containerRegistriesConfPath,
 			},
-			{
+			corev1.EnvVar{
 				Name:  ipOptions,
 				Value: ipOptionForExternal(info),
 			},
 			buildSSHKeyEnvVar(info.SSHKey),
-			pullSecret,
-		},
+			pullSecret),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "http",


### PR DESCRIPTION
Pass the proxy when starting the image-customization-controller container.
Avoid the issue that ironic agent image cannot be downloaded due to network proxy.

See https://github.com/openshift/installer/issues/5552 for details.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>