### PR TITLE
Bug 2084215: Add baremetal prefix to kube-rbac-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ manifests: generate
 	# manifests needed for monitoring
 	mv $(TMP_DIR)/monitoring.coreos.com_v1_servicemonitor_cluster-baremetal-operator-servicemonitor.yaml manifests/0000_90_cluster-baremetal-operator_03_servicemonitor.yaml
 	mv $(TMP_DIR)/v1_service_cluster-baremetal-operator-service.yaml manifests/0000_31_cluster-baremetal-operator_03_service.yaml
-	mv $(TMP_DIR)/v1_configmap_kube-rbac-proxy.yaml manifests/0000_31_cluster-baremetal-operator_05_kube-rbac-proxy-config.yaml
+	mv $(TMP_DIR)/v1_configmap_baremetal-kube-rbac-proxy.yaml manifests/0000_31_cluster-baremetal-operator_05_baremetal-kube-rbac-proxy-config.yaml
 
 	# manifests needed for the webhook
 	mv $(TMP_DIR)/v1_service_cluster-baremetal-webhook-service.yaml manifests/0000_31_cluster-baremetal-operator_03_webhookservice.yaml

--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -20,14 +20,14 @@ spec:
         k8s-app: cluster-baremetal-operator
     spec:
       containers:
-      - name: kube-rbac-proxy
+      - name: baremetal-kube-rbac-proxy
         image: registry.ci.openshift.org/openshift:kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://localhost:8080/"
         - "--tls-cert-file=/etc/tls/private/tls.crt"
         - "--tls-private-key-file=/etc/tls/private/tls.key"
-        - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
+        - "--config-file=/etc/baremetal-kube-rbac-proxy/config-file.yaml"
         - "--logtostderr=true"
         - "--v=10"
         ports:
@@ -40,13 +40,13 @@ spec:
             cpu: 10m
         volumeMounts:
         - name: config
-          mountPath: /etc/kube-rbac-proxy
+          mountPath: /etc/baremetal-kube-rbac-proxy
         - name: cluster-baremetal-operator-tls
           mountPath: /etc/tls/private
       volumes:
         - name: config
           configMap:
-            name: kube-rbac-proxy
+            name: baremetal-kube-rbac-proxy
             defaultMode: 420
         - name: cluster-baremetal-operator-tls
           secret:

--- a/config/prometheus/proxyconfig.yaml
+++ b/config/prometheus/proxyconfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kube-rbac-proxy
+  name: baremetal-kube-rbac-proxy
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/0000_31_cluster-baremetal-operator_05_baremetal-kube-rbac-proxy-config.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_baremetal-kube-rbac-proxy-config.yaml
@@ -13,5 +13,5 @@ metadata:
   annotations:
     capability.openshift.io/name: baremetal
     include.release.openshift.io/self-managed-high-availability: "true"
-  name: kube-rbac-proxy
+  name: baremetal-kube-rbac-proxy
   namespace: openshift-machine-api

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -60,11 +60,11 @@ spec:
         - --upstream=http://localhost:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --config-file=/etc/baremetal-kube-rbac-proxy/config-file.yaml
         - --logtostderr=true
         - --v=10
         image: registry.ci.openshift.org/openshift:kube-rbac-proxy
-        name: kube-rbac-proxy
+        name: baremetal-kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
@@ -74,7 +74,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         volumeMounts:
-        - mountPath: /etc/kube-rbac-proxy
+        - mountPath: /etc/baremetal-kube-rbac-proxy
           name: config
         - mountPath: /etc/tls/private
           name: cluster-baremetal-operator-tls
@@ -105,7 +105,7 @@ spec:
           secretName: cluster-baremetal-webhook-server-cert
       - configMap:
           defaultMode: 420
-          name: kube-rbac-proxy
+          name: baremetal-kube-rbac-proxy
         name: config
       - name: cluster-baremetal-operator-tls
         secret:


### PR DESCRIPTION
The MAO already supplies a resource called `kube-rbac-proxy`, so we want
ours to be unique.