### PR TITLE
OCPBUGS-23504: hack for deploying V6-only clusters from dualstack hubs

### DIFF
--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -215,7 +215,8 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
 				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
 				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
-				{Name: "IRONIC_EXTERNAL_URL_V6", Value: ""},
+				{Name: "IRONIC_EXTERNAL_URL_V6_PROTO", Value: ""},
+				{Name: "IRONIC_EXTERNAL_URL_V6_HOSTS", Value: ""},
 			},
 		},
 		"metal3-httpd": {
@@ -360,7 +361,8 @@ func TestNewMetal3Containers(t *testing.T) {
 				withEnv(
 					containers["metal3-baremetal-operator"],
 					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
-					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
+					envWithValue("IRONIC_EXTERNAL_URL_V6_PROTO", "https"),
+					envWithFieldValue("IRONIC_EXTERNAL_URL_V6_HOSTS", "status.podIPs"),
 				),
 				withEnv(
 					containers["metal3-httpd"],
@@ -394,7 +396,11 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpec",
 			config: disabledProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				containers["metal3-baremetal-operator"],
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6_PROTO", "https"),
+					envWithFieldValue("IRONIC_EXTERNAL_URL_V6_HOSTS", "status.podIPs"),
+				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
@@ -419,7 +425,11 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "DisabledSpecWithoutProvisioningIP",
 			config: disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
 			expectedContainers: []corev1.Container{
-				containers["metal3-baremetal-operator"],
+				withEnv(
+					containers["metal3-baremetal-operator"],
+					envWithValue("IRONIC_EXTERNAL_URL_V6_PROTO", "https"),
+					envWithFieldValue("IRONIC_EXTERNAL_URL_V6_HOSTS", "status.podIPs"),
+				),
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),


### PR DESCRIPTION
In 4.13, we cannot calculate pod IPs of the Metal3 pod to pass to BMO
since BMO is a part of this same pod. As a 4.13-only hack, pass
the variables to compose the external URL to BMO. Another 4.13-only
hack will build the URL out of them.
