### PR TITLE
OCPBUGS-5181: also use BMH.ConsumerRef for linking to master Machines

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -493,21 +493,39 @@ func getHostByMachine(meta metav1.ObjectMeta) string {
 	annotations := meta.GetAnnotations()
 	annotation, ok := annotations[HostAnnotation]
 	if !ok {
-		klog.Warningf("Ignoring machine %s without annotation linking it to BareMetalHost", meta.Name)
+		klog.Warningf("Machine %s has no annotation linking it to BareMetalHost", meta.Name)
 		return ""
 	}
 
 	hostNamespace, hostName, err := cache.SplitMetaNamespaceKey(annotation)
 	if err != nil {
-		klog.Warningf("Ignoring machine %s with invalid BareMetalHost link %s", meta.Name, annotation)
+		klog.Warningf("Machine %s has an invalid BareMetalHost link %s", meta.Name, annotation)
 		return ""
 	}
 	if hostNamespace != ComponentNamespace {
-		klog.Warningf("Ignoring machine %s that is linked to a BareMetalHost in namespace %s", meta.Name, hostNamespace)
+		klog.Warningf("Machine %s is linked to a BareMetalHost in namespace %s (expected %s)", meta.Name, hostNamespace, ComponentNamespace)
 		return ""
 	}
 
 	return hostName
+}
+
+func getMachineByHost(name string, consumerRef *corev1.ObjectReference) string {
+	if consumerRef == nil || consumerRef.Name == "" {
+		return ""
+	}
+
+	if consumerRef.APIVersion != "machine.openshift.io/v1beta1" || consumerRef.Kind != "Machine" {
+		klog.Warningf("BareMetalHost %s is consumed by an object of kind %s (API %s)", name, consumerRef.Kind, consumerRef.APIVersion)
+		return ""
+	}
+
+	if consumerRef.Namespace != ComponentNamespace {
+		klog.Warningf("BareMetalHost %s is linked to a Machine in namespace %s (expected %s)", name, consumerRef.Namespace, ComponentNamespace)
+		return ""
+	}
+
+	return consumerRef.Name
 }
 
 func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Context, provConfig *metal3iov1alpha1.Provisioning) error {
@@ -526,7 +544,9 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 		return nil
 	}
 
+	masterMachineNames := []string{}
 	for _, machine := range machines.Items {
+		masterMachineNames = append(masterMachineNames, machine.Name)
 		bmhName := getHostByMachine(machine.ObjectMeta)
 		if bmhName != "" {
 			bmhNames = append(bmhNames, bmhName)
@@ -539,7 +559,8 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 		return err
 	}
 	for _, bmh := range bmhl.Items {
-		if slice.Contains(bmhNames, bmh.Name) && len(bmh.Spec.BootMACAddress) > 0 {
+		if (slice.Contains(bmhNames, bmh.Name) || slice.Contains(masterMachineNames, getMachineByHost(bmh.Name, bmh.Spec.ConsumerRef))) &&
+			len(bmh.Spec.BootMACAddress) > 0 {
 			macs = append(macs, bmh.Spec.BootMACAddress)
 		}
 	}

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -191,30 +191,61 @@ func TestUpdateProvisioningMacAddresses(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "test-master-0", Namespace: ComponentNamespace},
 			Spec: baremetalv1alpha1.BareMetalHostSpec{
 				BootMACAddress: "00:3d:25:45:bf:e5",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "machine.openshift.io/v1beta1",
+					Kind:       "Machine",
+					Name:       "node-0",
+					Namespace:  "openshift-machine-api",
+				},
 			},
 		},
 		&baremetalv1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-controlplane-1", Namespace: ComponentNamespace},
 			Spec: baremetalv1alpha1.BareMetalHostSpec{
 				BootMACAddress: "00:3d:25:45:bf:e6",
+				// No consumerRef, using the reference from the Machine
 			},
 		},
 		&baremetalv1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-master-2", Namespace: ComponentNamespace},
 			Spec: baremetalv1alpha1.BareMetalHostSpec{
 				BootMACAddress: "00:3d:25:45:bf:e7",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "machine.openshift.io/v1beta1",
+					Kind:       "Machine",
+					Name:       "node-5",
+					Namespace:  "openshift-machine-api",
+				},
 			},
 		},
 		&baremetalv1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0", Namespace: ComponentNamespace},
 			Spec: baremetalv1alpha1.BareMetalHostSpec{
 				BootMACAddress: "00:3d:25:45:bf:e8",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "machine.openshift.io/v1beta1",
+					Kind:       "Machine",
+					Name:       "node-6",
+					Namespace:  "openshift-machine-api",
+				},
 			},
 		},
 		&baremetalv1alpha1.BareMetalHost{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-worker-1", Namespace: ComponentNamespace},
 			Spec: baremetalv1alpha1.BareMetalHostSpec{
 				BootMACAddress: "00:3d:25:45:bf:e9",
+			},
+		},
+		&baremetalv1alpha1.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "something-else", Namespace: ComponentNamespace},
+			Spec: baremetalv1alpha1.BareMetalHostSpec{
+				BootMACAddress: "00:3d:25:45:bf:ea",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "machine.openshift.io/v1beta1",
+					Kind:       "Machine",
+					Name:       "not-node",
+					Namespace:  "unexpected-namespace",
+				},
 			},
 		},
 		&machinev1beta1.Machine{
@@ -252,10 +283,10 @@ func TestUpdateProvisioningMacAddresses(t *testing.T) {
 			},
 		},
 		&machinev1beta1.Machine{
+			// This machine does not have a direct reference, but there is a back reference from the BMH.
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node-5",
-				Labels:      map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"},
-				Annotations: map[string]string{"metal3.io/BareMetalHost": "openshift-machine-api/test-master-2"},
+				Name:   "node-5",
+				Labels: map[string]string{"machine.openshift.io/cluster-api-machine-role": "master"},
 			},
 		},
 		&machinev1beta1.Machine{


### PR DESCRIPTION
This is the 3rd attempt to fix the race when determining, which MAC
addresses the master nodes have.

In the 2nd attempt, we started using annotations on Machines that link
to BareMetalHosts. Apparently, it's also not rock-solid, so let's
additionally consider consumer references on BareMetalHosts.
