### PR TITLE
OCPBUGS-14064: Split baremetal-operator into a separate pod

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -79,6 +79,8 @@ func getDeployKernelUrl() *string {
 	return &deployKernelUrl
 }
 
+// TODO(dtantsur): these two can be removed once we no longer have ironic/inspector split
+
 func getIronicEndpoint() *string {
 	ironicEndpoint := fmt.Sprintf("https://localhost:%d/%s", baremetalIronicPort, baremetalIronicEndpointSubpath)
 	return &ironicEndpoint
@@ -87,6 +89,17 @@ func getIronicEndpoint() *string {
 func getIronicInspectorEndpoint() *string {
 	ironicInspectorEndpoint := fmt.Sprintf("https://localhost:%d/%s", baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
 	return &ironicInspectorEndpoint
+}
+
+func getRemoteEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	if err != nil {
+		return
+	}
+
+	ironicEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(ironicIPs[0]), baremetalIronicPort, baremetalIronicEndpointSubpath)
+	inspectorEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(inspectorIPs[0]), baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
+	return
 }
 
 func getProvisioningOSDownloadURL(config *metal3iov1alpha1.ProvisioningSpec) *string {

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -114,11 +114,13 @@ type provisioningBuilder struct {
 	metal3iov1alpha1.ProvisioningSpec
 }
 
+const testProvisioningIP = "172.30.20.3"
+
 func managedProvisioning() *provisioningBuilder {
 	return &provisioningBuilder{
 		metal3iov1alpha1.ProvisioningSpec{
 			ProvisioningInterface:     "eth0",
-			ProvisioningIP:            "172.30.20.3",
+			ProvisioningIP:            testProvisioningIP,
 			ProvisioningMacAddresses:  []string{"34:b3:2d:81:f8:fb", "34:b3:2d:81:f8:fc", "34:b3:2d:81:f8:fd"},
 			ProvisioningNetworkCIDR:   "172.30.20.0/24",
 			ProvisioningDHCPRange:     "172.30.20.11,172.30.20.101",

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -68,12 +68,6 @@ const (
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
 	pullSecretEnvVar                 = "IRONIC_AGENT_PULL_SECRET" // #nosec
-	// Default cert directory set by kubebuilder
-	baremetalWebhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
-	baremetalWebhookCertVolume    = "cert"
-	baremetalWebhookSecretName    = "baremetal-operator-webhook-server-cert"
-	baremetalWebhookLabelName     = "baremetal.openshift.io/metal3-validating-webhook"
-	baremetalWebhookServiceLabel  = "metal3-validating-webhook"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -116,12 +110,6 @@ var vmediaTlsMount = corev1.VolumeMount{
 	Name:      vmediaTlsVolume,
 	MountPath: metal3TlsRootDir + "/vmedia",
 	ReadOnly:  true,
-}
-
-var baremetalWebhookCertMount = corev1.VolumeMount{
-	Name:      baremetalWebhookCertVolume,
-	ReadOnly:  true,
-	MountPath: baremetalWebhookCertMountPath,
 }
 
 var pullSecret = corev1.EnvVar{
@@ -279,7 +267,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 	}
 }
 
-func setIronicExternalUrl(info ProvisioningInfo) (corev1.EnvVar, error) {
+func setIronicExternalUrl(info *ProvisioningInfo) (corev1.EnvVar, error) {
 	ironicIPs, err := getServerInternalIPs(info.OSClient)
 
 	if err != nil {
@@ -406,13 +394,8 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 	return initContainer
 }
 
-func newMetal3Containers(info *ProvisioningInfo) ([]corev1.Container, error) {
-	bmo, err := createContainerMetal3BaremetalOperator(*info)
-	if err != nil {
-		return []corev1.Container{}, err
-	}
+func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 	containers := []corev1.Container{
-		bmo,
 		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3Ironic(info.Images, info, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3RamdiskLogs(info.Images),
@@ -430,7 +413,7 @@ func newMetal3Containers(info *ProvisioningInfo) ([]corev1.Container, error) {
 		containers = append(containers, createContainerMetal3Dnsmasq(info.Images, &info.ProvConfig.Spec))
 	}
 
-	return injectProxyAndCA(containers, info.Proxy), nil
+	return injectProxyAndCA(containers, info.Proxy)
 }
 
 func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
@@ -453,99 +436,6 @@ func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar 
 
 func buildSSHKeyEnvVar(sshKey string) corev1.EnvVar {
 	return corev1.EnvVar{Name: sshKeyEnvVar, Value: sshKey}
-}
-
-func createContainerMetal3BaremetalOperator(info ProvisioningInfo) (corev1.Container, error) {
-	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
-	externalUrlVar, err := setIronicExternalUrl(info)
-	if err != nil {
-		return corev1.Container{}, err
-	}
-	container := corev1.Container{
-		Name:  "metal3-baremetal-operator",
-		Image: info.Images.BaremetalOperator,
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "metrics",
-				ContainerPort: 60000,
-				HostPort:      60000,
-			},
-			{
-				Name:          "webhook-server",
-				HostPort:      int32(webhookPort),
-				ContainerPort: int32(webhookPort),
-			},
-		},
-		Command:         []string{"/baremetal-operator"},
-		Args:            []string{"--health-addr", ":9446", "-build-preprov-image"},
-		ImagePullPolicy: "IfNotPresent",
-		VolumeMounts: []corev1.VolumeMount{
-			ironicCredentialsMount,
-			inspectorCredentialsMount,
-			ironicTlsMount,
-			baremetalWebhookCertMount,
-		},
-		Env: []corev1.EnvVar{
-			getWatchNamespace(&info.ProvConfig.Spec),
-			{
-				Name: "POD_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
-				},
-			},
-			{
-				Name: "POD_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
-				},
-			},
-			{
-				Name:  "OPERATOR_NAME",
-				Value: "baremetal-operator",
-			},
-			{
-				Name:  ironicCertEnvVar,
-				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
-			},
-			{
-				Name:  ironicInsecureEnvVar,
-				Value: "true",
-			},
-			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
-			buildEnvVar(ironicEndpoint, &info.ProvConfig.Spec),
-			buildEnvVar(ironicInspectorEndpoint, &info.ProvConfig.Spec),
-			{
-				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
-				Value: "Never",
-			},
-			{
-				Name:  "METAL3_AUTH_ROOT_DIR",
-				Value: metal3AuthRootDir,
-			},
-			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
-			externalUrlVar,
-		},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("20m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-			},
-		},
-	}
-
-	if !info.BaremetalWebhookEnabled {
-		// Webhook dependencies are not ready, thus we disable webhook explicitly,
-		// since default is enabled.
-		container.Args = append(container.Args, "--webhook-port", "0")
-	} else {
-		container.Args = append(container.Args, "--webhook-port", baremetalWebhookPort)
-	}
-
-	return container, nil
 }
 
 func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
@@ -842,12 +732,9 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 	return container
 }
 
-func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*corev1.PodTemplateSpec, error) {
+func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) *corev1.PodTemplateSpec {
 	initContainers := newMetal3InitContainers(info)
-	containers, err := newMetal3Containers(info)
-	if err != nil {
-		return nil, err
-	}
+	containers := newMetal3Containers(info)
 	tolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
@@ -891,7 +778,7 @@ func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string)
 			ServiceAccountName: "cluster-baremetal-operator",
 			Tolerations:        tolerations,
 		},
-	}, nil
+	}
 }
 
 func mountsWithTrustedCA(mounts []corev1.VolumeMount) []corev1.VolumeMount {
@@ -943,23 +830,18 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string
 	return envVars
 }
 
