### PR TITLE
OCPBUGS-5461: Add ironic IP to no_proxy

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -883,7 +883,7 @@ func injectProxyAndCA(containers []corev1.Container, proxy *configv1.Proxy) []co
 	var injectedContainers []corev1.Container
 
 	for _, container := range containers {
-		container.Env = envWithProxy(proxy, container.Env)
+		container.Env = envWithProxy(proxy, container.Env, "")
 		container.VolumeMounts = mountsWithTrustedCA(container.VolumeMounts)
 		injectedContainers = append(injectedContainers, container)
 	}
@@ -891,7 +891,7 @@ func injectProxyAndCA(containers []corev1.Container, proxy *configv1.Proxy) []co
 	return injectedContainers
 }
 
-func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar) []corev1.EnvVar {
+func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string) []corev1.EnvVar {
 	if proxy == nil {
 		return envVars
 	}
@@ -908,10 +908,10 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar) []corev1.EnvVa
 			Value: proxy.Status.HTTPSProxy,
 		})
 	}
-	if proxy.Status.NoProxy != "" {
+	if proxy.Status.NoProxy != "" || noproxy != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "NO_PROXY",
-			Value: proxy.Status.NoProxy,
+			Value: proxy.Status.NoProxy + "," + noproxy,
 		})
 	}
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -512,7 +512,7 @@ func TestProxyAndCAInjection(t *testing.T) {
 			for _, container := range tc.containers {
 				assert.Contains(t, container.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "https://172.2.0.1:3128"})
 				assert.Contains(t, container.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "https://172.2.0.1:3128"})
-				assert.Contains(t, container.Env, corev1.EnvVar{Name: "NO_PROXY", Value: ".example.com"})
+				assert.Contains(t, container.Env, corev1.EnvVar{Name: "NO_PROXY", Value: ".example.com,"})
 
 				assert.Contains(t, container.VolumeMounts, corev1.VolumeMount{
 					MountPath: "/etc/pki/ca-trust/extracted/pem",

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -84,7 +84,7 @@ func getUrlFromIP(ipAddr string) string {
 }
 
 func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIP, inspectorIP string) corev1.Container {
-	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{})
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIP+","+inspectorIP)
 
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -51,7 +51,7 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 		Env: []corev1.EnvVar{
 			{Name: "HTTP_PROXY", Value: "https://172.2.0.1:3128"},
 			{Name: "HTTPS_PROXY", Value: "https://172.2.0.1:3128"},
-			{Name: "NO_PROXY", Value: ".example.com"},
+			{Name: "NO_PROXY", Value: ".example.com,192.168.0.2,192.168.0.2"},
 			{Name: "DEPLOY_ISO", Value: "/shared/html/images/ironic-python-agent.iso"},
 			{Name: "DEPLOY_INITRD", Value: "/shared/html/images/ironic-python-agent.initramfs"},
 			{Name: "IRONIC_BASE_URL", Value: "https://192.168.0.2"},


### PR DESCRIPTION
Ensure internal ironic traffic bypasses any proxies. The NO_PROXY value created in createImageCustomizationContainer is what IPA will end up using.