### PR TITLE
NO-ISSUE: Silence a bogus error with newer golangci-lint

### DIFF
--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
@@ -98,10 +99,7 @@ func TestGetMetal3DeploymentConfig(t *testing.T) {
 				return
 			}
 
-			if actualValue == nil {
-				t.Fatal("actual value was nil")
-			}
-
+			require.NotNil(t, actualValue, "actual value was nil")
 			assert.Equal(t, tc.expectedValue, actualValue, fmt.Sprintf("%s : Expected : %s Actual : %s", tc.configName, *tc.expectedValue, *actualValue))
 			return
 		})


### PR DESCRIPTION
The version I have locally is complaining about actualValue potentially
being nil because it does not consider t.Fatal to be, well, fatal.
Change the approach to using require.NotNil instead of a condition.

Follow-up to:
- https://github.com/openshift/cluster-baremetal-operator/pull/466
