### PR TITLE
[WIP] TLS host validation between BMO and Ironic/Inspector

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -300,8 +300,8 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	for _, ensureResource := range []ensureFunc{
 		provisioning.EnsureAllSecrets,
 		provisioning.EnsureMetal3Deployment,
-		provisioning.EnsureBaremetalOperatorDeployment,
 		provisioning.EnsureMetal3StateService,
+		provisioning.EnsureBaremetalOperatorDeployment,
 		provisioning.EnsureImageCache,
 		provisioning.EnsureBaremetalOperatorWebhook,
 		provisioning.EnsureImageCustomizationService,

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -104,8 +104,8 @@ func getControlPlanePorts(info *ProvisioningInfo) (ironicPort int, inspectorPort
 
 func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string) {
 	ironicPort, inspectorPort := getControlPlanePorts(info)
-	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, ironicPort, baremetalIronicEndpointSubpath)
-	inspectorEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, inspectorPort, baremetalIronicEndpointSubpath)
+	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc:%d/%s", stateService, info.Namespace, ironicPort, baremetalIronicEndpointSubpath)
+	inspectorEndpoint = fmt.Sprintf("https://%s.%s.svc:%d/%s", stateService, info.Namespace, inspectorPort, baremetalIronicEndpointSubpath)
 	return
 }
 

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -222,6 +222,8 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 		},
 	}
 
+	containers := injectProxyAndCA([]corev1.Container{container}, info.Proxy)
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: podTemplateAnnotations,
@@ -229,7 +231,7 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 		},
 		Spec: corev1.PodSpec{
 			Volumes:            bmoVolumes,
-			Containers:         []corev1.Container{container},
+			Containers:         containers,
 			HostNetwork:        false,
 			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 			PriorityClassName:  "system-node-critical",

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -152,34 +152,8 @@ func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateS
 				"node-role.kubernetes.io/master": "",
 			},
 			Volumes: []corev1.Volume{
-				{
-					Name: ironicTlsVolume,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: tlsSecretName,
-						},
-					},
-				},
-				{
-					Name: inspectorTlsVolume,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: tlsSecretName,
-						},
-					},
-				},
-				{
-					Name: "trusted-ca",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							Items: []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: externalTrustBundleConfigMapName,
-							},
-							Optional: pointer.BoolPtr(true),
-						},
-					},
-				},
+				serviceTlsVolume(),
+				trustedCAVolume(),
 			},
 			Containers:        injectProxyAndCA(containers, info.Proxy),
 			HostNetwork:       true,

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	stateService        = "metal3-state"
-	httpPortName        = "http"
-	vmediaHttpsPortName = "vmedia-https"
+	stateService           = "metal3-state"
+	httpPortName           = "http"
+	vmediaHttpsPortName    = "vmedia-https"
+	stateServiceSecretName = "metal3-state-tls" // #nosec
 )
 
 func newMetal3StateService(info *ProvisioningInfo) *corev1.Service {
@@ -49,6 +50,9 @@ func newMetal3StateService(info *ProvisioningInfo) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      stateService,
 			Namespace: info.Namespace,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": stateServiceSecretName,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,


### PR DESCRIPTION
Now that BMO uses the metal3-state service for talking to Ironic and
Inspector, we can use the standard OpenShift service CA and turn on
TLS host validation.
