### PR TITLE
Extract functions for ZTP integration

### DIFF
--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -456,30 +456,3 @@ func TestProxyAndCAInjection(t *testing.T) {
 		})
 	}
 }
-
-func TestIPOptionForExternal(t *testing.T) {
-	tests := []struct {
-		ns   NetworkStackType
-		want string
-	}{
-		{
-			ns:   NetworkStackV4,
-			want: "ip=dhcp",
-		},
-		{
-			ns:   NetworkStackV6,
-			want: "ip=dhcp6",
-		},
-		{
-			ns:   NetworkStackDual,
-			want: "ip=dhcp,dhcp6",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			if got := ipOptionForExternal(&ProvisioningInfo{NetworkStack: tt.ns}); got != tt.want {
-				t.Errorf("ipOptionForExternal() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -6,9 +6,9 @@ import (
 )
 
 func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages string, dest corev1.VolumeMount, destPath string) corev1.Container {
-	ipOptionValue := ipOptionForExternal(info)
+	ipOptionValue := info.NetworkStack.IpOption()
 	if !info.ProvConfig.Spec.VirtualMediaViaExternalNetwork {
-		ipOptionValue = ipOptionForProvisioning(info)
+		ipOptionValue = IpOptionForProvisioning(&info.ProvConfig.Spec, info.NetworkStack)
 	}
 
 	container := corev1.Container{

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -17,6 +17,19 @@ const (
 	NetworkStackDual NetworkStackType = (NetworkStackV4 | NetworkStackV6)
 )
 
+func (ns NetworkStackType) IpOption() string {
+	switch ns {
+	case NetworkStackV4:
+		return "ip=dhcp"
+	case NetworkStackV6:
+		return "ip=dhcp6"
+	case NetworkStackDual:
+		return "ip=dhcp,dhcp6"
+	default:
+		return ""
+	}
+}
+
 type ProvisioningInfo struct {
 	Client                  kubernetes.Interface
 	EventRecorder           events.Recorder

--- a/provisioning/provisioning_info_test.go
+++ b/provisioning/provisioning_info_test.go
@@ -1,0 +1,32 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkStackIpOption(t *testing.T) {
+	tests := []struct {
+		ns   NetworkStackType
+		want string
+	}{
+		{
+			ns:   NetworkStackV4,
+			want: "ip=dhcp",
+		},
+		{
+			ns:   NetworkStackV6,
+			want: "ip=dhcp6",
+		},
+		{
+			ns:   NetworkStackDual,
+			want: "ip=dhcp,dhcp6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.ns.IpOption())
+		})
+	}
+}

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -1,0 +1,71 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func getPodHostIP(podClient coreclientv1.PodsGetter, targetNamespace string) (string, error) {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"k8s-app":    metal3AppName,
+			cboLabelName: stateService,
+		}}
+
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return "", err
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: selector.String(),
+	}
+
+	podList, err := podClient.Pods(targetNamespace).List(context.Background(), listOptions)
+	if err != nil {
+		return "", err
+	}
+
+	var hostIP string
+	switch len(podList.Items) {
+	case 0:
+		// Ironic IP not available yet, just return an empty string
+	case 1:
+		hostIP = podList.Items[0].Status.HostIP
+	default:
+		// We expect only one pod with the above LabelSelector
+		err = fmt.Errorf("there should be only one pod listed for the given label")
+	}
+
+	return hostIP, err
+}
+
+func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec) (string, error) {
+	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+		return config.ProvisioningIP, nil
+	} else {
+		return getPodHostIP(client.CoreV1(), targetNamespace)
+	}
+}
+
+func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkStack NetworkStackType) string {
+	var optionValue string
+	ip := net.ParseIP(config.ProvisioningIP)
+	if config.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkDisabled || ip == nil {
+		// It ProvisioningNetworkDisabled or no valid IP to check, fallback to the external network
+		return networkStack.IpOption()
+	}
+	if ip.To4() != nil {
+		optionValue = "ip=dhcp"
+	} else {
+		optionValue = "ip=dhcp6"
+	}
+	return optionValue
+}


### PR DESCRIPTION
To start an agent image, the assisted service needs to know the Ironic
URL and kernel parameters. This change makes the corresponding functions
public, moves them to a new utils.go and detaches from ProvisioningInfo.
