### PR TITLE
OCPBUGS-53392: Remove webhookport (9447) as HostPort

### DIFF
--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -84,7 +84,6 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "webhook-server",
-				HostPort:      int32(webhookPort),
 				ContainerPort: int32(webhookPort),
 			},
 		},


### PR DESCRIPTION
The webhookport should not be exposed on the host