### PR TITLE
OCPBUGS-1844: enable DNS in the provisioning dnsmasq

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ installation. If using metal3 for power management, BMCs must be
 accessible from the machine networks. User should provide two IPs on
 the external network that would be used for provisioning services.
 
+- ProvisioningDNS allows sending the DNS information via DHCP on the
+provisionig network. It is off by default since the Provisioning
+service itself (Ironic) does not require DNS, but it may be useful
+for layered products (e.g. ZTP).
+
 - WatchAllNamespaces provides a way to explicitly allow use of this
 Provisioning configuration across all Namespaces. It is an
 optional configuration which defaults to false and in that state

--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -141,6 +141,12 @@ type ProvisioningSpec struct {
 	// the external network that would be used for provisioning services.
 	ProvisioningNetwork ProvisioningNetwork `json:"provisioningNetwork,omitempty"`
 
+	// ProvisioningDNS allows sending the DNS information via DHCP on the
+	// provisionig network. It is off by default since the Provisioning
+	// service itself (Ironic) does not require DNS, but it may be useful
+	// for layered products (e.g. ZTP).
+	ProvisioningDNS bool `json:"provisioningDNS,omitempty"`
+
 	// WatchAllNamespaces provides a way to explicitly allow use of this
 	// Provisioning configuration across all Namespaces. It is an
 	// optional configuration which defaults to false and in that state

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -102,6 +102,12 @@ spec:
                   where the 1st address represents the start of the range and the
                   2nd address represents the last usable address in the  range.
                 type: string
+              provisioningDNS:
+                description: ProvisioningDNS allows sending the DNS information via
+                  DHCP on the provisionig network. It is off by default since the
+                  Provisioning service itself (Ironic) does not require DNS, but it
+                  may be useful for layered products (e.g. ZTP).
+                type: boolean
               provisioningIP:
                 description: ProvisioningIP is the IP address assigned to the provisioningInterface
                   of the baremetal server. This IP address should be within the provisioning

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -103,6 +103,12 @@ spec:
                   where the 1st address represents the start of the range and the
                   2nd address represents the last usable address in the  range.
                 type: string
+              provisioningDNS:
+                description: ProvisioningDNS allows sending the DNS information via
+                  DHCP on the provisionig network. It is off by default since the
+                  Provisioning service itself (Ironic) does not require DNS, but it
+                  may be useful for layered products (e.g. ZTP).
+                type: boolean
               provisioningIP:
                 description: ProvisioningIP is the IP address assigned to the provisioningInterface
                   of the baremetal server. This IP address should be within the provisioning

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -41,11 +41,13 @@ var (
 	ironicInspectorEndpoint        = "IRONIC_INSPECTOR_ENDPOINT"
 	httpPort                       = "HTTP_PORT"
 	vmediaHttpsPort                = "VMEDIA_TLS_PORT"
+	dnsIP                          = "DNS_IP"
 	dhcpRange                      = "DHCP_RANGE"
 	machineImageUrl                = "RHCOS_IMAGE_URL"
 	ipOptions                      = "IP_OPTIONS"
 	bootIsoSource                  = "IRONIC_BOOT_ISO_SOURCE"
 	useUnixSocket                  = "unix"
+	useProvisioningDNS             = "provisioning"
 )
 
 func getDHCPRange(config *metal3iov1alpha1.ProvisioningSpec) *string {

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -232,6 +232,11 @@ func (pb *provisioningBuilder) ProvisioningOSDownloadURL(value string) *provisio
 	return pb
 }
 
+func (pb *provisioningBuilder) ProvisioningDNS(value bool) *provisioningBuilder {
+	pb.ProvisioningSpec.ProvisioningDNS = value
+	return pb
+}
+
 func enableMultiNamespace() *provisioningBuilder {
 	return &provisioningBuilder{
 		metal3iov1alpha1.ProvisioningSpec{

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -533,6 +533,18 @@ func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images 
 }
 
 func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
+	envVars := []corev1.EnvVar{
+		buildEnvVar(httpPort, config),
+		buildEnvVar(provisioningInterface, config),
+		buildEnvVar(dhcpRange, config),
+		buildEnvVar(provisioningMacAddresses, config),
+	}
+	if config.ProvisioningDNS {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  dnsIP,
+			Value: useProvisioningDNS,
+		})
+	}
 	container := corev1.Container{
 		Name:            "metal3-dnsmasq",
 		Image:           images.Ironic,
@@ -545,12 +557,7 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 			sharedVolumeMount,
 			imageVolumeMount,
 		},
-		Env: []corev1.EnvVar{
-			buildEnvVar(httpPort, config),
-			buildEnvVar(provisioningInterface, config),
-			buildEnvVar(dhcpRange, config),
-			buildEnvVar(provisioningMacAddresses, config),
-		},
+		Env: envVars,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("5m"),

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -336,6 +336,23 @@ func TestNewMetal3Containers(t *testing.T) {
 			sshkey: "sshkey",
 		},
 		{
+			name:   "ManagedSpec with DNS",
+			config: managedProvisioning().ProvisioningDNS(true).build(),
+			expectedContainers: []corev1.Container{
+				containers["metal3-baremetal-operator"],
+				withEnv(containers["metal3-httpd"], sshkey),
+				withEnv(containers["metal3-ironic"], sshkey),
+				containers["metal3-ramdisk-logs"],
+				containers["metal3-ironic-inspector"],
+				containers["metal3-static-ip-manager"],
+				withEnv(
+					containers["metal3-dnsmasq"],
+					envWithValue("DNS_IP", "provisioning"),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
 			name:   "ManagedSpec with virtualmedia",
 			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
 			expectedContainers: []corev1.Container{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -298,9 +298,13 @@ func TestNewMetal3Containers(t *testing.T) {
 			override, haveOverride := newMap[existing.Name]
 			if haveOverride {
 				new = append(new, override)
+				delete(newMap, existing.Name)
 			} else {
 				new = append(new, existing)
 			}
+		}
+		for _, value := range newMap {
+			new = append(new, value)
 		}
 		c.Env = new
 		return c
@@ -335,7 +339,11 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "ManagedSpec with virtualmedia",
 			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
 			expectedContainers: []corev1.Container{
-				withEnv(containers["metal3-baremetal-operator"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"), envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183")),
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
 				withEnv(containers["metal3-httpd"], sshkey, envWithValue("IRONIC_LISTEN_PORT", "6388")),
 				withEnv(containers["metal3-ironic"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP")),
 				containers["metal3-ramdisk-logs"],


### PR DESCRIPTION
In the ZTP case, we need DNS on the provisioning network, so that
the CoreOS root filesystem can be downloaded from the cluster.