### PR TITLE
OCPBUGS-31948: Bump go version in CBO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-baremetal-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Steps used:
1. edit go.mod and changed 1.19 to 1.20
2. run go mod tidy
3. run go mod vendor