### PR TITLE
OCPBUGS-4248: Set external Ironic URL to ironic-proxy IP

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -26,8 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -278,34 +279,53 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 	}
 }
 
-func setIronicExternalUrl(client kubernetes.Interface, config *metal3iov1alpha1.ProvisioningSpec, namespace string) corev1.EnvVar {
-	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && config.VirtualMediaViaExternalNetwork {
-		ipv6PodIP, err := GetPodIP(client.CoreV1(), namespace, NetworkStackV6)
+func setIronicExternalUrl(info ProvisioningInfo) corev1.EnvVar {
+	// We need to set the external URL to point to the ironic-proxy when IPv6
+	// is enabled and the proxy is present
 
-		if err != nil {
-			return corev1.EnvVar{
-				Name: externalUrlEnvVar,
-			}
-		}
-
-		// protocol, host, port
-		urlTemplate := "%s://[%s]:%s"
-
-		if config.DisableVirtualMediaTLS {
-			return corev1.EnvVar{
-				Name:  externalUrlEnvVar,
-				Value: fmt.Sprintf(urlTemplate, "http", ipv6PodIP, baremetalHttpPort),
-			}
-		} else {
-			return corev1.EnvVar{
-				Name:  externalUrlEnvVar,
-				Value: fmt.Sprintf(urlTemplate, "https", ipv6PodIP, baremetalVmediaHttpsPort),
-			}
+	if !UseIronicProxy(&info.ProvConfig.Spec) {
+		return corev1.EnvVar{
+			Name: externalUrlEnvVar,
 		}
 	}
 
-	return corev1.EnvVar{
-		Name: externalUrlEnvVar,
+	ironicIPs, _, err := GetIronicIPs(info)
+
+	if err != nil {
+		klog.Errorf("Failed to get Ironic IP when setting external url: %w", err)
+		return corev1.EnvVar{
+			Name: externalUrlEnvVar,
+		}
+	}
+
+	var ironicIPv6 string
+
+	for _, ironicIP := range ironicIPs {
+		if utilnet.IsIPv6String(ironicIP) {
+			ironicIPv6 = ironicIP
+			break
+		}
+	}
+
+	if ironicIPv6 == "" {
+		return corev1.EnvVar{
+			Name: externalUrlEnvVar,
+		}
+	}
+
+	// protocol, host, port
+	urlTemplate := "%s://[%s]:%s"
+
+	if info.ProvConfig.Spec.DisableVirtualMediaTLS {
+		return corev1.EnvVar{
+			Name:  externalUrlEnvVar,
+			Value: fmt.Sprintf(urlTemplate, "http", ironicIPv6, baremetalHttpPort),
+		}
+	} else {
+		return corev1.EnvVar{
+			Name:  externalUrlEnvVar,
+			Value: fmt.Sprintf(urlTemplate, "https", ironicIPv6, baremetalVmediaHttpsPort),
+		}
 	}
 }
 
@@ -400,7 +420,7 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 
 func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 	containers := []corev1.Container{
-		createContainerMetal3BaremetalOperator(info.Client, info.Images, &info.ProvConfig.Spec, info.BaremetalWebhookEnabled, info.Namespace),
+		createContainerMetal3BaremetalOperator(*info),
 		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3Ironic(info.Images, info, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3RamdiskLogs(info.Images),
@@ -443,11 +463,11 @@ func buildSSHKeyEnvVar(sshKey string) corev1.EnvVar {
 	return corev1.EnvVar{Name: sshKeyEnvVar, Value: sshKey}
 }
 
-func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images *Images, config *metal3iov1alpha1.ProvisioningSpec, enableWebhook bool, namespace string) corev1.Container {
+func createContainerMetal3BaremetalOperator(info ProvisioningInfo) corev1.Container {
 	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
 	container := corev1.Container{
 		Name:  "metal3-baremetal-operator",
-		Image: images.BaremetalOperator,
+		Image: info.Images.BaremetalOperator,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "metrics",
@@ -470,7 +490,7 @@ func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images 
 			baremetalWebhookCertMount,
 		},
 		Env: []corev1.EnvVar{
-			getWatchNamespace(config),
+			getWatchNamespace(&info.ProvConfig.Spec),
 			{
 				Name: "POD_NAMESPACE",
 				ValueFrom: &corev1.EnvVarSource{
@@ -499,9 +519,9 @@ func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images 
 				Name:  ironicInsecureEnvVar,
 				Value: "true",
 			},
-			buildEnvVar(deployKernelUrl, config),
-			buildEnvVar(ironicEndpoint, config),
-			buildEnvVar(ironicInspectorEndpoint, config),
+			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
+			buildEnvVar(ironicEndpoint, &info.ProvConfig.Spec),
+			buildEnvVar(ironicInspectorEndpoint, &info.ProvConfig.Spec),
 			{
 				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
 				Value: "Never",
@@ -510,8 +530,8 @@ func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images 
 				Name:  "METAL3_AUTH_ROOT_DIR",
 				Value: metal3AuthRootDir,
 			},
-			setIronicExternalIp(externalIpEnvVar, config),
-			setIronicExternalUrl(client, config, namespace),
+			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
+			setIronicExternalUrl(info),
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -521,7 +541,7 @@ func createContainerMetal3BaremetalOperator(client kubernetes.Interface, images 
 		},
 	}
 
-	if !enableWebhook {
+	if !info.BaremetalWebhookEnabled {
 		// Webhook dependencies are not ready, thus we disable webhook explicitly,
 		// since default is enabled.
 		container.Args = append(container.Args, "--webhook-port", "0")

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -23,7 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	osconfigv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/config/v1"
+	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
 
 	fakekube "k8s.io/client-go/kubernetes/fake"
@@ -388,7 +390,11 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpec",
 			config: disabledProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				containers["metal3-baremetal-operator"],
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_IP", ""),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
@@ -412,7 +418,11 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpecWithoutProvisioningIP",
 			config: disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
 			expectedContainers: []corev1.Container{
-				containers["metal3-baremetal-operator"],
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_IP", ""),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
@@ -458,6 +468,27 @@ func TestNewMetal3Containers(t *testing.T) {
 							{IP: "fd2e:6f44:5dd8:c956::16"},
 						},
 					}}),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster",
+						},
+						Status: v1.InfrastructureStatus{
+							PlatformStatus: &v1.PlatformStatus{
+								Type: v1.BareMetalPlatformType,
+								BareMetal: &v1.BareMetalPlatformStatus{
+									APIServerInternalIPs: []string{
+										"192.168.1.1",
+										"fd2e:6f44:5dd8:c956::16",
+									},
+								},
+							},
+						},
+					}),
 			}
 			actualContainers := newMetal3Containers(info)
 			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -490,7 +490,10 @@ func TestNewMetal3Containers(t *testing.T) {
 						},
 					}),
 			}
-			actualContainers := newMetal3Containers(info)
+			actualContainers, err := newMetal3Containers(info)
+			if err != nil {
+				t.Errorf("Failed to get metal3 containers: %v", err)
+			}
 			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
 			for i, container := range actualContainers {
 				assert.Equal(t, tc.expectedContainers[i].Name, actualContainers[i].Name)
@@ -524,6 +527,10 @@ func TestProxyAndCAInjection(t *testing.T) {
 		},
 	}
 
+	containers, err := newMetal3Containers(info)
+	if err != nil {
+		t.Errorf("Failed to get metal3 containers: %v", err)
+	}
 	tCases := []struct {
 		name       string
 		containers []corev1.Container
@@ -534,7 +541,7 @@ func TestProxyAndCAInjection(t *testing.T) {
 		},
 		{
 			name:       "metal3 containers have proxy and CA information",
-			containers: newMetal3Containers(info),
+			containers: containers,
 		},
 	}
 	for _, tc := range tCases {

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIP, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
+	ironicIPs, inspectorIP, err := GetIronicIPs(*info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -83,8 +83,8 @@ func getUrlFromIP(ipAddr string) string {
 	}
 }
 
-func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIP, inspectorIP string) corev1.Container {
-	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIP+","+inspectorIP)
+func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIPs []string, inspectorIP string) corev1.Container {
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIPs[0]+","+inspectorIP)
 
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",
@@ -115,7 +115,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 			},
 			corev1.EnvVar{
 				Name:  ironicBaseUrl,
-				Value: getUrlFromIP(ironicIP),
+				Value: getUrlFromIP(ironicIPs[0]),
 			},
 			corev1.EnvVar{
 				Name:  ironicInspectorBaseUrl,
@@ -151,9 +151,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 	return container
 }
 
