### PR TITLE
METAL-856: set USE_IRONIC_INSPECTOR explicitly

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -68,6 +68,7 @@ const (
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
 	pullSecretEnvVar                 = "IRONIC_AGENT_PULL_SECRET" // #nosec
+	forceInspectorEnvVar             = "USE_IRONIC_INSPECTOR"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -565,6 +566,11 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 				Name:  inspectorListenPortEnvVar,
 				Value: fmt.Sprint(inspectorPort),
 			},
+			// TODO(dtantsur): remove when removing inspector
+			{
+				Name:  forceInspectorEnvVar,
+				Value: "true",
+			},
 		},
 		Ports: ports,
 		Resources: corev1.ResourceRequirements{
@@ -627,6 +633,11 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 			setIronicExternalIp(externalIpEnvVar, config),
 			buildEnvVar(provisioningMacAddresses, config),
 			buildEnvVar(vmediaHttpsPort, config),
+			// TODO(dtantsur): remove when removing inspector
+			{
+				Name:  forceInspectorEnvVar,
+				Value: "true",
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -694,6 +705,10 @@ func createContainerMetal3IronicInspector(images *Images, info *ProvisioningInfo
 			buildEnvVar(provisioningIP, config),
 			buildEnvVar(provisioningInterface, config),
 			buildEnvVar(provisioningMacAddresses, config),
+			{
+				Name:  forceInspectorEnvVar,
+				Value: "true",
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -219,6 +219,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_INSPECTOR_PRIVATE_PORT", Value: "unix"},
 				{Name: "IRONIC_LISTEN_PORT", Value: "6385"},
 				{Name: "IRONIC_INSPECTOR_LISTEN_PORT", Value: "5050"},
+				{Name: "USE_IRONIC_INSPECTOR", Value: "true"},
 			},
 		},
 		"metal3-ironic": {
@@ -236,6 +237,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "IRONIC_EXTERNAL_IP"},
 				{Name: "PROVISIONING_MACS", Value: "34:b3:2d:81:f8:fb,34:b3:2d:81:f8:fc,34:b3:2d:81:f8:fd"},
 				{Name: "VMEDIA_TLS_PORT", Value: "6183"},
+				{Name: "USE_IRONIC_INSPECTOR", Value: "true"},
 			},
 		},
 		"metal3-ramdisk-logs": {
@@ -252,6 +254,7 @@ func TestNewMetal3Containers(t *testing.T) {
 				{Name: "PROVISIONING_IP", Value: "172.30.20.3/24"},
 				{Name: "PROVISIONING_INTERFACE", Value: "eth0"},
 				{Name: "PROVISIONING_MACS", Value: "34:b3:2d:81:f8:fb,34:b3:2d:81:f8:fc,34:b3:2d:81:f8:fd"},
+				{Name: "USE_IRONIC_INSPECTOR", Value: "true"},
 			},
 		},
 		"metal3-static-ip-manager": {


### PR DESCRIPTION
Upstream ironic-image is going to change the default to not use
inspector. To have control over the transition, enable inspector
explicitly for now.
