### PR TITLE
OCPBUGS-23504: fixes for deploying V6-only clusters from dualstack hubs

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -92,15 +92,9 @@ func getIronicInspectorEndpoint() *string {
 	return &ironicInspectorEndpoint
 }
 
-func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
-	// NOTE(dtantsur): don't use provisioning network here, this call is for traffic within the control plane.
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, false)
-	if err != nil {
-		return
-	}
-
-	ironicEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(ironicIPs[0]), baremetalIronicPort, baremetalIronicEndpointSubpath)
-	inspectorEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(inspectorIPs[0]), baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
+func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string) {
+	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, baremetalIronicPort, baremetalIronicEndpointSubpath)
+	inspectorEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
 	return
 }
 

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -80,6 +80,8 @@ func getDeployKernelUrl() *string {
 	return &deployKernelUrl
 }
 
+// TODO(dtantsur): these two can be removed once we no longer have ironic/inspector split
+
 func getIronicEndpoint() *string {
 	ironicEndpoint := fmt.Sprintf("https://localhost:%d/%s", baremetalIronicPort, baremetalIronicEndpointSubpath)
 	return &ironicEndpoint
@@ -88,6 +90,17 @@ func getIronicEndpoint() *string {
 func getIronicInspectorEndpoint() *string {
 	ironicInspectorEndpoint := fmt.Sprintf("https://localhost:%d/%s", baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
 	return &ironicInspectorEndpoint
+}
+
+func getRemoteEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	if err != nil {
+		return
+	}
+
+	ironicEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(ironicIPs[0]), baremetalIronicPort, baremetalIronicEndpointSubpath)
+	inspectorEndpoint = fmt.Sprintf("https://%s:%d/%s", wrapIPv6(inspectorIPs[0]), baremetalIronicInspectorPort, baremetalIronicEndpointSubpath)
+	return
 }
 
 func getProvisioningOSDownloadURL(config *metal3iov1alpha1.ProvisioningSpec) *string {

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -92,8 +92,9 @@ func getIronicInspectorEndpoint() *string {
 	return &ironicInspectorEndpoint
 }
 
-func getRemoteEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+func getControlPlaneEndpoints(info *ProvisioningInfo) (ironicEndpoint string, inspectorEndpoint string, err error) {
+	// NOTE(dtantsur): don't use provisioning network here, this call is for traffic within the control plane.
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, false)
 	if err != nil {
 		return
 	}

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -115,6 +115,7 @@ type provisioningBuilder struct {
 }
 
 const testProvisioningIP = "172.30.20.3"
+const testProvisioningIPv6 = "fd2e:6f44:5dd8:b856::2"
 
 func managedProvisioning() *provisioningBuilder {
 	return &provisioningBuilder{
@@ -134,7 +135,7 @@ func managedIPv6Provisioning() *provisioningBuilder {
 	return &provisioningBuilder{
 		metal3iov1alpha1.ProvisioningSpec{
 			ProvisioningInterface:     "eth0",
-			ProvisioningIP:            "fd2e:6f44:5dd8:b856::2",
+			ProvisioningIP:            testProvisioningIPv6,
 			ProvisioningNetworkCIDR:   "fd2e:6f44:5dd8:b856::0/80",
 			ProvisioningMacAddresses:  []string{"34:b3:2d:81:f8:fb", "34:b3:2d:81:f8:fc", "34:b3:2d:81:f8:fd"},
 			ProvisioningDHCPRange:     "fd2e:6f44:5dd8:b856::10,fd2e:6f44:5dd8:b856::ff",

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -114,11 +114,13 @@ type provisioningBuilder struct {
 	metal3iov1alpha1.ProvisioningSpec
 }
 
+const testProvisioningIP = "172.30.20.3"
+
 func managedProvisioning() *provisioningBuilder {
 	return &provisioningBuilder{
 		metal3iov1alpha1.ProvisioningSpec{
 			ProvisioningInterface:     "eth0",
-			ProvisioningIP:            "172.30.20.3",
+			ProvisioningIP:            testProvisioningIP,
 			ProvisioningMacAddresses:  []string{"34:b3:2d:81:f8:fb", "34:b3:2d:81:f8:fc", "34:b3:2d:81:f8:fd"},
 			ProvisioningNetworkCIDR:   "172.30.20.0/24",
 			ProvisioningDHCPRange:     "172.30.20.11,172.30.20.101",

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -280,16 +280,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 }
 
 func setIronicExternalUrl(info ProvisioningInfo) (corev1.EnvVar, error) {
-	// We need to set the external URL to point to the ironic-proxy when IPv6
-	// is enabled and the proxy is present
-
-	if !UseIronicProxy(&info.ProvConfig.Spec) {
-		return corev1.EnvVar{
-			Name: externalUrlEnvVar,
-		}, nil
-	}
-
-	ironicIPs, _, err := GetIronicIPs(info)
+	ironicIPs, err := getServerInternalIPs(info.OSClient)
 
 	if err != nil {
 		return corev1.EnvVar{}, fmt.Errorf("Failed to get Ironic IP when setting external url: %w", err)

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -268,8 +268,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 }
 
 func setIronicExternalUrl(info *ProvisioningInfo) (corev1.EnvVar, error) {
-	ironicIPs, err := getServerInternalIPs(info.OSClient)
-
+	ironicIPs, err := GetRealIronicIPs(info)
 	if err != nil {
 		return corev1.EnvVar{}, fmt.Errorf("Failed to get Ironic IP when setting external url: %w", err)
 	}

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -280,23 +279,20 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 	}
 }
 
-func setIronicExternalUrl(info ProvisioningInfo) corev1.EnvVar {
+func setIronicExternalUrl(info ProvisioningInfo) (corev1.EnvVar, error) {
 	// We need to set the external URL to point to the ironic-proxy when IPv6
 	// is enabled and the proxy is present
 
 	if !UseIronicProxy(&info.ProvConfig.Spec) {
 		return corev1.EnvVar{
 			Name: externalUrlEnvVar,
-		}
+		}, nil
 	}
 
 	ironicIPs, _, err := GetIronicIPs(info)
 
 	if err != nil {
-		klog.Errorf("Failed to get Ironic IP when setting external url: %w", err)
-		return corev1.EnvVar{
-			Name: externalUrlEnvVar,
-		}
+		return corev1.EnvVar{}, fmt.Errorf("Failed to get Ironic IP when setting external url: %w", err)
 	}
 
 	var ironicIPv6 string
@@ -311,7 +307,7 @@ func setIronicExternalUrl(info ProvisioningInfo) corev1.EnvVar {
 	if ironicIPv6 == "" {
 		return corev1.EnvVar{
 			Name: externalUrlEnvVar,
-		}
+		}, nil
 	}
 
 	// protocol, host, port
@@ -321,12 +317,12 @@ func setIronicExternalUrl(info ProvisioningInfo) corev1.EnvVar {
 		return corev1.EnvVar{
 			Name:  externalUrlEnvVar,
 			Value: fmt.Sprintf(urlTemplate, "http", ironicIPv6, baremetalHttpPort),
-		}
+		}, nil
 	} else {
 		return corev1.EnvVar{
 			Name:  externalUrlEnvVar,
 			Value: fmt.Sprintf(urlTemplate, "https", ironicIPv6, baremetalVmediaHttpsPort),
-		}
+		}, nil
 	}
 }
 
@@ -419,9 +415,13 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 	return initContainer
 }
 
-func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
+func newMetal3Containers(info *ProvisioningInfo) ([]corev1.Container, error) {
+	bmo, err := createContainerMetal3BaremetalOperator(*info)
+	if err != nil {
+		return []corev1.Container{}, err
+	}
 	containers := []corev1.Container{
-		createContainerMetal3BaremetalOperator(*info),
+		bmo,
 		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3Ironic(info.Images, info, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3RamdiskLogs(info.Images),
@@ -439,7 +439,7 @@ func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 		containers = append(containers, createContainerMetal3Dnsmasq(info.Images, &info.ProvConfig.Spec))
 	}
 
-	return injectProxyAndCA(containers, info.Proxy)
+	return injectProxyAndCA(containers, info.Proxy), nil
 }
 
 func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
@@ -464,8 +464,12 @@ func buildSSHKeyEnvVar(sshKey string) corev1.EnvVar {
 	return corev1.EnvVar{Name: sshKeyEnvVar, Value: sshKey}
 }
 
-func createContainerMetal3BaremetalOperator(info ProvisioningInfo) corev1.Container {
+func createContainerMetal3BaremetalOperator(info ProvisioningInfo) (corev1.Container, error) {
 	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
+	externalUrlVar, err := setIronicExternalUrl(info)
+	if err != nil {
+		return corev1.Container{}, err
+	}
 	container := corev1.Container{
 		Name:  "metal3-baremetal-operator",
 		Image: info.Images.BaremetalOperator,
@@ -532,7 +536,7 @@ func createContainerMetal3BaremetalOperator(info ProvisioningInfo) corev1.Contai
 				Value: metal3AuthRootDir,
 			},
 			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
-			setIronicExternalUrl(info),
+			externalUrlVar,
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -550,7 +554,7 @@ func createContainerMetal3BaremetalOperator(info ProvisioningInfo) corev1.Contai
 		container.Args = append(container.Args, "--webhook-port", baremetalWebhookPort)
 	}
 
-	return container
+	return container, nil
 }
 
 func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
@@ -847,9 +851,12 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 	return container
 }
 
-func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) *corev1.PodTemplateSpec {
+func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*corev1.PodTemplateSpec, error) {
 	initContainers := newMetal3InitContainers(info)
-	containers := newMetal3Containers(info)
+	containers, err := newMetal3Containers(info)
+	if err != nil {
+		return nil, err
+	}
 	tolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
@@ -893,7 +900,7 @@ func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string)
 			ServiceAccountName: "cluster-baremetal-operator",
 			Tolerations:        tolerations,
 		},
-	}
+	}, nil
 }
 
 func mountsWithTrustedCA(mounts []corev1.VolumeMount) []corev1.VolumeMount {
@@ -945,7 +952,7 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string
 	return envVars
 }
 
-func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
+func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"k8s-app":                 metal3AppName,
@@ -958,7 +965,10 @@ func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
 		cboLabelName:              stateService,
 		baremetalWebhookLabelName: baremetalWebhookServiceLabel,
 	}
