### PR TITLE
OCPBUGS-54244: no default for provisioningIP when provisioningInterface is set

### DIFF
--- a/api/v1alpha1/provisioning_validation_test.go
+++ b/api/v1alpha1/provisioning_validation_test.go
@@ -288,9 +288,9 @@ func TestValidateDisabledProvisioningConfig(t *testing.T) {
 			expectedMode:  ProvisioningNetworkDisabled,
 		},
 		{
-			// No Provisioning IP or Network
-			name:          "NoProvisioningIPNetwork",
-			spec:          disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
+			// No Provisioning IP or Network but interface provided
+			name:          "WithProvisioningInterfaceNoIP",
+			spec:          disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").ProvisioningInterface("em1").build(),
 			expectedError: false,
 			expectedMode:  ProvisioningNetworkDisabled,
 		},

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -162,7 +162,8 @@ func buildEnvVar(name string, baremetalProvisioningConfig *metal3iov1alpha1.Prov
 			Name:  name,
 			Value: *value,
 		}
-	} else if name == provisioningIP && baremetalProvisioningConfig.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkDisabled {
+	} else if name == provisioningIP && baremetalProvisioningConfig.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkDisabled &&
+		baremetalProvisioningConfig.ProvisioningInterface == "" {
 		return corev1.EnvVar{
 			Name: name,
 			ValueFrom: &corev1.EnvVarSource{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -390,6 +390,26 @@ func TestNewMetal3Containers(t *testing.T) {
 			},
 			sshkey: "",
 		},
+		{
+			name:   "DisabledSpecWithProvisioningInterface",
+			config: disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").ProvisioningInterface("em1").build(),
+			expectedContainers: []corev1.Container{
+				withEnv(
+					containers["metal3-httpd"],
+					envWithValue("PROVISIONING_INTERFACE", "em1"),
+					envWithValue("PROVISIONING_IP", ""),
+					envWithValue("IRONIC_LISTEN_PORT", "6388"),
+				),
+				withEnv(
+					containers["metal3-ironic"],
+					envWithValue("PROVISIONING_INTERFACE", "em1"),
+					envWithValue("PROVISIONING_IP", ""),
+					envWithValue("IRONIC_KERNEL_PARAMS", "rd.net.timeout.carrier=30 ip=dhcp6"),
+				),
+				containers["metal3-ramdisk-logs"],
+			},
+			sshkey: "",
+		},
 	}
 	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Previously, without a provisioning network, PROVISIONING_IP always
defaulted to the pod's hostIP. This is not a valid configuration when
provisioningInterface is provided.

Depends on updated validations from:
- https://github.com/openshift/cluster-baremetal-operator/pull/466