### PR TITLE
OCPBUGS-23131,OCPBUGS-23149: fix IRONIC_EXTERNAL_URL_V6

### DIFF
--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -115,6 +115,7 @@ type provisioningBuilder struct {
 }
 
 const testProvisioningIP = "172.30.20.3"
+const testProvisioningIPv6 = "fd2e:6f44:5dd8:b856::2"
 
 func managedProvisioning() *provisioningBuilder {
 	return &provisioningBuilder{
@@ -134,7 +135,7 @@ func managedIPv6Provisioning() *provisioningBuilder {
 	return &provisioningBuilder{
 		metal3iov1alpha1.ProvisioningSpec{
 			ProvisioningInterface:     "eth0",
-			ProvisioningIP:            "fd2e:6f44:5dd8:b856::2",
+			ProvisioningIP:            testProvisioningIPv6,
 			ProvisioningNetworkCIDR:   "fd2e:6f44:5dd8:b856::0/80",
 			ProvisioningMacAddresses:  []string{"34:b3:2d:81:f8:fb", "34:b3:2d:81:f8:fc", "34:b3:2d:81:f8:fd"},
 			ProvisioningDHCPRange:     "fd2e:6f44:5dd8:b856::10,fd2e:6f44:5dd8:b856::ff",

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -268,8 +268,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 }
 
 func setIronicExternalUrl(info *ProvisioningInfo) (corev1.EnvVar, error) {
-	ironicIPs, err := getServerInternalIPs(info.OSClient)
-
+	ironicIPs, err := GetRealIronicIPs(info)
 	if err != nil {
 		return corev1.EnvVar{}, fmt.Errorf("Failed to get Ironic IP when setting external url: %w", err)
 	}

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -83,12 +83,22 @@ func TestNewBMOContainers(t *testing.T) {
 		expectedContainers []corev1.Container
 	}{
 		{
-			name:   "ManagedSpec",
+			name:   "ManagedSpec with IPv4",
 			config: managedProvisioning().build(),
 			expectedContainers: []corev1.Container{
 				withEnv(
 					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "ManagedSpec with IPv6",
+			config: managedIPv6Provisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6", fmt.Sprintf("https://[%s]:6183", testProvisioningIPv6)),
 				),
 			},
 			sshkey: "sshkey",

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -107,13 +107,14 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 }
 
 func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSpec, error) {
-	ironicIP, err := getPodHostIP(info.Client.CoreV1(), info.Namespace)
+	ironicIPs, err := getPodIPs(info.Client.CoreV1(), info.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot figure out the upstream IP for ironic proxy")
 	}
 
 	containers := []corev1.Container{
-		createContainerIronicProxy(ironicIP, info.Images),
+		// Even in a dual-stack environment, we don't really care which IP address to use since both are accessible internally.
+		createContainerIronicProxy(ironicIPs[0], info.Images),
 	}
 
 	tolerations := []corev1.Toleration{


### PR DESCRIPTION
IRONIC_EXTERNAL_URL_V6 is currently calculated incorrectly:

1) It uses the API VIP, but the Ironic's httpd is not proxied in the
   same way as Ironic itself and thus may not be available there.
2) It uses an external IP even when a provisioning network is enabled
   and VirtualMediaViaExternalNetwork is false.

This change fixes both issues, while also cleaning up the provisioning
utils to ensure all functions are dualstack-aware. The split between
the BMO and Metal3 pods is an implicit requirement of this change.

This change does NOT fix the fact that ICC is not configured correctly
for deploying IPv6-only nodes from a dualstack cluster.
