### PR TITLE
OCPBUGS-28230: add terminationmessagepolicy to show last of error log in API

### DIFF
--- a/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
+++ b/config/cluster-baremetal-operator/cluster-baremetal-operator.yaml
@@ -44,6 +44,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: images
           mountPath: /etc/cluster-baremetal-operator/images

--- a/config/profiles/default/manager_auth_proxy_patch.yaml
+++ b/config/profiles/default/manager_auth_proxy_patch.yaml
@@ -39,6 +39,7 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: config
           mountPath: /etc/baremetal-kube-rbac-proxy

--- a/config/profiles/default/manager_webhook_patch.yaml
+++ b/config/profiles/default/manager_webhook_patch.yaml
@@ -15,6 +15,7 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cluster-baremetal-operator/tls
           name: cert

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment.yaml
@@ -52,6 +52,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cluster-baremetal-operator/tls
           name: cert
@@ -78,6 +79,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/baremetal-kube-rbac-proxy
           name: config


### PR DESCRIPTION
will improve visibility for reasons why a pod failed.