-	template := newMetal3PodTemplateSpec(info, &podSpecLabels)
+	template, err := newMetal3PodTemplateSpec(info, &podSpecLabels)
+	if err != nil {
+		return nil, err
+	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      baremetalDeploymentName,
@@ -980,7 +990,7 @@ func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 		},
-	}
+	}, nil
 }
 
 func getMetal3DeploymentSelector(client appsclientv1.DeploymentsGetter, targetNamespace string) (*metav1.LabelSelector, error) {
@@ -995,7 +1005,12 @@ func EnsureMetal3Deployment(info *ProvisioningInfo) (updated bool, err error) {
 	// Create metal3 deployment object based on current baremetal configuration
 	// It will be created with the cboOwnedAnnotation
 
-	metal3Deployment := newMetal3Deployment(info)
+	metal3Deployment, err := newMetal3Deployment(info)
+	if err != nil {
+		err = fmt.Errorf("unable to create a metal3 deployment: %w", err)
+		return
+	}
+
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, info.ProvConfig.Status.Generations)
 
 	err = controllerutil.SetControllerReference(info.ProvConfig, metal3Deployment, info.Scheme)

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -68,12 +68,6 @@ const (
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
 	pullSecretEnvVar                 = "IRONIC_AGENT_PULL_SECRET" // #nosec
-	// Default cert directory set by kubebuilder
-	baremetalWebhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
-	baremetalWebhookCertVolume    = "cert"
-	baremetalWebhookSecretName    = "baremetal-operator-webhook-server-cert"
-	baremetalWebhookLabelName     = "baremetal.openshift.io/metal3-validating-webhook"
-	baremetalWebhookServiceLabel  = "metal3-validating-webhook"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -116,12 +110,6 @@ var vmediaTlsMount = corev1.VolumeMount{
 	Name:      vmediaTlsVolume,
 	MountPath: metal3TlsRootDir + "/vmedia",
 	ReadOnly:  true,
-}
-
-var baremetalWebhookCertMount = corev1.VolumeMount{
-	Name:      baremetalWebhookCertVolume,
-	ReadOnly:  true,
-	MountPath: baremetalWebhookCertMountPath,
 }
 
 var pullSecret = corev1.EnvVar{
@@ -279,7 +267,7 @@ func setIronicExternalIp(name string, config *metal3iov1alpha1.ProvisioningSpec)
 	}
 }
 
-func setIronicExternalUrl(info ProvisioningInfo) (corev1.EnvVar, error) {
+func setIronicExternalUrl(info *ProvisioningInfo) (corev1.EnvVar, error) {
 	ironicIPs, err := getServerInternalIPs(info.OSClient)
 
 	if err != nil {
@@ -406,13 +394,8 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 	return initContainer
 }
 
-func newMetal3Containers(info *ProvisioningInfo) ([]corev1.Container, error) {
-	bmo, err := createContainerMetal3BaremetalOperator(*info)
-	if err != nil {
-		return []corev1.Container{}, err
-	}
+func newMetal3Containers(info *ProvisioningInfo) []corev1.Container {
 	containers := []corev1.Container{
-		bmo,
 		createContainerMetal3Httpd(info.Images, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3Ironic(info.Images, info, &info.ProvConfig.Spec, info.SSHKey),
 		createContainerMetal3RamdiskLogs(info.Images),
@@ -430,7 +413,7 @@ func newMetal3Containers(info *ProvisioningInfo) ([]corev1.Container, error) {
 		containers = append(containers, createContainerMetal3Dnsmasq(info.Images, &info.ProvConfig.Spec))
 	}
 
-	return injectProxyAndCA(containers, info.Proxy), nil
+	return injectProxyAndCA(containers, info.Proxy)
 }
 
 func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar {
@@ -453,99 +436,6 @@ func getWatchNamespace(config *metal3iov1alpha1.ProvisioningSpec) corev1.EnvVar 
 
 func buildSSHKeyEnvVar(sshKey string) corev1.EnvVar {
 	return corev1.EnvVar{Name: sshKeyEnvVar, Value: sshKey}
-}
-
-func createContainerMetal3BaremetalOperator(info ProvisioningInfo) (corev1.Container, error) {
-	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
-	externalUrlVar, err := setIronicExternalUrl(info)
-	if err != nil {
-		return corev1.Container{}, err
-	}
-	container := corev1.Container{
-		Name:  "metal3-baremetal-operator",
-		Image: info.Images.BaremetalOperator,
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "metrics",
-				ContainerPort: 60000,
-				HostPort:      60000,
-			},
-			{
-				Name:          "webhook-server",
-				HostPort:      int32(webhookPort),
-				ContainerPort: int32(webhookPort),
-			},
-		},
-		Command:         []string{"/baremetal-operator"},
-		Args:            []string{"--health-addr", ":9446", "-build-preprov-image"},
-		ImagePullPolicy: "IfNotPresent",
-		VolumeMounts: []corev1.VolumeMount{
-			ironicCredentialsMount,
-			inspectorCredentialsMount,
-			ironicTlsMount,
-			baremetalWebhookCertMount,
-		},
-		Env: []corev1.EnvVar{
-			getWatchNamespace(&info.ProvConfig.Spec),
-			{
-				Name: "POD_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
-				},
-			},
-			{
-				Name: "POD_NAME",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
-				},
-			},
-			{
-				Name:  "OPERATOR_NAME",
-				Value: "baremetal-operator",
-			},
-			{
-				Name:  ironicCertEnvVar,
-				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
-			},
-			{
-				Name:  ironicInsecureEnvVar,
-				Value: "true",
-			},
-			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
-			buildEnvVar(ironicEndpoint, &info.ProvConfig.Spec),
-			buildEnvVar(ironicInspectorEndpoint, &info.ProvConfig.Spec),
-			{
-				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
-				Value: "Never",
-			},
-			{
-				Name:  "METAL3_AUTH_ROOT_DIR",
-				Value: metal3AuthRootDir,
-			},
-			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
-			externalUrlVar,
-		},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("20m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-			},
-		},
-	}
-
-	if !info.BaremetalWebhookEnabled {
-		// Webhook dependencies are not ready, thus we disable webhook explicitly,
-		// since default is enabled.
-		container.Args = append(container.Args, "--webhook-port", "0")
-	} else {
-		container.Args = append(container.Args, "--webhook-port", baremetalWebhookPort)
-	}
-
-	return container, nil
 }
 
 func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.ProvisioningSpec) corev1.Container {
@@ -842,12 +732,9 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 	return container
 }
 
-func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*corev1.PodTemplateSpec, error) {
+func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) *corev1.PodTemplateSpec {
 	initContainers := newMetal3InitContainers(info)
-	containers, err := newMetal3Containers(info)
-	if err != nil {
-		return nil, err
-	}
+	containers := newMetal3Containers(info)
 	tolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
@@ -891,7 +778,7 @@ func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string)
 			ServiceAccountName: "cluster-baremetal-operator",
 			Tolerations:        tolerations,
 		},
