### PR TITLE
OCPBUGS-35211: Add capability to metal3-ramdisk-logs container

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -74,7 +74,6 @@ const (
 )
 
 var ironicUserID int64 = 1002
-var ironicGroupID int64 = 1003
 var inspectorGroupID int64 = 1004
 
 var podTemplateAnnotations = map[string]string{
@@ -700,10 +699,11 @@ func createContainerMetal3RamdiskLogs(images *Images) corev1.Container {
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  ptr.To(ironicUserID),
-			RunAsGroup: ptr.To(ironicGroupID),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
+				Add: []corev1.Capability{
+					"CAP_DAC_OVERRIDE",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The /shared directory is mounted to the ironic, ironic-inspector, ramdisk-logs, dnsmasq, and httpd containers. As the ironic container creates the /shared directory, the ramdisk-logs container was unable to delete files from the directory as it was running as the ironic user and group, but the ironic container (which created and owned the files) was running in privileged mode. 

To resolve this issue, the metal3-ramdisk-logs container is now run with the privileged SecurityContext. 