### PR TITLE
NO-ISSUE: Fix ordering problem in the unit tests

### DIFF
--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -288,8 +288,12 @@ func TestNewMetal3Containers(t *testing.T) {
 				new = append(new, existing)
 			}
 		}
-		for _, value := range newMap {
-			new = append(new, value)
+		// Make sure new variables also end up in the final list.
+		// Append them to the end in the same order.
+		for _, value := range ne {
+			if _, exist := newMap[value.Name]; exist {
+				new = append(new, value)
+			}
 		}
 		c.Env = new
 		return c


### PR DESCRIPTION
The last fix [1] implicitly relied on the map ordering, which is not
defined.

[1] https://github.com/dtantsur/cluster-baremetal-operator/commit/60965080e7354b7328ee3cb0b5a51cb6d3023a4a
