### PR TITLE
Use a file URL for passing kernel to Ironic

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -31,7 +31,7 @@ var (
 	baremetalWebhookPort           = "9447"
 	baremetalIronicPort            = 6385
 	baremetalIronicInspectorPort   = 5050
-	baremetalKernelUrlSubPath      = "images/ironic-python-agent.kernel"
+	baremetalKernelSubPath         = "ironic-python-agent.kernel"
 	baremetalIronicEndpointSubpath = "v1/"
 	provisioningIP                 = "PROVISIONING_IP"
 	provisioningInterface          = "PROVISIONING_INTERFACE"
@@ -75,8 +75,7 @@ func getProvisioningIPCIDR(config *metal3iov1alpha1.ProvisioningSpec) *string {
 }
 
 func getDeployKernelUrl() *string {
-	// TODO(dtantsur): it's a share file system, we should look into using a file:// URL
-	deployKernelUrl := fmt.Sprintf("http://localhost:%s/%s", baremetalHttpPort, baremetalKernelUrlSubPath)
+	deployKernelUrl := fmt.Sprintf("file://%s/%s", imageSharedDir, baremetalKernelSubPath)
 	return &deployKernelUrl
 }
 

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -48,13 +48,13 @@ func TestGetMetal3DeploymentConfig(t *testing.T) {
 			name:          "Unmanaged DeployKernelUrl",
 			configName:    deployKernelUrl,
 			spec:          unmanagedProvisioning().build(),
-			expectedValue: "http://localhost:6180/images/ironic-python-agent.kernel",
+			expectedValue: "file:///shared/html/images/ironic-python-agent.kernel",
 		},
 		{
 			name:          "Disabled DeployKernelUrl",
 			configName:    deployKernelUrl,
 			spec:          disabledProvisioning().build(),
-			expectedValue: "http://localhost:6180/images/ironic-python-agent.kernel",
+			expectedValue: "file:///shared/html/images/ironic-python-agent.kernel",
 		},
 		{
 			name:          "Disabled IronicEndpoint",

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -209,7 +209,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
-				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6180/images/ironic-python-agent.kernel"},
+				{Name: "DEPLOY_KERNEL_URL", Value: "file:///shared/html/images/ironic-python-agent.kernel"},
 				{Name: "IRONIC_ENDPOINT", Value: "https://localhost:6385/v1/"},
 				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: "https://localhost:5050/v1/"},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},


### PR DESCRIPTION
The image server and Ironic use the same shared file system, there is
little sense to go through the TCP stack. Use a file:/// URL to avoid
spending time on downloading the image.
