### PR TITLE
OCPBUGS-16169: use proxying for inspector in addition to ironic

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -62,6 +62,7 @@ const (
 	ironicPrivatePortEnvVar          = "IRONIC_PRIVATE_PORT"
 	inspectorPrivatePortEnvVar       = "IRONIC_INSPECTOR_PRIVATE_PORT"
 	ironicListenPortEnvVar           = "IRONIC_LISTEN_PORT"
+	inspectorListenPortEnvVar        = "IRONIC_INSPECTOR_LISTEN_PORT"
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
@@ -571,11 +572,13 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 	httpsPort, _ := strconv.Atoi(baremetalVmediaHttpsPort) // #nosec
 
 	ironicPort := baremetalIronicPort
+	inspectorPort := baremetalIronicInspectorPort
 	// In the proxy mode, the ironic API is served on the private port,
 	// while ironic-proxy, running as a DeamonSet on all nodes, serves on
-	// 6385 and proxies the traffic.
+	// 6385 and proxies the traffic (same for inspector).
 	if UseIronicProxy(config) {
 		ironicPort = ironicPrivatePort
+		inspectorPort = inspectorPrivatePort
 	}
 
 	volumes := []corev1.VolumeMount{
@@ -594,8 +597,8 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 		},
 		{
 			Name:          "inspector",
-			ContainerPort: 5050,
-			HostPort:      5050,
+			ContainerPort: int32(inspectorPort),
+			HostPort:      int32(inspectorPort),
 		},
 		{
 			Name:          httpPortName,
@@ -650,6 +653,10 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 			{
 				Name:  ironicListenPortEnvVar,
 				Value: fmt.Sprint(ironicPort),
+			},
+			{
+				Name:  inspectorListenPortEnvVar,
+				Value: fmt.Sprint(inspectorPort),
 			},
 		},
 		Ports: ports,

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -232,6 +232,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_INSPECTOR_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_LISTEN_PORT", Value: "6385"},
+				{Name: "IRONIC_INSPECTOR_LISTEN_PORT", Value: "5050"},
 			},
 		},
 		"metal3-ironic": {
@@ -333,8 +334,18 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "ManagedSpec with virtualmedia",
 			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
 			expectedContainers: []corev1.Container{
-				withEnv(containers["metal3-baremetal-operator"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"), envWithValue("IRONIC_EXTERNAL_URL_V6", "https://$(IRONIC_EXTERNAL_IP):6183")),
-				withEnv(containers["metal3-httpd"], sshkey, envWithValue("IRONIC_LISTEN_PORT", "6388")),
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					sshkey,
+					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://$(IRONIC_EXTERNAL_IP):6183"),
+				),
+				withEnv(
+					containers["metal3-httpd"],
+					sshkey,
+					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
+				),
 				withEnv(containers["metal3-ironic"], sshkey, envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP")),
 				containers["metal3-ramdisk-logs"],
 				containers["metal3-ironic-inspector"],
@@ -366,6 +377,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],
@@ -391,6 +403,7 @@ func TestNewMetal3Containers(t *testing.T) {
 					envWithValue("PROVISIONING_INTERFACE", ""),
 					envWithFieldValue("PROVISIONING_IP", "status.hostIP"),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+					envWithValue("IRONIC_INSPECTOR_LISTEN_PORT", "5051"),
 				),
 				withEnv(
 					containers["metal3-ironic"],


### PR DESCRIPTION
Apparently, inspector has the same issue as ironic: there is
a possibility to hit an outdated URI.

As a result, both Ironic and Inspector are always reachable via
the API VIP. I hope nobody asks the same for the image server.

Requires:
- https://github.com/openshift/ironic-image/pull/385

(cherry picked from commit 768b991bda3cf88dd7c4e789e0788e57b4ff2da8)
