### PR TITLE
Jira OCPBUGS-16919: Trigger reconcile if Secret openshift-config/pull-secret changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	// +kubebuilder:scaffold:imports
 
@@ -83,10 +84,11 @@ func main() {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		Namespace:          controllers.ComponentNamespace,
-		LeaderElection:     enableLeaderElection,
-		Port:               9443,
-		CertDir:            "/etc/cluster-baremetal-operator/tls",
+		NewCache: cache.MultiNamespacedCacheBuilder(
+			[]string{controllers.ComponentNamespace, provisioning.OpenshiftConfigNamespace}),
+		LeaderElection: enableLeaderElection,
+		Port:           9443,
+		CertDir:        "/etc/cluster-baremetal-operator/tls",
 	})
 	if err != nil {
 		klog.ErrorS(err, "unable to start manager")

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -117,7 +117,7 @@ var pullSecret = corev1.EnvVar{
 	ValueFrom: &corev1.EnvVarSource{
 		SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: pullSecretName,
+				Name: PullSecretName,
 			},
 			Key: openshiftConfigSecretKey,
 		},

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -29,13 +30,16 @@ const (
 	inspectorSecretName      = "metal3-ironic-inspector-password"
 	inspectorUsername        = "inspector-user"
 	tlsSecretName            = "metal3-ironic-tls" // #nosec
-	openshiftConfigNamespace = "openshift-config"
 	openshiftConfigSecretKey = ".dockerconfigjson" // #nosec
-	pullSecretName           = "pull-secret"
 	// NOTE(dtantsur): this is kept here to be able to remove the old
 	// secret when a Provisioning is removed.
 	ironicrpcSecretName = "metal3-ironic-rpc-password" // #nosec
 	baremetalSecretName = "metal3-mariadb-password"    // #nosec
+
+	// OpenshiftConfigNamespace holds the name of the openshift-config namespace.
+	OpenshiftConfigNamespace = "openshift-config"
+	// PullSecretName holds the name of the pull-secret in openshift-config and openshift-machine-config.
+	PullSecretName = "pull-secret"
 )
 
 type shouldUpdateDataFn func(existing *corev1.Secret) (bool, error)
@@ -118,19 +122,49 @@ password = %s
 // createRegistryPullSecret creates a copy of the pull-secret in the
 // openshift-config namespace for use with LocalObjectReference
 func createRegistryPullSecret(info *ProvisioningInfo) error {
-	secretClient := info.Client.CoreV1().Secrets(openshiftConfigNamespace)
-	openshiftConfigSecret, err := secretClient.Get(context.TODO(), pullSecretName, metav1.GetOptions{})
+	client := info.Client.CoreV1()
+	openshiftConfigSecret, err := client.Secrets(OpenshiftConfigNamespace).Get(context.TODO(), PullSecretName, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("could not get secret %s/%s, err: %w", OpenshiftConfigNamespace, PullSecretName, err)
+	}
+	openshiftConfigSecretKeyData, ok := openshiftConfigSecret.Data[openshiftConfigSecretKey]
+	if !ok {
+		return fmt.Errorf("could not find key %q in secret %s/%s", openshiftConfigSecretKey, OpenshiftConfigNamespace, PullSecretName)
+	}
+
+	// Try to get the openshift-machine-api/pull-secret field .dockerconfigjson.
+	// The openshift-machine-api/pull-secret .dockerconfigjson field should be double encoded due to PR
+	// https://github.com/openshift/cluster-baremetal-operator/pull/184
+	// Attempt decoding this and use the decoded string for comparison.
+	// If any of the below steps fail, machineAPISecretKeyData will be the empty string and it will trigger an update
+	// action for applySecret (that is, if openshift-machine-api/pull-secret already exists).
+	machineAPINamespace := info.Namespace
+	var machineAPISecretKeyData string
+	if machineAPISecret, err := client.Secrets(machineAPINamespace).Get(context.TODO(), PullSecretName, metav1.GetOptions{}); err == nil {
+		if data, ok := machineAPISecret.Data[openshiftConfigSecretKey]; ok {
+			if decoded, err := base64.StdEncoding.DecodeString(string(data)); err == nil {
+				machineAPISecretKeyData = string(decoded)
+			}
+		}
+	}
+
+	shallUpdateData := func(*corev1.Secret) (bool, error) {
+		shallUpdate := string(openshiftConfigSecretKeyData) != machineAPISecretKeyData
+		if shallUpdate {
+			klog.Infof("content of secret %[1]s/%[3]s does not match content of secret %[2]s/%[3]s, reconciling %[2]s/%[3]s",
+				OpenshiftConfigNamespace, machineAPINamespace, PullSecretName)
+			reportRegistryPullSecretReconcile()
+		}
+		return shallUpdate, nil
 	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pullSecretName,
-			Namespace: info.Namespace,
+			Name:      PullSecretName,
+			Namespace: machineAPINamespace,
 		},
 		StringData: map[string]string{
-			openshiftConfigSecretKey: base64.StdEncoding.EncodeToString(openshiftConfigSecret.Data[openshiftConfigSecretKey]),
+			openshiftConfigSecretKey: base64.StdEncoding.EncodeToString(openshiftConfigSecretKeyData),
 		},
 	}
 
@@ -138,8 +172,11 @@ func createRegistryPullSecret(info *ProvisioningInfo) error {
 		return err
 	}
 
-	return applySecret(info.Client.CoreV1(), info.EventRecorder, secret, doNotUpdateData)
+	return applySecret(client, info.EventRecorder, secret, shallUpdateData)
 }
