### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -367,6 +367,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return initContainer
 }
@@ -393,6 +394,7 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return initContainer
@@ -475,6 +477,7 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 				corev1.ResourceMemory: resource.MustParse("5Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return container
@@ -585,6 +588,7 @@ func createContainerMetal3Httpd(images *Images, config *metal3iov1alpha1.Provisi
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return container
@@ -652,6 +656,7 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return container
@@ -670,6 +675,7 @@ func createContainerMetal3RamdiskLogs(images *Images) corev1.Container {
 				corev1.ResourceMemory: resource.MustParse("5Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return container
 }
@@ -717,6 +723,7 @@ func createContainerMetal3IronicInspector(images *Images, info *ProvisioningInfo
 				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return container
@@ -743,6 +750,7 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	return container

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -175,6 +175,7 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	if !info.BaremetalWebhookEnabled {

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -130,6 +130,7 @@ func createContainerImageCache(images *Images) corev1.Container {
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return container
 }

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -151,6 +151,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return container
 }

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -104,6 +104,7 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return container
 }

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -36,6 +36,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
 		},
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	return container
 }


### PR DESCRIPTION
found more.  This makes debugging via the API easier by attaching the last few kb of failed logs to pod status.