### PR TITLE
OCPBUGS-20563: Add tls-cipher-suites to baremetal-kube-rbac-proxy

### DIFF
--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,7 @@ spec:
         - "--upstream=http://localhost:8080/"
         - "--tls-cert-file=/etc/tls/private/tls.crt"
         - "--tls-private-key-file=/etc/tls/private/tls.key"
+        - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
         - "--config-file=/etc/baremetal-kube-rbac-proxy/config-file.yaml"
         - "--logtostderr=true"
         - "--v=10"

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -60,6 +60,7 @@ spec:
         - --upstream=http://localhost:8080/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --config-file=/etc/baremetal-kube-rbac-proxy/config-file.yaml
         - --logtostderr=true
         - --v=10


### PR DESCRIPTION
This commit adds the tls-cipher-suites to the baremetal-kube-rbac-proxy