### PR TITLE
OCPBUGS-15232: Use Service instead of provisioning IP for BMO to talk to Ironic

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -91,8 +91,9 @@ func getIronicInspectorEndpoint() *string {
 	return &ironicInspectorEndpoint
 }
 
-func getRemoteEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
+	// NOTE(dtantsur): don't use provisioning network here, this call is for traffic within the control plane.
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, false)
 	if err != nil {
 		return
 	}

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -91,15 +91,9 @@ func getIronicInspectorEndpoint() *string {
 	return &ironicInspectorEndpoint
 }
 
-func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
-	// NOTE(dtantsur): don't use provisioning network here, this call is for traffic within the control plane.
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, false)
-	if err != nil {
-		return
-	}
-
-	ironicEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(ironicIPs[0]), baremetalIronicPort, baremetalIronicEndpointSubpath)
-	inspectorEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(inspectorIPs[0]), baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
+func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string) {
+	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, baremetalIronicPort, baremetalIronicEndpointSubpath)
+	inspectorEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
 	return
 }
 

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -98,10 +98,7 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		return corev1.Container{}, err
 	}
 
-	ironicURL, inspectorURL, err := getControlPlaneEndpoints(info)
-	if err != nil {
-		return corev1.Container{}, err
-	}
+	ironicURL, inspectorURL := getControlPlaneEndpoints(info)
 
 	container := corev1.Container{
 		Name:  "metal3-baremetal-operator",

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -98,7 +98,7 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		return corev1.Container{}, err
 	}
 
-	ironicURL, inspectorURL, err := getRemoteEndpoints(info)
+	ironicURL, inspectorURL, err := getControlPlaneEndpoints(info)
 	if err != nil {
 		return corev1.Container{}, err
 	}

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -30,8 +30,7 @@ func TestNewBMOContainers(t *testing.T) {
 			},
 		}
 	}
-	primaryIP := "192.168.111.1"
-	realIP := "192.168.111.22"
+	primaryIP := "192.168.1.1"
 	containers := map[string]corev1.Container{
 		"metal3-baremetal-operator": {
 			Name: "metal3-baremetal-operator",
@@ -43,8 +42,8 @@ func TestNewBMOContainers(t *testing.T) {
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "DEPLOY_KERNEL_URL", Value: "file:///shared/html/images/ironic-python-agent.kernel"},
-				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://%s:6385/v1/", primaryIP)},
-				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://%s:5050/v1/", primaryIP)},
+				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://metal3-state.openshift-machine-api.svc.cluster.local:6385/v1/")},
+				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://metal3-state.openshift-machine-api.svc.cluster.local:5050/v1/")},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
 				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
 				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
@@ -90,14 +89,6 @@ func TestNewBMOContainers(t *testing.T) {
 				withEnv(
 					containers["metal3-baremetal-operator"],
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-					envWithValue(
-						"IRONIC_ENDPOINT",
-						fmt.Sprintf("https://%s:6385/v1/", realIP),
-					),
-					envWithValue(
-						"IRONIC_INSPECTOR_ENDPOINT",
-						fmt.Sprintf("https://%s:5050/v1/", realIP),
-					),
 				),
 			},
 			sshkey: "sshkey",
@@ -131,6 +122,7 @@ func TestNewBMOContainers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 			info := &ProvisioningInfo{
+				Namespace:    "openshift-machine-api",
 				Images:       &images,
 				ProvConfig:   &metal3iov1alpha1.Provisioning{Spec: *tc.config},
 				SSHKey:       tc.sshkey,
@@ -144,9 +136,8 @@ func TestNewBMOContainers(t *testing.T) {
 						},
 					},
 					Status: corev1.PodStatus{
-						HostIP: realIP,
 						PodIPs: []corev1.PodIP{
-							{IP: realIP},
+							{IP: "192.168.111.22"},
 							{IP: "fd2e:6f44:5dd8:c956::16"},
 						},
 					}}),

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -30,7 +30,8 @@ func TestNewBMOContainers(t *testing.T) {
 			},
 		}
 	}
-	primaryIP := "192.168.1.1"
+	primaryIP := "192.168.111.1"
+	realIP := "192.168.111.22"
 	containers := map[string]corev1.Container{
 		"metal3-baremetal-operator": {
 			Name: "metal3-baremetal-operator",
@@ -91,11 +92,11 @@ func TestNewBMOContainers(t *testing.T) {
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 					envWithValue(
 						"IRONIC_ENDPOINT",
-						fmt.Sprintf("https://%s:6385/v1/", testProvisioningIP),
+						fmt.Sprintf("https://%s:6385/v1/", realIP),
 					),
 					envWithValue(
 						"IRONIC_INSPECTOR_ENDPOINT",
-						fmt.Sprintf("https://%s:5050/v1/", testProvisioningIP),
+						fmt.Sprintf("https://%s:5050/v1/", realIP),
 					),
 				),
 			},
@@ -143,8 +144,9 @@ func TestNewBMOContainers(t *testing.T) {
 						},
 					},
 					Status: corev1.PodStatus{
+						HostIP: realIP,
 						PodIPs: []corev1.PodIP{
-							{IP: "192.168.111.22"},
+							{IP: realIP},
 							{IP: "fd2e:6f44:5dd8:c956::16"},
 						},
 					}}),

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, true)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, true)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -25,6 +25,14 @@ func newMetal3StateService(targetNamespace string, disableVirtualMediaTLS bool) 
 
 	ports := []corev1.ServicePort{
 		{
+			Name: "ironic",
+			Port: int32(baremetalIronicPort),
+		},
+		{
+			Name: "inspector",
+			Port: int32(baremetalIronicInspectorPort),
+		},
+		{
 			Name: httpPortName,
 			Port: int32(port),
 		},

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -91,11 +91,11 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
+func GetIronicIPs(info ProvisioningInfo, allowProvisioningNetwork bool) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
 	config := info.ProvConfig.Spec
 
-	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+	if allowProvisioningNetwork && config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		podIP = config.ProvisioningIP
 	} else {
 		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	utilnet "k8s.io/utils/net"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
@@ -91,11 +90,11 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo, allowProvisioningNetwork bool) (ironicIPs []string, inspectorIPs []string, err error) {
+func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
 	config := info.ProvConfig.Spec
 
-	if allowProvisioningNetwork && config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		podIP = config.ProvisioningIP
 	} else {
 		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
@@ -157,12 +156,4 @@ func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkS
 		optionValue = "ip=dhcp6"
 	}
 	return optionValue
-}
-
-func wrapIPv6(ip string) string {
-	if utilnet.IsIPv6String(ip) {
-		return fmt.Sprintf("[%s]", ip)
-	} else {
-		return ip
-	}
 }


### PR DESCRIPTION
Using provisioning network addresses for communication between BMO and
Ironic seems to work but is a questionable design. Use the existing metal3-state
service instead.

Follow-up to c1bf1cba12c17990d43a15b4689189097f4f6116.
