### PR TITLE
OCPBUGS-36285: Move pull secret from env var to VolumeMount in metal3-image-customization container

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -68,7 +68,6 @@ const (
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
-	pullSecretEnvVar                 = "IRONIC_AGENT_PULL_SECRET" // #nosec
 	forceInspectorEnvVar             = "USE_IRONIC_INSPECTOR"
 	inspectorHtpasswdPath            = "/auth/inspector/htpasswd" // #nosec G101
 )
@@ -116,18 +115,6 @@ var vmediaTlsMount = corev1.VolumeMount{
 	Name:      vmediaTlsVolume,
 	MountPath: metal3TlsRootDir + "/vmedia",
 	ReadOnly:  true,
-}
-
-var pullSecret = corev1.EnvVar{
-	Name: pullSecretEnvVar,
-	ValueFrom: &corev1.EnvVarSource{
-		SecretKeyRef: &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: PullSecretName,
-			},
-			Key: openshiftConfigSecretKey,
-		},
-	},
 }
 
 var inspectorHtpasswdMount = corev1.VolumeMount{

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -47,6 +47,12 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 	ironicIP := "192.168.0.2"
 	ironicIP6 := "2001:db8::2"
 
+	expectedVolumeMounts := []corev1.VolumeMount{
+		imageRegistriesVolumeMount,
+		imageVolumeMount,
+		ironicAgentPullSecretMount,
+	}
+
 	container1 := corev1.Container{
 		Name: "image-customization-controller",
 		Env: []corev1.EnvVar{
@@ -61,8 +67,8 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 			{Name: "REGISTRIES_CONF_PATH", Value: "/etc/containers/registries.conf"},
 			{Name: "IP_OPTIONS", Value: "ip=dhcp"},
 			{Name: "IRONIC_RAMDISK_SSH_KEY", Value: "sshkey"},
-			pullSecret,
 		},
+		VolumeMounts: expectedVolumeMounts,
 	}
 	secret1 := map[string]string{
 		"IRONIC_BASE_URL":           "https://192.168.0.2:6385",
@@ -82,8 +88,8 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 			{Name: "REGISTRIES_CONF_PATH", Value: "/etc/containers/registries.conf"},
 			{Name: "IP_OPTIONS", Value: "ip=dhcp"},
 			{Name: "IRONIC_RAMDISK_SSH_KEY", Value: "sshkey"},
-			pullSecret,
 		},
+		VolumeMounts: expectedVolumeMounts,
 	}
 	secret2 := map[string]string{
 		"IRONIC_BASE_URL":           "https://192.168.0.2:6385",
@@ -106,8 +112,8 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 			{Name: "REGISTRIES_CONF_PATH", Value: "/etc/containers/registries.conf"},
 			{Name: "IP_OPTIONS", Value: "ip=dhcp"},
 			{Name: "IRONIC_RAMDISK_SSH_KEY", Value: "sshkey"},
-			pullSecret,
 		},
+		VolumeMounts: expectedVolumeMounts,
 	}
 	secret3 := map[string]string{
 		"IRONIC_BASE_URL":           "https://192.168.0.2:6385,https://[2001:db8::2]:6385",
@@ -163,6 +169,7 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 			}
 			actualSecret := newImageCustomizationConfig(info, tc.ironicIPs, tc.inspectorIPs)
 			assert.Equal(t, tc.expectedSecret, actualSecret.StringData)
+			assert.Equal(t, tc.expectedContainer.VolumeMounts, actualContainer.VolumeMounts)
 		})
 	}
 }


### PR DESCRIPTION
This is a backport of #428 