-	}, nil
+	}
 }
 
 func mountsWithTrustedCA(mounts []corev1.VolumeMount) []corev1.VolumeMount {
@@ -943,23 +830,18 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string
 	return envVars
 }
 
-func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
+func newMetal3Deployment(info *ProvisioningInfo) *appsv1.Deployment {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"k8s-app":                 metal3AppName,
-			cboLabelName:              stateService,
-			baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+			"k8s-app":    metal3AppName,
+			cboLabelName: stateService,
 		},
 	}
 	podSpecLabels := map[string]string{
-		"k8s-app":                 metal3AppName,
-		cboLabelName:              stateService,
-		baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+		"k8s-app":    metal3AppName,
+		cboLabelName: stateService,
 	}
-	template, err := newMetal3PodTemplateSpec(info, &podSpecLabels)
-	if err != nil {
-		return nil, err
-	}
+	template := newMetal3PodTemplateSpec(info, &podSpecLabels)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      baremetalDeploymentName,
@@ -968,9 +850,8 @@ func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 				cboOwnedAnnotation: "",
 			},
 			Labels: map[string]string{
-				"k8s-app":                 metal3AppName,
-				cboLabelName:              stateService,
-				baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+				"k8s-app":    metal3AppName,
+				cboLabelName: stateService,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -981,7 +862,7 @@ func newMetal3Deployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 		},
-	}, nil
+	}
 }
 
 func getMetal3DeploymentSelector(client appsclientv1.DeploymentsGetter, targetNamespace string) (*metav1.LabelSelector, error) {
@@ -996,11 +877,7 @@ func EnsureMetal3Deployment(info *ProvisioningInfo) (updated bool, err error) {
 	// Create metal3 deployment object based on current baremetal configuration
 	// It will be created with the cboOwnedAnnotation
 
-	metal3Deployment, err := newMetal3Deployment(info)
-	if err != nil {
-		err = fmt.Errorf("unable to create a metal3 deployment: %w", err)
-		return
-	}
+	metal3Deployment := newMetal3Deployment(info)
 
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(metal3Deployment, info.ProvConfig.Status.Generations)
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -498,7 +498,10 @@ func TestNewMetal3Containers(t *testing.T) {
 						},
 					}),
 			}
-			actualContainers := newMetal3Containers(info)
+			actualContainers, err := newMetal3Containers(info)
+			if err != nil {
+				t.Errorf("Failed to get metal3 containers: %v", err)
+			}
 			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
 			for i, container := range actualContainers {
 				assert.Equal(t, tc.expectedContainers[i].Name, actualContainers[i].Name)
@@ -532,6 +535,10 @@ func TestProxyAndCAInjection(t *testing.T) {
 		},
 	}
 
