### PR TITLE
NO-ISSUE: Makefile: don't run all linters when running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ VERBOSE ?= ""
 
 all: generate lint build
 
-# Run tests
-test: generate lint manifests
+# Run unit tests
+unit:
 	go test $(VERBOSE) ./... -coverprofile cover.out
 
-# Alias for CI
-unit: test
+# Run tests
+test: generate lint manifests unit
 
 # Build cluster-baremetal-operator binary
 build:


### PR DESCRIPTION
Contrary to the comment, it's not needed for the CI since the CI runs
manifest checks and linters separately.
