### PR TITLE
OCPBUGS-4712: delete ironic-proxy/image-cache when not needed

### DIFF
--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -279,7 +279,6 @@ func EnsureImageCache(info *ProvisioningInfo) (updated bool, err error) {
 // Provide the current state of metal3 image-cache daemonset
 func GetImageCacheState(client appsclientv1.DaemonSetsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DaemonSetConditionType, error) {
 	if config.Spec.ProvisioningOSDownloadURL == "" {
-		// TODO(dtantsur): do we need to check it's really deleted?
 		return DaemonSetDisabled, nil
 	}
 


### PR DESCRIPTION
Keeping ironic-proxy active (e.g. when switching from provisioning
network Disabled to Managed) causes a conflict with the metal3 pod.