+
+// reportRegistryPullSecretReconcile is used for unit testing, to report that the reconciler was triggered.
+var reportRegistryPullSecretReconcile = func() {}
 
 func EnsureAllSecrets(info *ProvisioningInfo) (bool, error) {
 	// Create a Secret for the Ironic Password
@@ -163,7 +200,7 @@ func EnsureAllSecrets(info *ProvisioningInfo) (bool, error) {
 
 func DeleteAllSecrets(info *ProvisioningInfo) error {
 	var secretErrors []error
-	for _, sn := range []string{baremetalSecretName, ironicSecretName, inspectorSecretName, ironicrpcSecretName, tlsSecretName, pullSecretName} {
+	for _, sn := range []string{baremetalSecretName, ironicSecretName, inspectorSecretName, ironicrpcSecretName, tlsSecretName, PullSecretName} {
 		if err := client.IgnoreNotFound(info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), sn, metav1.DeleteOptions{})); err != nil {
 			secretErrors = append(secretErrors, err)
 		}


### PR DESCRIPTION
When secret openshift-config/pull-secret changes, secret openshift-machine-api/pull-secret shall be updated. In order to achieve this:
* Add a new Watch to the ProvisioningReconciler.
* In method createRegistryPullSecret, recreate the secret in openshift-machine-api if it does not match the secret in openshift/config.

### Testing instructions

Spawn cluster with clusterbot:
~~~
launch openshift/cluster-baremetal-operator#352 ovn,metal
~~~

Modify secret openshift-config/pull-secret:
~~~
mkdir pull1
pushd pull1
oc extract secret/pull-secret -n openshift-config
vim .dockerconfigjson   # modify the pull-secret
oc create secret docker-registry --from-file .dockerconfigjson -n openshift-config pull-secret -o yaml --dry-run=true | oc apply -f -
popd
~~~

Check the log of the cluster-baremetal-operator-... pod, it should show:
~~~
$ oc logs -n openshift-machine-api -l  k8s-app=cluster-baremetal-operator | grep "content of secret"
Defaulted container "cluster-baremetal-operator" out of: cluster-baremetal-operator, baremetal-kube-rbac-proxy
I0823 17:17:18.778372       1 baremetal_secrets.go:154] content of secret openshift-config/pull-secret does not match content of secret openshift-machine-api/pull-secret, reconciling openshift-machine-api/pull-secret
~~~

Make sure that secret openshift-machine-api/pull-secret was updated:
~~~
mkdir pullverify
pushd pullverify
oc extract secret/pull-secret -n openshift-machine-api
cat .dockerconfigjson | base64 -d | less     # make sure that the pull-secret matches the changes
popd
~~~