-func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIP, inspectorIP string) *corev1.PodTemplateSpec {
+func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIPs []string, inspectorIP string) *corev1.PodTemplateSpec {
 	containers := []corev1.Container{
-		createImageCustomizationContainer(info.Images, info, ironicIP, inspectorIP),
+		createImageCustomizationContainer(info.Images, info, ironicIPs, inspectorIP),
 	}
 
 	// Extract the pre-provisioning images from a container in the payload
@@ -209,7 +209,7 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 	}
 }
 
-func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspectorIP string) *appsv1.Deployment {
+func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string, inspectorIP string) *appsv1.Deployment {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"k8s-app":    metal3AppName,
@@ -220,7 +220,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspector
 		"k8s-app":    metal3AppName,
 		cboLabelName: imageCustomizationService,
 	}
-	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIP, inspectorIP)
+	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIPs, inspectorIP)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        imageCustomizationDeploymentName,
@@ -240,12 +240,12 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspector
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIP, inspectorIP, err := GetIronicIP(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
+	ironicIPs, inspectorIP, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}
 
-	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIP, inspectorIP)
+	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIPs, inspectorIP)
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(imageCustomizationDeployment, info.ProvConfig.Status.Generations)
 	err = controllerutil.SetControllerReference(info.ProvConfig, imageCustomizationDeployment, info.Scheme)
 	if err != nil {

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -106,7 +106,7 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 				NetworkStack: NetworkStackV4,
 				Proxy:        tc.proxy,
 			}
