### PR TITLE
OCPBUGS-56723: Treat ResourceNotFound as non-fatal

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -249,7 +249,11 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 	case ReasonComplete, ReasonProvisioningCRNotFound:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(newReason), progressMsg))
-	case ReasonInvalidConfiguration, ReasonDeployTimedOut, ReasonResourceNotFound:
+	case ReasonResourceNotFound:
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, string(newReason), ""))
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionFalse, string(ReasonEmpty), ""))
+		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))
+	case ReasonInvalidConfiguration, ReasonDeployTimedOut:
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue, string(newReason), msg))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty), ""))
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(newReason), progressMsg))


### PR DESCRIPTION
Status ReasonResourceNotFound is not a fatal error, it's a temporary condition while the Metal3 pod does not exist yet.  Setting the operator's status as Degraded is wrong since nothing bad is happening. We set Degraded=False, Progressing=True, Available=False instead.