+	containers, err := newMetal3Containers(info)
+	if err != nil {
+		t.Errorf("Failed to get metal3 containers: %v", err)
+	}
 	tCases := []struct {
 		name       string
 		containers []corev1.Container
@@ -542,7 +549,7 @@ func TestProxyAndCAInjection(t *testing.T) {
 		},
 		{
 			name:       "metal3 containers have proxy and CA information",
-			containers: newMetal3Containers(info),
+			containers: containers,
 		},
 	}
 	for _, tc := range tCases {

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -202,24 +202,6 @@ func TestNewMetal3Containers(t *testing.T) {
 		}
 	}
 	containers := map[string]corev1.Container{
-		"metal3-baremetal-operator": {
-			Name: "metal3-baremetal-operator",
-			Env: []corev1.EnvVar{
-				envWithFieldValue("WATCH_NAMESPACE", "metadata.namespace"),
-				envWithFieldValue("POD_NAMESPACE", "metadata.namespace"),
-				envWithFieldValue("POD_NAME", "metadata.name"),
-				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
-				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
-				{Name: "IRONIC_INSECURE", Value: "true"},
-				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6180/images/ironic-python-agent.kernel"},
-				{Name: "IRONIC_ENDPOINT", Value: "https://localhost:6385/v1/"},
-				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: "https://localhost:5050/v1/"},
-				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
-				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
-				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
-				{Name: "IRONIC_EXTERNAL_URL_V6", Value: ""},
-			},
-		},
 		"metal3-httpd": {
 			Name: "metal3-httpd",
 			Env: []corev1.EnvVar{
@@ -328,10 +310,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "ManagedSpec",
 			config: managedProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(containers["metal3-httpd"], sshkey),
 				withEnv(containers["metal3-ironic"], sshkey),
 				containers["metal3-ramdisk-logs"],
@@ -345,10 +323,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "ManagedSpec with DNS",
 			config: managedProvisioning().ProvisioningDNS(true).build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(containers["metal3-httpd"], sshkey),
 				withEnv(containers["metal3-ironic"], sshkey),
 				containers["metal3-ramdisk-logs"],
@@ -365,11 +339,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "ManagedSpec with virtualmedia",
 			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(
 					containers["metal3-httpd"],
 					sshkey,
@@ -388,10 +357,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "UnmanagedSpec",
 			config: unmanagedProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(containers["metal3-httpd"], envWithValue("PROVISIONING_INTERFACE", "ensp0")),
 				withEnv(containers["metal3-ironic"], envWithValue("PROVISIONING_INTERFACE", "ensp0")),
 				containers["metal3-ramdisk-logs"],
@@ -405,11 +370,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpec",
 			config: disabledProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_IP", ""),
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
@@ -434,11 +394,6 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpecWithoutProvisioningIP",
 			config: disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
 			expectedContainers: []corev1.Container{
-				withEnv(
-					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_IP", ""),
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
@@ -507,10 +462,7 @@ func TestNewMetal3Containers(t *testing.T) {
 						},
 					}),
 			}
-			actualContainers, err := newMetal3Containers(info)
-			if err != nil {
-				t.Errorf("Failed to get metal3 containers: %v", err)
-			}
+			actualContainers := newMetal3Containers(info)
 			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
 			for i, container := range actualContainers {
 				assert.Equal(t, tc.expectedContainers[i].Name, actualContainers[i].Name)
@@ -565,10 +517,7 @@ func TestProxyAndCAInjection(t *testing.T) {
 			}),
 	}
 
-	containers, err := newMetal3Containers(info)
-	if err != nil {
-		t.Errorf("Failed to get metal3 containers: %v", err)
-	}
+	containers := newMetal3Containers(info)
 	tCases := []struct {
 		name       string
 		containers []corev1.Container

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -98,10 +98,7 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		return corev1.Container{}, err
 	}
 
-	ironicURL, inspectorURL, err := getControlPlaneEndpoints(info)
-	if err != nil {
-		return corev1.Container{}, err
-	}
+	ironicURL, inspectorURL := getControlPlaneEndpoints(info)
 
 	container := corev1.Container{
 		Name:  "metal3-baremetal-operator",

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -222,6 +222,8 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 		},
 	}
 
+	containers := injectProxyAndCA([]corev1.Container{container}, info.Proxy)
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: podTemplateAnnotations,
@@ -229,7 +231,7 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 		},
 		Spec: corev1.PodSpec{
 			Volumes:            bmoVolumes,
-			Containers:         []corev1.Container{container},
+			Containers:         containers,
 			HostNetwork:        false,
 			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 			PriorityClassName:  "system-node-critical",

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -98,7 +98,7 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		return corev1.Container{}, err
 	}
 