-			actualContainer := createImageCustomizationContainer(&images, info, ironicIP, tc.inspectorIP)
+			actualContainer := createImageCustomizationContainer(&images, info, []string{ironicIP}, tc.inspectorIP)
 			for e := range actualContainer.Env {
 				assert.EqualValues(t, tc.expectedContainer.Env[e], actualContainer.Env[e])
 			}

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -27,7 +27,7 @@ import (
 const (
 	ironicProxyService         = "ironic-proxy"
 	ironicPrivatePort          = 6388
-	ironicPrivatePortv6        = 6388 // TODO(honza): What should this value be?
+	ironicPrivatePortv6        = 6388
 	ironicUpstreamIPEnvVar     = "IRONIC_UPSTREAM_IP"
 	ironicUpstreamIPv6EnvVar   = "IRONIC_UPSTREAM_IP_V6"
 	ironicUpstreamPortEnvVar   = "IRONIC_UPSTREAM_PORT"
@@ -115,7 +115,7 @@ func createContainerIronicProxy(ironicIPs []string, images *Images) corev1.Conta
 }
 
 func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSpec, error) {
-	ironicIPs, _, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
+	ironicIPs, _, err := GetIronicIPs(*info)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot figure out the upstream IP for ironic proxy")
 	}

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,13 +25,66 @@ import (
 )
 
 const (
-	ironicProxyService       = "ironic-proxy"
-	ironicPrivatePort        = 6388
-	ironicUpstreamIPEnvVar   = "IRONIC_UPSTREAM_IP"
-	ironicUpstreamPortEnvVar = "IRONIC_UPSTREAM_PORT"
+	ironicProxyService         = "ironic-proxy"
+	ironicPrivatePort          = 6388
+	ironicPrivatePortv6        = 6388 // TODO(honza): What should this value be?
+	ironicUpstreamIPEnvVar     = "IRONIC_UPSTREAM_IP"
+	ironicUpstreamIPv6EnvVar   = "IRONIC_UPSTREAM_IP_V6"
+	ironicUpstreamPortEnvVar   = "IRONIC_UPSTREAM_PORT"
+	ironicUpstreamPortv6EnvVar = "IRONIC_UPSTREAM_PORT_V6"
 )
 
