### PR TITLE
[4.19] OCPBUGS-51275: add missing relatedObjects

### DIFF
--- a/manifests/0000_31_cluster-baremetal-operator_07_clusteroperator.cr.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_07_clusteroperator.cr.yaml
@@ -39,3 +39,15 @@ status:
     name: ""
     resource: "bmceventsubscriptions"
     namespace: openshift-machine-api
+  - group: "metal3.io"
+    name: ""
+    resource: "hostfirmwarecomponents"
+    namespace: openshift-machine-api
+  - group: "metal3.io"
+    name: ""
+    resource: "dataimages"
+    namespace: openshift-machine-api
+  - group: "metal3.io"
+    name: ""
+    resource: "hostupdatepolicies"
+    namespace: openshift-machine-api


### PR DESCRIPTION
This commit adds the missing relatedObjects to CBO