-	ironicURL, inspectorURL, err := getRemoteEndpoints(info)
+	ironicURL, inspectorURL, err := getControlPlaneEndpoints(info)
 	if err != nil {
 		return corev1.Container{}, err
 	}

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -1,0 +1,332 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+const (
+	bmoServiceName    = "metal3-baremetal-operator"
+	bmoDeploymentName = "metal3-baremetal-operator"
+	// Default cert directory set by kubebuilder
+	baremetalWebhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
+	baremetalWebhookCertVolume    = "cert"
+	baremetalWebhookSecretName    = "baremetal-operator-webhook-server-cert"
+	baremetalWebhookLabelName     = "baremetal.openshift.io/metal3-validating-webhook"
+	baremetalWebhookServiceLabel  = "metal3-validating-webhook"
+)
+
+var baremetalWebhookCertMount = corev1.VolumeMount{
+	Name:      baremetalWebhookCertVolume,
+	ReadOnly:  true,
+	MountPath: baremetalWebhookCertMountPath,
+}
+
+var bmoVolumes = []corev1.Volume{
+	trustedCAVolume(),
+	{
+		Name: baremetalWebhookCertVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: baremetalWebhookSecretName,
+			},
+		},
+	},
+	{
+		Name: ironicCredentialsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: ironicSecretName,
+				Items: []corev1.KeyToPath{
+					{Key: ironicUsernameKey, Path: ironicUsernameKey},
+					{Key: ironicPasswordKey, Path: ironicPasswordKey},
+					{Key: ironicConfigKey, Path: ironicConfigKey},
+				},
+			},
+		},
+	},
+	{
+		Name: inspectorCredentialsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: inspectorSecretName,
+				Items: []corev1.KeyToPath{
+					{Key: ironicUsernameKey, Path: ironicUsernameKey},
+					{Key: ironicPasswordKey, Path: ironicPasswordKey},
+					{Key: ironicConfigKey, Path: ironicConfigKey},
+				},
+			},
+		},
+	},
+	{
+		Name: ironicTlsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: tlsSecretName,
+			},
+		},
+	},
+	{
+		Name: inspectorTlsVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: tlsSecretName,
+			},
+		},
+	},
+}
+
+func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container, error) {
+	webhookPort, _ := strconv.ParseInt(baremetalWebhookPort, 10, 32) // #nosec
+	externalUrlVar, err := setIronicExternalUrl(info)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	ironicURL, inspectorURL, err := getRemoteEndpoints(info)
+	if err != nil {
+		return corev1.Container{}, err
+	}
+
+	container := corev1.Container{
+		Name:  "metal3-baremetal-operator",
+		Image: info.Images.BaremetalOperator,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "metrics",
+				ContainerPort: 60000,
+				HostPort:      60000,
+			},
+			{
+				Name:          "webhook-server",
+				HostPort:      int32(webhookPort),
+				ContainerPort: int32(webhookPort),
+			},
+		},
+		Command:         []string{"/baremetal-operator"},
+		Args:            []string{"--health-addr", ":9446", "-build-preprov-image"},
+		ImagePullPolicy: "IfNotPresent",
+		VolumeMounts: []corev1.VolumeMount{
+			ironicCredentialsMount,
+			inspectorCredentialsMount,
+			ironicTlsMount,
+			baremetalWebhookCertMount,
+		},
+		Env: []corev1.EnvVar{
+			getWatchNamespace(&info.ProvConfig.Spec),
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+			{
+				Name:  "OPERATOR_NAME",
+				Value: "baremetal-operator",
+			},
+			{
+				Name:  ironicCertEnvVar,
+				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
+			},
+			{
+				Name:  ironicInsecureEnvVar,
+				Value: "true",
+			},
+			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
+			{
+				Name:  ironicEndpoint,
+				Value: ironicURL,
+			},
+			{
+				Name:  ironicInspectorEndpoint,
+				Value: inspectorURL,
+			},
+			{
+				Name:  "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE",
+				Value: "Never",
+			},
+			{
+				Name:  "METAL3_AUTH_ROOT_DIR",
+				Value: metal3AuthRootDir,
+			},
+			setIronicExternalIp(externalIpEnvVar, &info.ProvConfig.Spec),
+			externalUrlVar,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+	}
+
+	if !info.BaremetalWebhookEnabled {
+		// Webhook dependencies are not ready, thus we disable webhook explicitly,
+		// since default is enabled.
+		container.Args = append(container.Args, "--webhook-port", "0")
+	} else {
+		container.Args = append(container.Args, "--webhook-port", baremetalWebhookPort)
+	}
+
+	return container, nil
+}
+
+func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*corev1.PodTemplateSpec, error) {
+	container, err := createContainerBaremetalOperator(info)
+	if err != nil {
+		return nil, err
+	}
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Key:               "node.kubernetes.io/not-ready",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Effect:            corev1.TaintEffectNoExecute,
+			Operator:          corev1.TolerationOpExists,
+			TolerationSeconds: pointer.Int64Ptr(120),
+		},
+	}
+
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: podTemplateAnnotations,
+			Labels:      *labels,
+		},
+		Spec: corev1.PodSpec{
+			Volumes:            bmoVolumes,
+			Containers:         []corev1.Container{container},
+			HostNetwork:        false,
+			DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+			PriorityClassName:  "system-node-critical",
+			NodeSelector:       map[string]string{"node-role.kubernetes.io/master": ""},
+			ServiceAccountName: "cluster-baremetal-operator",
+			Tolerations:        tolerations,
+		},
+	}, nil
+}
+
+func newBMODeployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"k8s-app":                 metal3AppName,
+			cboLabelName:              bmoServiceName,
+			baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+		},
+	}
+	podSpecLabels := map[string]string{
+		"k8s-app":                 metal3AppName,
+		cboLabelName:              bmoServiceName,
+		baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+	}
+	template, err := newBMOPodTemplateSpec(info, &podSpecLabels)
+	if err != nil {
+		return nil, err
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bmoDeploymentName,
+			Namespace: info.Namespace,
+			Annotations: map[string]string{
+				cboOwnedAnnotation: "",
+			},
+			Labels: map[string]string{
+				"k8s-app":                 metal3AppName,
+				cboLabelName:              bmoServiceName,
+				baremetalWebhookLabelName: baremetalWebhookServiceLabel,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Selector: selector,
+			Template: *template,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+	}, nil
+}
+
+func EnsureBaremetalOperatorDeployment(info *ProvisioningInfo) (updated bool, err error) {
+	// Create metal3 deployment object based on current baremetal configuration
+	// It will be created with the cboOwnedAnnotation
+
+	bmoDeployment, err := newBMODeployment(info)
+	if err != nil {
+		err = fmt.Errorf("unable to create a metal3 baremetal-operator deployment: %w", err)
+		return
+	}
+
+	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(bmoDeployment, info.ProvConfig.Status.Generations)
+
+	err = controllerutil.SetControllerReference(info.ProvConfig, bmoDeployment, info.Scheme)
+	if err != nil {
+		err = fmt.Errorf("unable to set controllerReference on deployment: %w", err)
+		return
+	}
+
+	deploymentRolloutStartTime = time.Now()
+	deployment, updated, err := resourceapply.ApplyDeployment(context.Background(),
+		info.Client.AppsV1(), info.EventRecorder, bmoDeployment, expectedGeneration)
+	if err != nil {
+		return updated, err
+	}
+	if updated {
+		resourcemerge.SetDeploymentGeneration(&info.ProvConfig.Status.Generations, deployment)
+	}
+	return updated, nil
+}
+
+func GetBaremetalOperatorDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace string, config *metal3iov1alpha1.Provisioning) (appsv1.DeploymentConditionType, error) {
+	existing, err := client.Deployments(targetNamespace).Get(context.Background(), bmoDeploymentName, metav1.GetOptions{})
+	if err != nil || existing == nil {
+		// There were errors accessing the deployment.
+		return appsv1.DeploymentReplicaFailure, err
+	}
+	deploymentState := getDeploymentCondition(existing)
+	if deploymentState == appsv1.DeploymentProgressing && deploymentRolloutTimeout <= time.Since(deploymentRolloutStartTime) {
+		return appsv1.DeploymentReplicaFailure, nil
+	}
+	return deploymentState, nil
+}
+
+func DeleteBaremetalOperatorDeployment(info *ProvisioningInfo) error {
+	return client.IgnoreNotFound(info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), bmoDeploymentName, metav1.DeleteOptions{}))
+}

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -83,12 +83,22 @@ func TestNewBMOContainers(t *testing.T) {
 		expectedContainers []corev1.Container
 	}{
 		{
-			name:   "ManagedSpec",
+			name:   "ManagedSpec with IPv4",
 			config: managedProvisioning().build(),
 			expectedContainers: []corev1.Container{
 				withEnv(
 					containers["metal3-baremetal-operator"],
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "ManagedSpec with IPv6",
+			config: managedIPv6Provisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6", fmt.Sprintf("https://[%s]:6183", testProvisioningIPv6)),
 				),
 			},
 			sshkey: "sshkey",

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -30,7 +30,8 @@ func TestNewBMOContainers(t *testing.T) {
 			},
 		}
 	}