-func createContainerIronicProxy(ironicIP string, images *Images) corev1.Container {
+func ironicIPsToVars(ironicIPs []string) []corev1.EnvVar {
+	var vars []corev1.EnvVar
+
+	for _, ironicIP := range ironicIPs {
+		if utilnet.IsIPv4String(ironicIP) {
+			vars = append(vars, []corev1.EnvVar{
+				{
+					Name:  ironicUpstreamIPEnvVar,
+					Value: ironicIP,
+				},
+				{
+					Name:  ironicUpstreamPortEnvVar,
+					Value: fmt.Sprint(ironicPrivatePort),
+				},
+			}...)
+		} else {
+			vars = append(vars, []corev1.EnvVar{
+				{
+					Name:  ironicUpstreamIPv6EnvVar,
+					Value: ironicIP,
+				},
+				{
+					Name:  ironicUpstreamPortv6EnvVar,
+					Value: fmt.Sprint(ironicPrivatePortv6),
+				},
+			}...)
+		}
+	}
+
+	return vars
+}
+
+func createContainerIronicProxy(ironicIPs []string, images *Images) corev1.Container {
+	vars := []corev1.EnvVar{
+		{
+			Name:  httpPort,
+			Value: fmt.Sprint(baremetalIronicPort),
+		},
+		// The provisioning IP is not used except that
+		// httpd cannot start until the IP is available on some interface
+		{
+			Name: provisioningIP,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.hostIP",
+				},
+			},
+		},
+	}
+
+	vars = append(vars, ironicIPsToVars(ironicIPs)...)
 	container := corev1.Container{
 		Name:            "ironic-proxy",
 		Image:           images.Ironic,
@@ -49,30 +103,7 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 				HostPort:      int32(baremetalIronicPort),
 			},
 		},
-		Env: []corev1.EnvVar{
-			{
-				Name:  httpPort,
-				Value: fmt.Sprint(baremetalIronicPort),
-			},
-			{
-				Name:  ironicUpstreamIPEnvVar,
-				Value: ironicIP,
-			},
-			{
-				Name:  ironicUpstreamPortEnvVar,
-				Value: fmt.Sprint(ironicPrivatePort),
-			},
-			// The provisioning IP is not used except that
-			// httpd cannot start until the IP is available on some interface
-			{
-				Name: provisioningIP,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.hostIP",
-					},
-				},
-			},
-		},
+		Env: vars,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("5m"),
@@ -84,13 +115,13 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 }
 
 func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSpec, error) {
-	ironicIP, err := getPodHostIP(info.Client.CoreV1(), info.Namespace)
+	ironicIPs, _, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot figure out the upstream IP for ironic proxy")
 	}
 
 	containers := []corev1.Container{
-		createContainerIronicProxy(ironicIP, info.Images),
+		createContainerIronicProxy(ironicIPs, info.Images),
 	}
 
 	tolerations := []corev1.Toleration{

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -92,7 +92,7 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIP string, inspectorIP string, err error) {
+func GetIronicIPs(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIPs []string, inspectorIP string, err error) {
 	// Inspector does not support proxy
 
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
@@ -105,25 +105,21 @@ func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *me
 	}
 
 	if UseIronicProxy(config) {
-		var internalIPs []string
-		internalIPs, err = getServerInternalIPs(osclient)
+		ironicIPs, err = getServerInternalIPs(osclient)
 		if err != nil {
 			err = fmt.Errorf("error fetching internalIPs: %w", err)
 			return
 		}
 
-		if internalIPs != nil {
-			ironicIP = internalIPs[0]
-		}
 		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP (which is what Inspector uses)
-		if ironicIP == "" {
-			ironicIP = inspectorIP
+		if ironicIPs == nil {
+			ironicIPs = []string{inspectorIP}
 		}
 	} else {
-		ironicIP = inspectorIP
+		ironicIPs = []string{inspectorIP}
 	}
 
-	return ironicIP, inspectorIP, err
+	return ironicIPs, inspectorIP, err
 }
 
 func GetPodIP(podClient coreclientv1.PodsGetter, targetNamespace string, networkType NetworkStackType) (string, error) {


### PR DESCRIPTION
We need to set the external url when
	
1. IPv6 is enabled
2. `VirtualMediaViaExternalNetwork` is enabled
	
When `VirtualMediaViaExternalNetwork` is enabled, ironic-proxy is also enabled.  This means that we can set the external url to be the IPv6 version of ironic-proxy.

In this patch, we

1.  Update openshift dependencies to gain access to `APIServerInternalIPs` (note the plural)
2.  Update the `GetIronicIP` function to `GetIronicIPs` (and `getServerInternalIP` to `getInternalIPs`), and thereby force all callers to deal with the dual stack scenario
3.  Pass both IPv4 and IPv6 IPs to ironic-proxy so it can listen to both (Ironic image patch forthcoming)
4. Set the external url only when the proxy and virtual media are enabled.
