### PR TITLE
OCPBUGS-30919: SCC-pinning for metal3-baremetal-operator

### DIFF
--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -209,9 +209,16 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 
 	containers := injectProxyAndCA([]corev1.Container{container}, info.Proxy)
 
+	podAnnotations := make(map[string]string)
+	for key, val := range podTemplateAnnotations {
+		podAnnotations[key] = val
+	}
+
+	podAnnotations["openshift.io/required-scc"] = "hostnetwork-v2"
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: podTemplateAnnotations,
+			Annotations: podAnnotations,
 			Labels:      *labels,
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
[OCPBUGS-30919](https://issues.redhat.com/browse/OCPBUGS-30919)

Pin `metal3-baremetal-operator` pod to use the `hostnetwork-v2` SCC. This change resolves an issue where the operator pod was being assigned an incorrect SCC, causing it to get stuck in a CreateContainerConfigError state. 

Note for review: verify that the pod has the required SCC annotation by checking for the `openshift.io/required-scc: hostnetwork-v2` in the pod's metadata. 