-	primaryIP := "192.168.1.1"
+	primaryIP := "192.168.111.1"
+	realIP := "192.168.111.22"
 	containers := map[string]corev1.Container{
 		"metal3-baremetal-operator": {
 			Name: "metal3-baremetal-operator",
@@ -91,11 +92,11 @@ func TestNewBMOContainers(t *testing.T) {
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 					envWithValue(
 						"IRONIC_ENDPOINT",
-						fmt.Sprintf("https://%s:6385/v1/", testProvisioningIP),
+						fmt.Sprintf("https://%s:6385/v1/", realIP),
 					),
 					envWithValue(
 						"IRONIC_INSPECTOR_ENDPOINT",
-						fmt.Sprintf("https://%s:5050/v1/", testProvisioningIP),
+						fmt.Sprintf("https://%s:5050/v1/", realIP),
 					),
 				),
 			},
@@ -143,8 +144,9 @@ func TestNewBMOContainers(t *testing.T) {
 						},
 					},
 					Status: corev1.PodStatus{
+						HostIP: realIP,
 						PodIPs: []corev1.PodIP{
-							{IP: "192.168.111.22"},
+							{IP: realIP},
 							{IP: "fd2e:6f44:5dd8:c956::16"},
 						},
 					}}),

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -1,0 +1,187 @@
+package provisioning
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/config/v1"
+	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestNewBMOContainers(t *testing.T) {
+	envWithValue := func(name, value string) corev1.EnvVar {
+		return corev1.EnvVar{Name: name, Value: value}
+	}
+	envWithFieldValue := func(name, fieldPath string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name:  name,
+			Value: "",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: fieldPath,
+				},
+			},
+		}
+	}
+	primaryIP := "192.168.1.1"
+	containers := map[string]corev1.Container{
+		"metal3-baremetal-operator": {
+			Name: "metal3-baremetal-operator",
+			Env: []corev1.EnvVar{
+				envWithFieldValue("WATCH_NAMESPACE", "metadata.namespace"),
+				envWithFieldValue("POD_NAMESPACE", "metadata.namespace"),
+				envWithFieldValue("POD_NAME", "metadata.name"),
+				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
+				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
+				{Name: "IRONIC_INSECURE", Value: "true"},
+				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6180/images/ironic-python-agent.kernel"},
+				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://%s:6385/v1/", primaryIP)},
+				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://%s:5050/v1/", primaryIP)},
+				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
+				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
+				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
+				{Name: "IRONIC_EXTERNAL_URL_V6", Value: ""},
+			},
+		},
+	}
+	withEnv := func(c corev1.Container, ne ...corev1.EnvVar) corev1.Container {
+		newMap := map[string]corev1.EnvVar{}
+		for _, n := range ne {
+			newMap[n.Name] = n
+		}
+
+		new := []corev1.EnvVar{}
+		for _, existing := range c.Env {
+			override, haveOverride := newMap[existing.Name]
+			if haveOverride {
+				new = append(new, override)
+				delete(newMap, existing.Name)
+			} else {
+				new = append(new, existing)
+			}
+		}
+		for _, value := range newMap {
+			new = append(new, value)
+		}
+		c.Env = new
+		return c
+	}
+	images := Images{
+		BaremetalOperator: expectedBaremetalOperator,
+	}
+	tCases := []struct {
+		name               string
+		config             *metal3iov1alpha1.ProvisioningSpec
+		sshkey             string
+		expectedContainers []corev1.Container
+	}{
+		{
+			name:   "ManagedSpec",
+			config: managedProvisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+					envWithValue(
+						"IRONIC_ENDPOINT",
+						fmt.Sprintf("https://%s:6385/v1/", testProvisioningIP),
+					),
+					envWithValue(
+						"IRONIC_INSPECTOR_ENDPOINT",
+						fmt.Sprintf("https://%s:5050/v1/", testProvisioningIP),
+					),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "ManagedSpec with virtualmedia",
+			config: managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "sshkey",
+		},
+		{
+			name:   "DisabledSpec",
+			config: disabledProvisioning().build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_IP", ""),
+					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+				),
+			},
+			sshkey: "",
+		},
+	}
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing tc : %s", tc.name)
+			info := &ProvisioningInfo{
+				Images:       &images,
+				ProvConfig:   &metal3iov1alpha1.Provisioning{Spec: *tc.config},
+				SSHKey:       tc.sshkey,
+				NetworkStack: NetworkStackV6,
+				Client: fakekube.NewSimpleClientset(&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "openshift-machine-api",
+						Labels: map[string]string{
+							"k8s-app":    metal3AppName,
+							cboLabelName: stateService,
+						},
+					},
+					Status: corev1.PodStatus{
+						PodIPs: []corev1.PodIP{
+							{IP: "192.168.111.22"},
+							{IP: "fd2e:6f44:5dd8:c956::16"},
+						},
+					}}),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster",
+						},
+						Status: v1.InfrastructureStatus{
+							PlatformStatus: &v1.PlatformStatus{
+								Type: v1.BareMetalPlatformType,
+								BareMetal: &v1.BareMetalPlatformStatus{
+									APIServerInternalIPs: []string{
+										primaryIP,
+										"fd2e:6f44:5dd8:c956::16",
+									},
+								},
+							},
+						},
+					}),
+			}
+			templateSpec, err := newBMOPodTemplateSpec(info, &map[string]string{})
+			assert.NoError(t, err)
+			actualContainers := templateSpec.Spec.Containers
+
+			assert.Equal(t, len(tc.expectedContainers), len(actualContainers), fmt.Sprintf("%s : Expected number of Containers : %d Actual number of Containers : %d", tc.name, len(tc.expectedContainers), len(actualContainers)))
+			for i, container := range actualContainers {
+				assert.Equal(t, tc.expectedContainers[i].Name, actualContainers[i].Name)
+				assert.Equal(t, len(tc.expectedContainers[i].Env), len(actualContainers[i].Env), "container name: ", tc.expectedContainers[i].Name)
+				for e := range container.Env {
+					assert.EqualValues(t, tc.expectedContainers[i].Env[e], actualContainers[i].Env[e], "container name: ", tc.expectedContainers[i].Name)
+				}
+			}
+		})
+	}
+}

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -30,8 +30,7 @@ func TestNewBMOContainers(t *testing.T) {
 			},
 		}
 	}
-	primaryIP := "192.168.111.1"
-	realIP := "192.168.111.22"
+	primaryIP := "192.168.1.1"
 	containers := map[string]corev1.Container{
 		"metal3-baremetal-operator": {
 			Name: "metal3-baremetal-operator",
@@ -43,8 +42,8 @@ func TestNewBMOContainers(t *testing.T) {
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "DEPLOY_KERNEL_URL", Value: "http://localhost:6180/images/ironic-python-agent.kernel"},
-				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://%s:6385/v1/", primaryIP)},
-				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://%s:5050/v1/", primaryIP)},
+				{Name: "IRONIC_ENDPOINT", Value: fmt.Sprintf("https://metal3-state.openshift-machine-api.svc.cluster.local:6385/v1/")},
+				{Name: "IRONIC_INSPECTOR_ENDPOINT", Value: fmt.Sprintf("https://metal3-state.openshift-machine-api.svc.cluster.local:5050/v1/")},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
 				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
 				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
@@ -90,14 +89,6 @@ func TestNewBMOContainers(t *testing.T) {
 				withEnv(
 					containers["metal3-baremetal-operator"],
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
-					envWithValue(
-						"IRONIC_ENDPOINT",
-						fmt.Sprintf("https://%s:6385/v1/", realIP),
-					),
-					envWithValue(
-						"IRONIC_INSPECTOR_ENDPOINT",
-						fmt.Sprintf("https://%s:5050/v1/", realIP),
-					),
 				),
 			},
 			sshkey: "sshkey",
@@ -131,6 +122,7 @@ func TestNewBMOContainers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing tc : %s", tc.name)
 			info := &ProvisioningInfo{
+				Namespace:    "openshift-machine-api",
 				Images:       &images,
 				ProvConfig:   &metal3iov1alpha1.Provisioning{Spec: *tc.config},
 				SSHKey:       tc.sshkey,
@@ -144,9 +136,8 @@ func TestNewBMOContainers(t *testing.T) {
 						},
 					},
 					Status: corev1.PodStatus{
-						HostIP: realIP,
 						PodIPs: []corev1.PodIP{
-							{IP: realIP},
+							{IP: "192.168.111.22"},
 							{IP: "fd2e:6f44:5dd8:c956::16"},
 						},
 					}}),

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, true)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info, true)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -240,7 +240,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string,
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIPs, inspectorIPs, err := GetIronicIPs(*info)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(info)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -83,8 +83,8 @@ func getUrlFromIP(ipAddr string) string {
 	}
 }
 