-func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
+func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"k8s-app":                 metal3AppName,
-			cboLabelName:              stateService,
-			baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+			"k8s-app":    metal3AppName,
+			cboLabelName: stateService,
 		},
 	}
 	podSpecLabels := map[string]string{
-		"k8s-app":                 metal3AppName,
-		cboLabelName:              stateService,
-		baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+		"k8s-app":    metal3AppName,
+		cboLabelName: stateService,
 	}
-	template, err := newMetal3PodTemplateSpec(info, &podSpecLabels)
-	if err != nil {
-		return nil, err
-	}
+	template := newMetal3PodTemplateSpec(info, &podSpecLabels)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      baremetalDeploymentName,
@@ -968,9 +850,8 @@ func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 				cboOwnedAnnotation: "",
 			},
 			Labels: map[string]string{
-				"k8s-app":                 metal3AppName,
-				cboLabelName:              stateService,
-				baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+				"k8s-app":    metal3AppName,
+				cboLabelName: stateService,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -981,7 +862,7 @@ func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 		},
-	}, nil
+	}
 }
 
 func getMetal3DeploymentSelector(client appsclientv1.DeploymentsGetter, targetNamespace string) (*metav1.LabelSelector, error) {
@@ -996,11 +877,7 @@ func EnsureMetal3Deployment(info *ProvisioningInfo) (updated bool, err error) {
 	// Create metal3 deployment object based on current baremetal configuration
 	// It will be created with the cboOwnedAnnotation
 
-	metal3Deployment, err := newMetal3Deployment(info)
-	if err != nil {
-		err = fmt.Errorf("unable to create a metal3 deployment: %w", err)
-		return
-	}
+	metal3Deployment := newMetal3Deployment(info)
 
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, info.ProvConfig.Status.Generations)
 

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -1,0 +1,332 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+const (
+	bmoServiceName    = "metal3-baremetal-operator"
+	bmoDeploymentName = "metal3-baremetal-operator"
+	// Default cert directory set by kubebuilder
+	baremetalWebhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
+	baremetalWebhookCertVolume    = "cert"
+	baremetalWebhookSecretName    = "baremetal-operator-webhook-server-cert"
+	baremetalWebhookLabelName     = "baremetal.openshift.io/metal3-validating-webhook"
+	baremetalWebhookServiceLabel  = "metal3-validating-webhook"
+)
+
+var baremetalWebhookCertMount = corev1.VolumeMount{
+	Name:      baremetalWebhookCertVolume,
+	ReadOnly:  true,
+	MountPath: baremetalWebhookCertMountPath,
+}
+
+var bmoVolumes = []corev1.Volume{
+	trustedCAVolume(),
+	{
+		Name: baremetalWebhookCertVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: baremetalWebhookSecretName,
+			},
+		},
+	},
+	{
+		Name: ironicCredentialsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: ironicSecretName,
+				Items: []corev1.KeyToPath{
+					{Key: ironicUsernameKey, Path: ironicUsernameKey},
+					{Key: ironicPasswordKey, Path: ironicPasswordKey},
+					{Key: ironicConfigKey, Path: ironicConfigKey},
+				},
+			},
+		},
+	},
+	{
+		Name: inspectorCredentialsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: inspectorSecretName,
+				Items: []corev1.KeyToPath{
+					{Key: ironicUsernameKey, Path: ironicUsernameKey},
+					{Key: ironicPasswordKey, Path: ironicPasswordKey},
+					{Key: ironicConfigKey, Path: ironicConfigKey},
+				},
+			},
+		},
+	},
+	{
+		Name: ironicTlsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: tlsSecretName,
+			},
+		},
+	},
+	{
+		Name: inspectorTlsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: tlsSecretName,
+			},
+		},
+	},
+}
+
+func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container, error) {
+	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
+	externalUrlVar, err := setIronicExternalUrl(info)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	ironicURL, inspectorURL, err := getRemoteEndpoints(info)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	container := corev1.Container{
+		Name:  "metal3-baremetal-operator",
+		Image: info.Images.BaremetalOperator,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "metrics",
+				ContainerPort: 60000,
+				HostPort:      60000,
+			},
+			{
+				Name:          "webhook-server",
+				HostPort:      int32(webhookPort),
+				ContainerPort: int32(webhookPort),
+			},
+		},
+		Command:         []string{"/baremetal-operator"},
+		Args:            []string{"--health-addr", ":9446", "-build-preprov-image"},
+		ImagePullPolicy: "IfNotPresent",
+		VolumeMounts: []corev1.VolumeMount{
+			ironicCredentialsMount,
+			inspectorCredentialsMount,
+			ironicTlsMount,
+			baremetalWebhookCertMount,
+		},
+		Env: []corev1.EnvVar{
+			getWatchNamespace(&info.ProvConfig.Spec),
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+			{
+				Name:  "OPERATOR_NAME",
+				Value: "baremetal-operator",
+			},
+			{
+				Name:  ironicCertEnvVar,
+				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
+			},
+			{
+				Name:  ironicInsecureEnvVar,
+				Value: "true",
+			},
+			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
+			{
+				Name:  ironicEndpoint,
+				Value: ironicURL,
+			},
+			{
+				Name:  ironicInspectorEndpoint,
+				Value: inspectorURL,
+			},
+			{
+				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
+				Value: "Never",
+			},
+			{
+				Name:  "METAL3_AUTH_ROOT_DIR",
+				Value: metal3AuthRootDir,
+			},
+			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
+			externalUrlVar,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+	}
+
+	if !info.BaremetalWebhookEnabled {
+		// Webhook dependencies are not ready, thus we disable webhook explicitly,
+		// since default is enabled.
+		container.Args = append(container.Args, "--webhook-port", "0")
+	} else {
+		container.Args = append(container.Args, "--webhook-port", baremetalWebhookPort)
+	}
+
+	return container, nil
+}
+
+func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*corev1.PodTemplateSpec, error) {
+	container, err := createContainerBaremetalOperator(info)
+	if err != nil {
+		return nil, err
+	}
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:               "node.kubernetes.io/not-ready",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+	}
+
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: podTemplateAnnotations,
+			Labels:      *labels,
+		},
+		Spec: corev1.PodSpec{
+			Volumes:            bmoVolumes,
+			Containers:         []corev1.Container{container},
+			HostNetwork:        false,
+			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+			PriorityClassName:  "system-node-critical",
+			NodeSelector:       map[string]string{"node-role.kubernetes.io/master": ""},
+			ServiceAccountName: "cluster-baremetal-operator",
+			Tolerations:        tolerations,
+		},
+	}, nil
+}
+
+func newBMODeployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"k8s-app":                 metal3AppName,
+			cboLabelName:              bmoServiceName,
+			baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+		},
+	}
+	podSpecLabels := map[string]string{
+		"k8s-app":                 metal3AppName,
+		cboLabelName:              bmoServiceName,
+		baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+	}
+	template, err := newBMOPodTemplateSpec(info, &podSpecLabels)
+	if err != nil {
+		return nil, err
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmoDeploymentName,
+			Namespace: info.Namespace,
+			Annotations: map[string]string{
+				cboOwnedAnnotation: "",
+			},
+			Labels: map[string]string{
+				"k8s-app":                 metal3AppName,
+				cboLabelName:              bmoServiceName,
+				baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Selector: selector,
+			Template: *template,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+	}, nil
+}
+
+func EnsureBaremetalOperatorDeployment(info *ProvisioningInfo) (updated bool, err error) {
+	// Create metal3 deployment object based on current baremetal configuration
+	// It will be created with the cboOwnedAnnotation
+
+	bmoDeployment, err := newBMODeployment(info)
+	if err != nil {
+		err = fmt.Errorf("unable to create a metal3 baremetal-operator deployment: %w", err)
+		return
+	}
+
+	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(bmoDeployment, info.ProvConfig.Status.Generations)
+
+	err = controllerutil.SetControllerReference(info.ProvConfig, bmoDeployment, info.Scheme)
+	if err != nil {
+		err = fmt.Errorf("unable to set controllerReference on deployment: %w", err)
+		return
+	}
+
+	deploymentRolloutStartTime = time.Now()
+	deployment, updated, err := resourceapply.ApplyDeployment(context.Background(),
+		info.Client.AppsV1(), info.EventRecorder, bmoDeployment, expectedGeneration)
+	if err != nil {
+		return updated, err
+	}
+	if updated {
+		resourcemerge.SetDeploymentGeneration(&info.ProvConfig.Status.Generations, deployment)
+	}
+	return updated, nil
+}
+
+func GetBaremetalOperatorDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DeploymentConditionType, error) {
+	existing, err := client.Deployments(targetNamespace).Get(context.Background(), bmoDeploymentName, metav1.GetOptions{})
+	if err != nil || existing == nil {
+		// There were errors accessing the deployment.
+		return appsv1.DeploymentReplicaFailure, err
+	}
+	deploymentState := getDeploymentCondition(existing)
+	if deploymentState == appsv1.DeploymentProgressing && deploymentRolloutTimeout <= time.Since(deploymentRolloutStartTime) {
+		return appsv1.DeploymentReplicaFailure, nil
+	}
+	return deploymentState, nil
+}
+
+func DeleteBaremetalOperatorDeployment(info *ProvisioningInfo) error {
+	return client.IgnoreNotFound(info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), bmoDeploymentName, metav1.DeleteOptions{}))
+}

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -1,0 +1,187 @@
+package provisioning
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/config/v1"
+	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestNewBMOContainers(t *testing.T) {
+	envWithValue := func(name, value string) corev1.EnvVar {
+		return corev1.EnvVar{Name: name, Value: value}
+	}
+	envWithFieldValue := func(name, fieldPath string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name:  name,
+			Value: "",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: fieldPath,
+				},
+			},
+		}
+	}
+	primaryIP := "192.168.1.1"
+	containers := map[string]corev1.Container{
+		"metal3-baremetal-operator": {
+			Name: "metal3-baremetal-operator",
+			Env: []corev1.EnvVar{
+				envWithFieldValue("WATCH_NAMESPACE", "metadata.namespace"),
+				envWithFieldValue("POD_NAMESPACE", "metadata.namespace"),
+				envWithFieldValue("POD_NAME", "metadata.name"),
+				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
+				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
+				{Name: "IRONIC_INSECURE", Value: "true"},
+				{Name: "DEPLOY_KERNEL_URL", Value: "file:///shared/html/images/ironic-python-agent.kernel"},
+				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://%s:6385/v1/", primaryIP)},
+				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://%s:5050/v1/", primaryIP)},
+				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
+				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
+				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
+				{Name: "IRONIC_EXTERNAL_URL_V6", Value: ""},
+			},
+		},
+	}
+	withEnv := func(c corev1.Container, ne ...corev1.EnvVar) corev1.Container {
+		newMap := map[string]corev1.EnvVar{}
+		for _, n := range ne {
+			newMap[n.Name] = n
+		}
+
+		new := []corev1.EnvVar{}
+		for _, existing := range c.Env {
+			override, haveOverride := newMap[existing.Name]
+			if haveOverride {
+				new = append(new, override)
+				delete(newMap, existing.Name)
+			} else {
+				new = append(new, existing)
+			}
+		}
+		for _, value := range newMap {
+			new = append(new, value)
+		}
+		c.Env = new
+		return c
+	}
+	images := Images{
+		BaremetalOperator: expectedBaremetalOperator,
+	}
+	tCases := []struct {
+		name               string
+		config             *metal3iov1alpha1.ProvisioningSpec
+		sshkey             string
+		expectedContainers []corev1.Container
+	}{
+		{
+			name:   "ManagedSpec",
+			config: managedProvisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+					envWithValue(
+						"IRONIC_ENDPOINT",
+						fmt.Sprintf("https://%s:6385/v1/", testProvisioningIP),
+					),
+					envWithValue(
+						"IRONIC_INSPECTOR_ENDPOINT",
+						fmt.Sprintf("https://%s:5050/v1/", testProvisioningIP),
+					),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "ManagedSpec with virtualmedia",
+			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "DisabledSpec",
+			config: disabledProvisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_IP", ""),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "",
+		},
+	}
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing tc : %s", tc.name)
+			info := &ProvisioningInfo{
+				Images:       &images,
+				ProvConfig:   &metal3iov1alpha1.Provisioning{Spec: *tc.config},
+				SSHKey:       tc.sshkey,
+				NetworkStack: NetworkStackV6,
+				Client: fakekube.NewSimpleClientset(&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"k8s-app":    metal3AppName,
+							cboLabelName: stateService,
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIPs: []corev1.PodIP{
+							{IP: "192.168.111.22"},
+							{IP: "fd2e:6f44:5dd8:c956::16"},
+						},
+					}}),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster",
+						},
+						Status: v1.InfrastructureStatus{
+							PlatformStatus: &v1.PlatformStatus{
+								Type: v1.BareMetalPlatformType,
+								BareMetal: &v1.BareMetalPlatformStatus{
+									APIServerInternalIPs: []string{
+										primaryIP,
+										"fd2e:6f44:5dd8:c956::16",
+									},
+								},
+							},
+						},
+					}),
+			}
+			templateSpec, err := newBMOPodTemplateSpec(info, &map[string]string{})
+			assert.NoError(t, err)
+			actualContainers := templateSpec.Spec.Containers
+
+			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
+			for i, container := range actualContainers {
+				assert.Equal(t, tc.expectedContainers[i].Name, actualContainers[i].Name)
+				assert.Equal(t, len(tc.expectedContainers[i].Env), len(actualContainers[i].Env), "container name: ", tc.expectedContainers[i].Name)
+				for e := range container.Env {
+					assert.EqualValues(t, tc.expectedContainers[i].Env[e], actualContainers[i].Env[e], "container name: ", tc.expectedContainers[i].Name)
+				}
+			}
+		})
+	}
+}

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	utilnet "k8s.io/utils/net"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
@@ -156,4 +157,12 @@ func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkS
 		optionValue = "ip=dhcp6"
 	}
 	return optionValue
+}
+
+func wrapIPv6(ip string) string {
+	if utilnet.IsIPv6String(ip) {
+		return fmt.Sprintf("[%s]", ip)
+	} else {
+		return ip
+	}
 }


### PR DESCRIPTION
There is no reason to keep it tied to Ironic. Actually, it causes
constant chicken-and-egg problems where BMO needs to know the location
of Ironic.
