### PR TITLE
OCPBUGS-18788: Remove metrics port from baremetal-operator

### DIFF
--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -105,11 +105,6 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		Image: info.Images.BaremetalOperator,
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "metrics",
-				ContainerPort: 60000,
-				HostPort:      60000,
-			},
-			{
 				Name:          "webhook-server",
 				HostPort:      int32(webhookPort),
 				ContainerPort: int32(webhookPort),


### PR DESCRIPTION
baremetal-operator isn't listening on port 60000, the metrics listener is on port 8085 (the default), it dosn't need to be defined in the pod as we arn't using it. Defining a HostPort (even an unused one) will prevent the pod from being schedulable if the port is already in use on the host.