### PR TITLE
OCPEDGE-1607: feat: add arbiter node selector

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -570,7 +570,7 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 
 	machines := machinev1beta1.MachineList{}
 	bmhNames := []string{}
-	labelReq, _ := labels.NewRequirement("machine.openshift.io/cluster-api-machine-role", selection.Equals, []string{"master"})
+	labelReq, _ := labels.NewRequirement("machine.openshift.io/cluster-api-machine-role", selection.Equals, []string{"master", "arbiter"})
 	err := r.Client.List(ctx, &machines, &client.ListOptions{LabelSelector: labels.NewSelector().Add(*labelReq)})
 	if err != nil {
 		if runtime.IsNotRegisteredError(err) || meta.IsNoMatchError(err) {


### PR DESCRIPTION
Per Arbiter EP: https://github.com/openshift/enhancements/pull/1674

Adding a label or check for arbiter as well as master when the provisioning controller is looking to update the mac address for the machines.
