### PR TITLE
[release-4.13] OCPBUGS-11985: use proxying for inspector in addition to ironic

### DIFF
--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -234,6 +234,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_INSPECTOR_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_LISTEN_PORT", Value: "6385"},
+				{Name: "IRONIC_INSPECTOR_LISTEN_PORT", Value: "5050"},
 			},
 		},
 		"metal3-ironic": {
@@ -361,7 +362,12 @@ func TestNewMetal3Containers(t *testing.T) {
 					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 				),
-				withEnv(containers["metal3-httpd"], sshkey, envWithValue("IRONIC_LISTEN_PORT", "6388")),
+				withEnv(
+					containers["metal3-httpd"],
+					sshkey,
+					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
+				),
 				withEnv(containers["metal3-ironic"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP")),
 				containers["metal3-ramdisk-logs"],
 				containers["metal3-ironic-inspector"],
@@ -393,6 +399,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],
@@ -418,6 +425,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithFieldValue("PROVISIONING_IP", "status.hostIP"),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -93,11 +93,12 @@ func getServerInternalIP(osclient osclientset.Interface) (string, error) {
 }
 
 func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIP string, inspectorIP string, err error) {
-	// Inspector does not support proxy
+	var podIP string
+
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
-		inspectorIP = config.ProvisioningIP
+		podIP = config.ProvisioningIP
 	} else {
-		inspectorIP, err = getPodHostIP(client.CoreV1(), targetNamespace)
+		podIP, err = getPodHostIP(client.CoreV1(), targetNamespace)
 		if err != nil {
 			return
 		}
@@ -105,15 +106,16 @@ func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *me
 
 	if UseIronicProxy(config) {
 		ironicIP, err = getServerInternalIP(osclient)
-		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP (which is what Inspector uses)
+		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP
 		if ironicIP == "" {
-			ironicIP = inspectorIP
+			ironicIP = podIP
 		}
 	} else {
-		ironicIP = inspectorIP
+		ironicIP = podIP
 	}
 
-	return
+	inspectorIP = ironicIP // keep returning separate variables for future enhancements
+	return ironicIP, inspectorIP, err
 }
 
 func GetPodIP(podClient coreclientv1.PodsGetter, targetNamespace string, networkType NetworkStackType) (string, error) {


### PR DESCRIPTION
Apparently, inspector has the same issue as ironic: there is
a possibility to hit an outdated URI.

As a result, both Ironic and Inspector are always reachable via
the API VIP. I hope nobody asks the same for the image server.

Requires:
- https://github.com/openshift/ironic-image/pull/361

(cherry picked from commit 768b991bda3cf88dd7c4e789e0788e57b4ff2da8)
