### PR TITLE
OCPBUGS-29660: Ignore provisioning ip config if disabled

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -61,6 +61,9 @@ func getDHCPRange(config *metal3iov1alpha1.ProvisioningSpec) *string {
 }
 
 func getProvisioningIPCIDR(config *metal3iov1alpha1.ProvisioningSpec) *string {
+	if config.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkDisabled {
+		return nil
+	}
 	if config.ProvisioningNetworkCIDR != "" && config.ProvisioningIP != "" {
 		_, net, err := net.ParseCIDR(config.ProvisioningNetworkCIDR)
 		if err == nil {

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -357,11 +357,13 @@ func TestNewMetal3Containers(t *testing.T) {
 				withEnv(
 					containers["metal3-httpd"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
+					envWithFieldValue("PROVISIONING_IP", "status.hostIP"),
 					envWithValue("IRONIC_LISTEN_PORT", "6388"),
 				),
 				withEnv(
 					containers["metal3-ironic"],
 					envWithValue("PROVISIONING_INTERFACE", ""),
+					envWithFieldValue("PROVISIONING_IP", "status.hostIP"),
 					envWithValue("IRONIC_KERNEL_PARAMS", "rd.net.timeout.carrier=30 ip=dhcp6"),
 				),
 				containers["metal3-ramdisk-logs"],


### PR DESCRIPTION
getProvisioningIPCIDR now returns nil if ProvisioningNetwork is disabled. The external HostIP will then be used (as intended when the prov network is disabled).