### PR TITLE
OCPBUGS-4248: Avoid ironic-proxy when setting external url

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -280,16 +280,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 }
 
 func setIronicExternalUrl(info ProvisioningInfo) (corev1.EnvVar, error) {
-	// We need to set the external URL to point to the ironic-proxy when IPv6
-	// is enabled and the proxy is present
-
-	if !UseIronicProxy(&info.ProvConfig.Spec) {
-		return corev1.EnvVar{
-			Name: externalUrlEnvVar,
-		}, nil
-	}
-
-	ironicIPs, _, err := GetIronicIPs(info)
+	ironicIPs, err := getServerInternalIPs(info.OSClient)
 
 	if err != nil {
 		return corev1.EnvVar{}, fmt.Errorf("Failed to get Ironic IP when setting external url: %w", err)


### PR DESCRIPTION
The external url is the url the BMC will use to retrieve images from the httpd container inside metal3 in dual stack scenarios.

Each time the metal3 pod is started, we have to find any existing nodes, and rebuild the Ironic database.  During this process, we also tell each BMC where to get images.  This means that httpd doesn't have to be proxied, and therefore, when we construct the external url, we should ignore the ironic-proxy altogether.

This substantially changes the work done in https://github.com/openshift/cluster-baremetal-operator/pull/324.