### PR TITLE
OCPBUGS-24579: pass all IPs to image-customization-controller

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -809,7 +810,7 @@ func injectProxyAndCA(containers []corev1.Container, proxy *configv1.Proxy) []co
 	var injectedContainers []corev1.Container
 
 	for _, container := range containers {
-		container.Env = envWithProxy(proxy, container.Env, "")
+		container.Env = envWithProxy(proxy, container.Env, nil)
 		container.VolumeMounts = mountsWithTrustedCA(container.VolumeMounts)
 		injectedContainers = append(injectedContainers, container)
 	}
@@ -817,7 +818,7 @@ func injectProxyAndCA(containers []corev1.Container, proxy *configv1.Proxy) []co
 	return injectedContainers
 }
 
-func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string) []corev1.EnvVar {
+func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy []string) []corev1.EnvVar {
 	if proxy == nil {
 		return envVars
 	}
@@ -834,10 +835,10 @@ func envWithProxy(proxy *configv1.Proxy, envVars []corev1.EnvVar, noproxy string
 			Value: proxy.Status.HTTPSProxy,
 		})
 	}
-	if proxy.Status.NoProxy != "" || noproxy != "" {
+	if proxy.Status.NoProxy != "" || noproxy != nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "NO_PROXY",
-			Value: proxy.Status.NoProxy + "," + noproxy,
+			Value: proxy.Status.NoProxy + "," + strings.Join(noproxy, ","),
 		})
 	}
 

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -18,6 +18,7 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,21 +71,21 @@ func imageRegistriesVolume() corev1.Volume {
 	}
 }
 
-func getUrlFromIP(ipAddr string) string {
-	if strings.Contains(ipAddr, ":") {
-		// This is an IPv6 addr
-		return "https://" + fmt.Sprintf("[%s]", ipAddr)
+func getUrlFromIP(ipAddrs []string, port int) string {
+	portString := fmt.Sprint(port)
+	var result []string
+	for _, ipAddr := range ipAddrs {
+		if ipAddr != "" {
+			result = append(result,
+				"https://"+net.JoinHostPort(ipAddr, portString))
+		}
 	}
-	if ipAddr != "" {
-		// This is an IPv4 addr
-		return "https://" + ipAddr
-	} else {
-		return ""
-	}
+	return strings.Join(result, ",")
 }
 
 func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, ironicIPs []string, inspectorIPs []string) corev1.Container {
-	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, ironicIPs[0]+","+inspectorIPs[0])
+	noProxy := append(ironicIPs, inspectorIPs...)
+	envVars := envWithProxy(info.Proxy, []corev1.EnvVar{}, noProxy)
 
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",
@@ -115,11 +116,12 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 			},
 			corev1.EnvVar{
 				Name:  ironicBaseUrl,
-				Value: getUrlFromIP(ironicIPs[0]),
+				Value: getUrlFromIP(ironicIPs, baremetalIronicPort),
 			},
 			corev1.EnvVar{
-				Name:  ironicInspectorBaseUrl,
-				Value: getUrlFromIP(inspectorIPs[0]),
+				Name: ironicInspectorBaseUrl,
+				// TODO(dtantsur): when inspector is gone, we may be able to stop passing this URL
+				Value: getUrlFromIP(inspectorIPs, baremetalIronicInspectorPort),
 			},
 			corev1.EnvVar{
 				Name:  ironicAgentImage,


### PR DESCRIPTION
This is needed to handle the case when single-stack spoke clusters are
deployed from a dual-stack hub.

While here, make sure to pass ports as part of the URLs. CBO is the
authority on port numbers, ICC should not hardcode them.

Requires:
- https://github.com/openshift/image-customization-controller/pull/120