-func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIP, inspectorIP string) corev1.Container {
-	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIP+","+inspectorIP)
+func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIPs []string, inspectorIPs []string) corev1.Container {
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIPs[0]+","+inspectorIPs[0])
 
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",
@@ -115,11 +115,11 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 			},
 			corev1.EnvVar{
 				Name:  ironicBaseUrl,
-				Value: getUrlFromIP(ironicIP),
+				Value: getUrlFromIP(ironicIPs[0]),
 			},
 			corev1.EnvVar{
 				Name:  ironicInspectorBaseUrl,
-				Value: getUrlFromIP(inspectorIP),
+				Value: getUrlFromIP(inspectorIPs[0]),
 			},
 			corev1.EnvVar{
 				Name:  ironicAgentImage,
@@ -151,9 +151,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 	return container
 }
 
-func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIP, inspectorIP string) *corev1.PodTemplateSpec {
+func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string, ironicIPs []string, inspectorIPs []string) *corev1.PodTemplateSpec {
 	containers := []corev1.Container{
-		createImageCustomizationContainer(info.Images, info, ironicIP, inspectorIP),
+		createImageCustomizationContainer(info.Images, info, ironicIPs, inspectorIPs),
 	}
 
 	// Extract the pre-provisioning images from a container in the payload
@@ -209,7 +209,7 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 	}
 }
 
-func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspectorIP string) *appsv1.Deployment {
+func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIPs []string, inspectorIPs []string) *appsv1.Deployment {
 	selector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"k8s-app":    metal3AppName,
@@ -220,7 +220,7 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspector
 		"k8s-app":    metal3AppName,
 		cboLabelName: imageCustomizationService,
 	}
