### PR TITLE
NO-ISSUE: Stop linting when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-baremetal-operator
 COPY . .
-RUN make cluster-baremetal-operator
+RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.15:base
 COPY --from=builder /go/src/github.com/openshift/cluster-baremetal-operator/bin/cluster-baremetal-operator /usr/bin/cluster-baremetal-operator

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMAGES_JSON ?= /etc/cluster-baremetal-operator/images/images.json
 # Set VERBOSE to -v to make tests produce more output
 VERBOSE ?= ""
 
-all: cluster-baremetal-operator
+all: generate lint build
 
 # Run tests
 test: generate lint manifests
@@ -29,11 +29,11 @@ test: generate lint manifests
 unit: test
 
 # Build cluster-baremetal-operator binary
-cluster-baremetal-operator: generate lint
+build:
 	go build -o bin/cluster-baremetal-operator main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate lint manifests
+run: generate manifests
 	go run ./main.go -images-json $(IMAGES_JSON)
 
 # Install CRDs into a cluster
@@ -111,7 +111,6 @@ generate:
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=cluster-baremetal-operator webhook paths=./... output:crd:artifacts:config=config/crd/bases
 	sed -i '/^    controller-gen.kubebuilder.io\/version: (devel)/d' config/crd/bases/*
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
-	$(GOLANGCI_LINT) run --fix
 
 # Build the docker image
 docker-build: test


### PR DESCRIPTION
When we build the image, the code has already been through code review, and CI.  Everything has been generated, and linted, and addressed.  At the build stage, we just want to compile the binary.

Furthermore, the golangci-lint program seems to require attention every time we upgrade Go in the builder.  This breaks the build, and we have to do emergency upgrades to get it unstuck.