### PR TITLE
OCPBUGS-27145: Drop unneccessary capabilities

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -356,6 +356,9 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
 		Env:          env,
@@ -377,7 +380,8 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"NET_ADMIN"},
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN"},
 			},
 		},
 		Env: []corev1.EnvVar{
@@ -460,6 +464,14 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add: []corev1.Capability{
+					"NET_ADMIN",
+					"NET_RAW",
+					"NET_BIND_SERVICE",
+				},
+			},
 		},
 		Command: []string{"/bin/rundnsmasq"},
 		VolumeMounts: []corev1.VolumeMount{
@@ -534,6 +546,9 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		Command:      []string{"/bin/runhttpd"},
 		VolumeMounts: volumes,
@@ -602,6 +617,9 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		Command:      []string{"/bin/runironic"},
 		VolumeMounts: volumes,
@@ -715,6 +733,13 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for mounting /proc to set the addr_gen_mode
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add: []corev1.Capability{
+					"NET_ADMIN",
+					"FOWNER", // Needed for setting the addr_gen_mode
+				},
+			},
 		},
 		Env: []corev1.EnvVar{
 			buildEnvVar(provisioningIP, config),

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -95,6 +95,9 @@ func createContainerImageCache(images *Images) corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		Command:      []string{"/bin/runhttpd"},
 		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -100,6 +100,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			imageRegistriesVolumeMount,

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -42,7 +42,8 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"FOWNER"},
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"FOWNER"},
 			},
 		},
 		Command: []string{"/bin/runironic-proxy"},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -35,6 +35,9 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 		SecurityContext: &corev1.SecurityContext{
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
 		},
 	}
 	return container


### PR DESCRIPTION
Some containers need to run privileged so that we can mount a hostPath volume, but we can at least drop the capabilites we don't need.