-	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIP, inspectorIP)
+	template := newImageCustomizationPodTemplateSpec(info, &podSpecLabels, ironicIPs, inspectorIPs)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        imageCustomizationDeploymentName,
@@ -240,12 +240,12 @@ func newImageCustomizationDeployment(info *ProvisioningInfo, ironicIP, inspector
 }
 
 func EnsureImageCustomizationDeployment(info *ProvisioningInfo) (updated bool, err error) {
-	ironicIP, inspectorIP, err := GetIronicIP(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
+	ironicIPs, inspectorIPs, err := GetIronicIPs(info.Client, info.Namespace, &info.ProvConfig.Spec, info.OSClient)
 	if err != nil {
 		return false, fmt.Errorf("unable to determine Ironic's IP to pass to the machine-image-customization-controller: %w", err)
 	}
 
-	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIP, inspectorIP)
+	imageCustomizationDeployment := newImageCustomizationDeployment(info, ironicIPs, inspectorIPs)
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(imageCustomizationDeployment, info.ProvConfig.Status.Generations)
 	err = controllerutil.SetControllerReference(info.ProvConfig, imageCustomizationDeployment, info.Scheme)
 	if err != nil {

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -106,7 +106,7 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 				NetworkStack: NetworkStackV4,
 				Proxy:        tc.proxy,
 			}
-			actualContainer := createImageCustomizationContainer(&images, info, ironicIP, tc.inspectorIP)
+			actualContainer := createImageCustomizationContainer(&images, info, []string{ironicIP}, []string{tc.inspectorIP})
 			for e := range actualContainer.Env {
 				assert.EqualValues(t, tc.expectedContainer.Env[e], actualContainer.Env[e])
 			}

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -107,12 +107,13 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 }
 
 func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSpec, error) {
-	ironicIPs, _, err := GetIronicIPs(*info)
+	ironicIPs, err := getPodIPs(info.Client.CoreV1(), info.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot figure out the upstream IP for ironic proxy")
 	}
 
 	containers := []corev1.Container{
+		// Even in a dual-stack environment, we don't really care which IP address to use since both are accessible internally.
 		createContainerIronicProxy(ironicIPs[0], info.Images),
 	}
 

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -107,13 +107,13 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 }
 
 func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateSpec, error) {
-	ironicIP, err := getPodHostIP(info.Client.CoreV1(), info.Namespace)
+	ironicIPs, _, err := GetIronicIPs(*info)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot figure out the upstream IP for ironic proxy")
 	}
 
 	containers := []corev1.Container{
-		createContainerIronicProxy(ironicIP, info.Images),
+		createContainerIronicProxy(ironicIPs[0], info.Images),
 	}
 
 	tolerations := []corev1.Toleration{

--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -25,6 +25,14 @@ func newMetal3StateService(targetNamespace string, disableVirtualMediaTLS bool) 
 
 	ports := []corev1.ServicePort{
 		{
+			Name: "ironic",
+			Port: int32(baremetalIronicPort),
+		},
+		{
+			Name: "inspector",
+			Port: int32(baremetalIronicInspectorPort),
+		},
+		{
 			Name: httpPortName,
 			Port: int32(port),
 		},

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -7,7 +7,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
@@ -70,7 +69,6 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 		err = fmt.Errorf("Cannot get the 'cluster' object from infrastructure API: %w", err)
 		return nil, err
 	}
-	// FIXME(dtantsur): handle the new APIServerInternalIPs field and the dualstack case.
 	switch infra.Status.PlatformStatus.Type {
 	case osconfigv1.BareMetalPlatformType:
 		if infra.Status.PlatformStatus == nil || infra.Status.PlatformStatus.BareMetal == nil {
@@ -101,20 +99,22 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIPs []string, inspectorIPs []string, err error) {
+func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
+
+	config := info.ProvConfig.Spec
 
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		podIP = config.ProvisioningIP
 	} else {
-		podIP, err = getPodHostIP(client.CoreV1(), targetNamespace)
+		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
 		if err != nil {
 			return
 		}
 	}
 
-	if UseIronicProxy(config) {
-		ironicIPs, err = getServerInternalIPs(osclient)
+	if UseIronicProxy(&config) {
+		ironicIPs, err = getServerInternalIPs(info.OSClient)
 		if err != nil {
 			err = fmt.Errorf("error fetching internalIPs: %w", err)
 			return

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -101,7 +101,7 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIP string, inspectorIP string, err error) {
+func GetIronicIPs(client kubernetes.Interface, targetNamespace string, config *metal3iov1alpha1.ProvisioningSpec, osclient osclientset.Interface) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
 
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
@@ -114,26 +114,22 @@ func GetIronicIP(client kubernetes.Interface, targetNamespace string, config *me
 	}
 
 	if UseIronicProxy(config) {
-		var internalIPs []string
-		internalIPs, err = getServerInternalIPs(osclient)
+		ironicIPs, err = getServerInternalIPs(osclient)
 		if err != nil {
 			err = fmt.Errorf("error fetching internalIPs: %w", err)
 			return
 		}
 
-		if internalIPs != nil {
-			ironicIP = internalIPs[0]
-		}
 		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP
-		if ironicIP == "" {
-			ironicIP = podIP
+		if ironicIPs == nil {
+			ironicIPs = []string{podIP}
 		}
 	} else {
-		ironicIP = podIP
+		ironicIPs = []string{podIP}
 	}
 
-	inspectorIP = ironicIP // keep returning separate variables for future enhancements
-	return ironicIP, inspectorIP, err
+	inspectorIPs = ironicIPs // keep returning separate variables for future enhancements
+	return ironicIPs, inspectorIPs, err
 }
 
 func GetPodIP(podClient coreclientv1.PodsGetter, targetNamespace string, networkType NetworkStackType) (string, error) {

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -100,12 +100,12 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
+func GetIronicIPs(info ProvisioningInfo, allowProvisioningNetwork bool) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
 
 	config := info.ProvConfig.Spec
 
-	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+	if allowProvisioningNetwork && config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		podIP = config.ProvisioningIP
 	} else {
 		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	utilnet "k8s.io/utils/net"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
@@ -167,4 +168,12 @@ func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkS
 		optionValue = "ip=dhcp6"
 	}
 	return optionValue
+}
+
+func wrapIPv6(ip string) string {
+	if utilnet.IsIPv6String(ip) {
+		return fmt.Sprintf("[%s]", ip)
+	} else {
+		return ip
+	}
 }

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -55,14 +56,27 @@ func getPod(podClient coreclientv1.PodsGetter, targetNamespace string) (corev1.P
 	return pods[0], nil
 }
 
-func getPodHostIP(podClient coreclientv1.PodsGetter, targetNamespace string) (string, error) {
+// getPodIPs returns pod IPs for the Metal3 pod (and thus Ironic and its httpd).
+func getPodIPs(podClient coreclientv1.PodsGetter, targetNamespace string) (ips []string, err error) {
 	pod, err := getPod(podClient, targetNamespace)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return pod.Status.HostIP, nil
+	// NOTE(dtantsur): we can use PodIPs here because with host networking they're identical to HostIP
+	for _, ip := range pod.Status.PodIPs {
+		if ip.IP != "" {
+			ips = append(ips, ip.IP)
+		}
+	}
+	if len(ips) == 0 {
+		// This is basically a safeguard to be able to assume that the returned slice is not empty later on
+		err = errors.New("the metal3 pod does not have any podIP's yet")
+	}
+	return
 }
 
+// getServerInternalIPs returns virtual IPs on which Kubernetes is accessible.
+// These are the IPs on which the proxied services (currently Ironic and Inspector) should be accessed by external consumers.
 func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	infra, err := osclient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
@@ -99,21 +113,26 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
-	var podIP string
-
+// GetRealIronicIPs returns the actual IPs on which Ironic is accessible without a proxy.
+// The provisioning IP is used when present and not disallowed for virtual media via configuration.
+func GetRealIronicIPs(info *ProvisioningInfo) ([]string, error) {
 	config := info.ProvConfig.Spec
-
 	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
-		podIP = config.ProvisioningIP
-	} else {
-		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
-		if err != nil {
-			return
-		}
+		return []string{config.ProvisioningIP}, nil
 	}
 
-	if UseIronicProxy(&config) {
+	return getPodIPs(info.Client.CoreV1(), info.Namespace)
+}
+
+// GetIronicIPs returns Ironic IPs for external consumption, potentially behind an HA proxy.
+// Without a proxy, the provisioning IP is used when present and not disallowed for virtual media via configuration.
+func GetIronicIPs(info *ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
+	podIPs, err := GetRealIronicIPs(info)
+	if err != nil {
+		return
+	}
+
+	if UseIronicProxy(&info.ProvConfig.Spec) {
 		ironicIPs, err = getServerInternalIPs(info.OSClient)
 		if err != nil {
 			err = fmt.Errorf("error fetching internalIPs: %w", err)
@@ -122,36 +141,14 @@ func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []str
 
 		// NOTE(janders) if ironicIP is an empty string (e.g. for NonePlatformType) fall back to Pod IP
 		if ironicIPs == nil {
-			ironicIPs = []string{podIP}
+			ironicIPs = podIPs
 		}
 	} else {
-		ironicIPs = []string{podIP}
+		ironicIPs = podIPs
 	}
 
 	inspectorIPs = ironicIPs // keep returning separate variables for future enhancements
 	return ironicIPs, inspectorIPs, err
-}
-
-func GetPodIP(podClient coreclientv1.PodsGetter, targetNamespace string, networkType NetworkStackType) (string, error) {
-	pod, err := getPod(podClient, targetNamespace)
-	if err != nil {
-		return "", err
-	}
-
-	for _, podIP := range pod.Status.PodIPs {
-		if networkType == NetworkStackDual {
-			return podIP.IP, nil
-		}
-		ip := net.ParseIP(podIP.IP)
-		if networkType == NetworkStackV6 && ip.To4() == nil {
-			return podIP.IP, nil
-		}
-		if networkType == NetworkStackV4 && ip.To4() != nil {
-			return podIP.IP, nil
-		}
-	}
-
-	return "", fmt.Errorf("Pod doesn't have an IP address of the requested type")
 }
 
 func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkStack NetworkStackType) string {

--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	utilnet "k8s.io/utils/net"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
@@ -100,12 +99,12 @@ func getServerInternalIPs(osclient osclientset.Interface) ([]string, error) {
 	}
 }
 
-func GetIronicIPs(info ProvisioningInfo, allowProvisioningNetwork bool) (ironicIPs []string, inspectorIPs []string, err error) {
+func GetIronicIPs(info ProvisioningInfo) (ironicIPs []string, inspectorIPs []string, err error) {
 	var podIP string
 
 	config := info.ProvConfig.Spec
 
-	if allowProvisioningNetwork && config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
+	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled && !config.VirtualMediaViaExternalNetwork {
 		podIP = config.ProvisioningIP
 	} else {
 		podIP, err = getPodHostIP(info.Client.CoreV1(), info.Namespace)
@@ -168,12 +167,4 @@ func IpOptionForProvisioning(config *metal3iov1alpha1.ProvisioningSpec, networkS
 		optionValue = "ip=dhcp6"
 	}
 	return optionValue
-}
-
-func wrapIPv6(ip string) string {
-	if utilnet.IsIPv6String(ip) {
-		return fmt.Sprintf("[%s]", ip)
-	} else {
-		return ip
-	}
 }


### PR DESCRIPTION
This change backports all fixes done for [METAL-163](https://issues.redhat.com//browse/METAL-163) to provide the right callback URLs for IPv6-only BMCs from dualstack clusters where IPv4 is the primary stack.

Due to architectural reasons, we're forced to also backport the split of the Metal3 pod into BMO and the rest of Metal3.