### PR TITLE
OCPBUGS-10343: use proxying for inspector in addition to ironic

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -63,6 +63,7 @@ const (
 	ironicPrivatePortEnvVar          = "IRONIC_PRIVATE_PORT"
 	inspectorPrivatePortEnvVar       = "IRONIC_INSPECTOR_PRIVATE_PORT"
 	ironicListenPortEnvVar           = "IRONIC_LISTEN_PORT"
+	inspectorListenPortEnvVar        = "IRONIC_INSPECTOR_LISTEN_PORT"
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
@@ -598,11 +599,13 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 	httpsPort, _ := strconv.Atoi(baremetalVmediaHttpsPort) // #nosec
 
 	ironicPort := baremetalIronicPort
+	inspectorPort := baremetalIronicInspectorPort
 	// In the proxy mode, the ironic API is served on the private port,
 	// while ironic-proxy, running as a DeamonSet on all nodes, serves on
-	// 6385 and proxies the traffic.
+	// 6385 and proxies the traffic (same for inspector).
 	if UseIronicProxy(config) {
 		ironicPort = ironicPrivatePort
+		inspectorPort = inspectorPrivatePort
 	}
 
 	volumes := []corev1.VolumeMount{
@@ -621,8 +624,8 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 		},
 		{
 			Name:          "inspector",
-			ContainerPort: 5050,
-			HostPort:      5050,
+			ContainerPort: int32(inspectorPort),
+			HostPort:      int32(inspectorPort),
 		},
 		{
 			Name:          httpPortName,
@@ -677,6 +680,10 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 			{
 				Name:  ironicListenPortEnvVar,
 				Value: fmt.Sprint(ironicPort),
+			},
+			{
+				Name:  inspectorListenPortEnvVar,
+				Value: fmt.Sprint(inspectorPort),
 			},
 		},
 		Ports: ports,

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -236,6 +236,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_INSPECTOR_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_LISTEN_PORT", Value: "6385"},
+				{Name: "IRONIC_INSPECTOR_LISTEN_PORT", Value: "5050"},
 			},
 		},
 		"metal3-ironic": {
@@ -363,7 +364,12 @@ func TestNewMetal3Containers(t *testing.T) {
 					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 				),
-				withEnv(containers["metal3-httpd"], sshkey, envWithValue("IRONIC_LISTEN_PORT", "6388")),
+				withEnv(
+					containers["metal3-httpd"],
+					sshkey,
+					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
+				),
 				withEnv(containers["metal3-ironic"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP")),
 				containers["metal3-ramdisk-logs"],
 				containers["metal3-ironic-inspector"],
@@ -399,6 +405,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],
@@ -428,6 +435,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithFieldValue("PROVISIONING_IP", "status.hostIP"),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -83,8 +83,8 @@ func getUrlFromIP(ipAddr string) string {
 	}
 }
 
-func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIPs []string, inspectorIP string) corev1.Container {
-	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIPs[0]+","+inspectorIP)
+func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIPs []string, inspectorIPs []string) corev1.Container {
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIPs[0]+","+inspectorIPs[0])
 
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",
@@ -119,7 +119,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 			},
 			corev1.EnvVar{
 				Name:  ironicInspectorBaseUrl,
-				Value: getUrlFromIP(inspectorIP),
+				Value: getUrlFromIP(inspectorIPs[0]),
 			},
 			corev1.EnvVar{
 				Name:  ironicAgentImage,
@@ -151,9 +151,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 	return container
 }
 
-func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIPs []string, inspectorIP string) *corev1.PodTemplateSpec {
+func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIPs []string, inspectorIPs []string) *corev1.PodTemplateSpec {
 	containers := []corev1.Container{
-		createImageCustomizationContainer(info.Images, info, ironicIPs, inspectorIP),
+		createImageCustomizationContainer(info.Images, info, ironicIPs, inspectorIPs),
 	}
 
 	// Extract the pre-provisioning images from a container in the payload
@@ -209,7 +209,7 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 	}
 }
 
-func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string, inspectorIP string) *appsv1.Deployment {
+func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string, inspectorIPs []string) *appsv1.Deployment {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"k8s-app":    metal3AppName,
@@ -220,7 +220,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 		"k8s-app":    metal3AppName,
 		cboLabelName: imageCustomizationService,
 	}
-	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIPs, inspectorIP)
+	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIPs, inspectorIPs)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        imageCustomizationDeploymentName,
@@ -240,12 +240,12 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIP, err := GetIronicIPs(*info)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}
 
-	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIPs, inspectorIP)
+	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIPs, inspectorIPs)
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(imageCustomizationDeployment, info.ProvConfig.Status.Generations)
 	err = controllerutil.SetControllerReference(info.ProvConfig, imageCustomizationDeployment, info.Scheme)
 	if err != nil {

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -106,7 +106,7 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 				NetworkStack: NetworkStackV4,
 				Proxy:        tc.proxy,
 			}
-			actualContainer := createImageCustomizationContainer(&images, info, []string{ironicIP}, tc.inspectorIP)
+			actualContainer := createImageCustomizationContainer(&images, info, []string{ironicIP}, []string{tc.inspectorIP})
 			for e := range actualContainer.Env {
 				assert.EqualValues(t, tc.expectedContainer.Env[e], actualContainer.Env[e])
 			}

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -90,15 +90,14 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIP string, err error) {
-	// Inspector does not support proxy
-
+func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
+	var podIP string
 	config := info.ProvConfig.Spec
 
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
-		inspectorIP = config.ProvisioningIP
+		podIP = config.ProvisioningIP
 	} else {
-		inspectorIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
+		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
 		if err != nil {
 			return
 		}
@@ -111,15 +110,15 @@ func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIP string
 			return
 		}
 
-		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP (which is what Inspector uses)
 		if ironicIPs == nil {
-			ironicIPs = []string{inspectorIP}
+			ironicIPs = []string{podIP}
 		}
 	} else {
-		ironicIPs = []string{inspectorIP}
+		ironicIPs = []string{podIP}
 	}
 
-	return ironicIPs, inspectorIP, err
+	inspectorIPs = ironicIPs // keep returning separate variables for future enhancements
+	return ironicIPs, inspectorIPs, err
 }
 
 func GetPodIP(podClient coreclientv1.PodsGetter, targetNamespace string, networkType NetworkStackType) (string, error) {


### PR DESCRIPTION
Apparently, inspector has the same issue as ironic: there is
a possibility to hit an outdated URI.

As a result, both Ironic and Inspector are always reachable via
the API VIP. I hope nobody asks the same for the image server.

Requires:
- https://github.com/openshift/ironic-image/pull/355
- https://github.com/openshift/cluster-baremetal-operator/pull/335
