### PR TITLE
OCPBUGS-4689: Do not fail the reconciler when no master Machines exist

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -518,7 +518,8 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 		return errors.Wrap(err, "cannot list master machines")
 	}
 	if len(machines.Items) < 1 {
-		return errors.New("machines with cluster-api-machine-role=master not found")
+		klog.Info("No Machines with cluster-api-machine-role=master found, set provisioningMacAddresses if the metal3 pod fails to start")
+		return nil
 	}
 
 	for _, machine := range machines.Items {


### PR DESCRIPTION
Some deployments don't have Machines or master BareMetalHosts.
Fall back to the old behavior (= not setting PROVISIONING_MACS).
