### PR TITLE
METAL-157: Don't run image cache unless required

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -297,8 +297,13 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %w", clusterOperatorName, err)
 		}
 	}
-	if deploymentState == appsv1.DeploymentAvailable && daemonSetState == provisioning.DaemonSetAvailable {
-		err = r.updateCOStatus(ReasonComplete, "metal3 pod and image cache are running", "")
+	if deploymentState == appsv1.DeploymentAvailable {
+		if daemonSetState == provisioning.DaemonSetAvailable {
+			err = r.updateCOStatus(ReasonComplete, "metal3 pod and image cache are running", "")
+		} else if daemonSetState == provisioning.DaemonSetDisabled {
+			err = r.updateCOStatus(ReasonComplete, "metal3 pod is running", "")
+		}
+
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Progressing state: %w", clusterOperatorName, err)
 		}

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -77,7 +77,8 @@ func getProvisioningIPCIDR(config *metal3iov1alpha1.ProvisioningSpec) *string {
 }
 
 func getDeployKernelUrl() *string {
-	deployKernelUrl := fmt.Sprintf("http://localhost:%d/%s", imageCachePort, baremetalKernelUrlSubPath)
+	// TODO(dtantsur): it's a share file system, we should look into using a file:// URL
+	deployKernelUrl := fmt.Sprintf("http://localhost:%s/%s", baremetalHttpPort, baremetalKernelUrlSubPath)
 	return &deployKernelUrl
 }
 

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -48,13 +48,13 @@ func TestGetMetal3DeploymentConfig(t *testing.T) {
 			name:          "Unmanaged DeployKernelUrl",
 			configName:    deployKernelUrl,
 			spec:          unmanagedProvisioning().build(),
-			expectedValue: "http://localhost:6181/images/ironic-python-agent.kernel",
+			expectedValue: "http://localhost:6180/images/ironic-python-agent.kernel",
 		},
 		{
 			name:          "Disabled DeployKernelUrl",
 			configName:    deployKernelUrl,
 			spec:          disabledProvisioning().build(),
-			expectedValue: "http://localhost:6181/images/ironic-python-agent.kernel",
+			expectedValue: "http://localhost:6180/images/ironic-python-agent.kernel",
 		},
 		{
 			name:          "Disabled IronicEndpoint",

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -207,7 +207,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
-				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6181/images/ironic-python-agent.kernel"},
+				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6180/images/ironic-python-agent.kernel"},
 				{Name: "IRONIC_ENDPOINT", Value: "https://localhost:6385/v1/"},
 				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: "https://localhost:5050/v1/"},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
 )
 
 func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages string, dest corev1.VolumeMount, destPath string) corev1.Container {
@@ -30,6 +31,9 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 				corev1.ResourceCPU:    resource.MustParse("5m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: pointer.BoolPtr(true),
 		},
 	}
 	return container


### PR DESCRIPTION
* Move the machine-os-images init container from cache to ICC
* Disable the cache if ProvisioningOSDownloadURL is empty
* Do not report cache state if it is disabled
