### PR TITLE
Add readOnlyRootFilesystem flag to baremetal containers deployed using CBO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/apimachinery v0.31.7
 	k8s.io/client-go v0.31.7
 	k8s.io/klog/v2 v2.130.1
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.19.7
 	sigs.k8s.io/controller-tools v0.15.0
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.4

--- a/go.sum
+++ b/go.sum
@@ -1250,8 +1250,8 @@ k8s.io/kube-aggregator v0.30.1/go.mod h1:SFbqWsM6ea8dHd3mPLsZFzJHbjBOS5ykIgJh4zn
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a h1:zD1uj3Jf+mD4zmA7W+goE5TxDkI7OGJjBNBzq5fJtLA=
 k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a/go.mod h1:UxDHUPsUwTOOxSU+oXURfFBcAS6JwiRXTYqYwfuGowc=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 h1:pUdcCO1Lk/tbT5ztQWOBi5HBgbBP1J8+AsQnQCKsi8A=
-k8s.io/utils v0.0.0-20240711033017-18e509b52bc8/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
+k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 mvdan.cc/gofumpt v0.8.0 h1:nZUCeC2ViFaerTcYKstMmfysj6uhQrA2vJe+2vwGU6k=
 mvdan.cc/gofumpt v0.8.0/go.mod h1:vEYnSzyGPmjvFkqJWtXkh79UwPWP9/HMxQdGEXZHjpg=
 mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 h1:WjUu4yQoT5BHT1w8Zu56SP8367OuBV5jvo+4Ulppyf8=

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -46,6 +46,7 @@ const (
 	bootIsoSource                  = "IRONIC_BOOT_ISO_SOURCE"
 	useUnixSocket                  = "unix"
 	useProvisioningDNS             = "provisioning"
+	customConfigPath               = "CUSTOM_CONFIG_DIR" // TODO(hroy): do we need this
 )
 
 func getDHCPRange(config *metal3iov1alpha1.ProvisioningSpec) *string {

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -60,6 +60,12 @@ const (
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
+	ironicConfigVolume               = "metal3-ironic-conf"
+	ironicDataVolume                 = "metal3-ironic-data"
+	ironicConfigPath                 = "/conf"
+	ironicDataPath                   = "/data"
+	ironicTmpVolume                  = "metal3-ironic-tmp"
+	ironicTmpPath                    = "/tmp"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -84,6 +90,27 @@ var ironicTlsMount = corev1.VolumeMount{
 	Name:      ironicTlsVolume,
 	MountPath: metal3TlsRootDir + "/ironic",
 	ReadOnly:  true,
+}
+
+var ironicCertMount = corev1.VolumeMount{
+	Name:      ironicTlsVolume,
+	MountPath: metal3TlsRootDir + "/ca/ironic",
+	ReadOnly:  true,
+}
+
+var ironicConfigMount = corev1.VolumeMount{
+	Name:      ironicConfigVolume,
+	MountPath: ironicConfigPath,
+}
+
+var ironicDataMount = corev1.VolumeMount{
+	Name:      ironicDataVolume,
+	MountPath: ironicDataPath,
+}
+
+var ironicTmpMount = corev1.VolumeMount{
+	Name:      ironicTmpVolume,
+	MountPath: ironicTmpPath,
 }
 
 var vmediaTlsMount = corev1.VolumeMount{
@@ -114,6 +141,24 @@ var metal3Volumes = []corev1.Volume{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	},
+	{
+		Name: ironicConfigVolume,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
+	{
+		Name: ironicDataVolume,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
+	{
+		Name: ironicTmpVolume,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
 	imageVolume(),
 	{
 		Name: ironicCredentialsVolume,
@@ -137,6 +182,12 @@ var metal3Volumes = []corev1.Volume{
 		},
 	},
 	trustedCAVolume(),
+	{
+		Name: "httpd-dir",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	},
 	{
 		Name: ironicTlsVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -288,6 +339,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 		Command:         []string{command},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -314,6 +366,7 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 		Command:         []string{"/set-static-ip"},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"NET_ADMIN"},
@@ -397,6 +450,7 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -412,6 +466,11 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		VolumeMounts: []corev1.VolumeMount{
 			sharedVolumeMount,
 			imageVolumeMount,
+			//TEST(hroy): is the cert mount needed here
+			ironicCertMount,
+			ironicConfigMount,
+			ironicDataMount,
+			//ironicTmpMount,
 		},
 		Env: envVars,
 		Resources: corev1.ResourceRequirements{
@@ -444,6 +503,9 @@ func createContainerMetal3Httpd(images *Images, info *ProvisioningInfo) corev1.C
 		ironicCredentialsMount,
 		imageVolumeMount,
 		ironicTlsMount,
+		ironicDataMount,
+		ironicConfigMount,
+		ironicCertMount,
 	}
 	ports := []corev1.ContainerPort{
 		{
@@ -472,6 +534,7 @@ func createContainerMetal3Httpd(images *Images, info *ProvisioningInfo) corev1.C
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -518,6 +581,10 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 		sharedVolumeMount,
 		imageVolumeMount,
 		ironicTlsMount,
+		ironicCertMount,
+		ironicDataMount,
+		ironicConfigMount,
+		ironicTmpMount,
 	}
 	if !config.DisableVirtualMediaTLS {
 		volumes = append(volumes, vmediaTlsMount)
@@ -528,6 +595,7 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -588,6 +656,7 @@ func createContainerMetal3RamdiskLogs(images *Images) corev1.Container {
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add: []corev1.Capability{
@@ -606,6 +675,7 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 		Command:         []string{"/refresh-static-ip"},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for mounting /proc to set the addr_gen_mode
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -106,6 +106,9 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 			"-retry-period-seconds", "26",
 		},
 		ImagePullPolicy: "IfNotPresent",
+		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			ironicCredentialsMount,
 			ironicTlsMount,

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -93,6 +93,8 @@ func createContainerImageCache(images *Images) corev1.Container {
 		Image:           images.Ironic,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
+			// TODO(hroy): is readOnlyRootFS flag needed here
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -100,7 +102,7 @@ func createContainerImageCache(images *Images) corev1.Container {
 			},
 		},
 		Command:      []string{"/bin/runhttpd"},
-		VolumeMounts: []corev1.VolumeMount{imageVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{imageVolumeMount}, // TODO(hroy): do we need to add any mounts here
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          imageCachePortName,

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -147,6 +147,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 		// TODO: This container does not have to run in privileged mode when the i-c-c has
 		// its own volume and does not have to use the imageCacheSharedVolume
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -37,6 +37,7 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 		Image:           images.Ironic,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"FOWNER"},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -33,6 +33,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/vendor/k8s.io/utils/buffer/ring_growing.go
+++ b/vendor/k8s.io/utils/buffer/ring_growing.go
@@ -16,31 +16,57 @@ limitations under the License.
 
 package buffer
 
+// defaultRingSize defines the default ring size if not specified
+const defaultRingSize = 16
+
+// RingGrowingOptions sets parameters for [RingGrowing] and
+// [TypedRingGrowing].
+type RingGrowingOptions struct {
+	// InitialSize is the number of pre-allocated elements in the
+	// initial underlying storage buffer.
+	InitialSize int
+}
+
 // RingGrowing is a growing ring buffer.
 // Not thread safe.
-type RingGrowing struct {
-	data     []interface{}
+//
+// Deprecated: Use TypedRingGrowing[any] instead.
+type RingGrowing = TypedRingGrowing[any]
+
+// NewRingGrowing constructs a new RingGrowing instance with provided parameters.
+//
+// Deprecated: Use NewTypedRingGrowing[any] instead.
+func NewRingGrowing(initialSize int) *RingGrowing {
+	return NewTypedRingGrowing[any](RingGrowingOptions{InitialSize: initialSize})
+}
+
+// TypedRingGrowing is a growing ring buffer.
+// The zero value has an initial size of 0 and is ready to use.
+// Not thread safe.
+type TypedRingGrowing[T any] struct {
+	data     []T
 	n        int // Size of Data
 	beg      int // First available element
 	readable int // Number of data items available
 }
 
-// NewRingGrowing constructs a new RingGrowing instance with provided parameters.
-func NewRingGrowing(initialSize int) *RingGrowing {
-	return &RingGrowing{
-		data: make([]interface{}, initialSize),
-		n:    initialSize,
+// NewTypedRingGrowing constructs a new TypedRingGrowing instance with provided parameters.
+func NewTypedRingGrowing[T any](opts RingGrowingOptions) *TypedRingGrowing[T] {
+	return &TypedRingGrowing[T]{
+		data: make([]T, opts.InitialSize),
+		n:    opts.InitialSize,
 	}
 }
 
 // ReadOne reads (consumes) first item from the buffer if it is available, otherwise returns false.
-func (r *RingGrowing) ReadOne() (data interface{}, ok bool) {
+func (r *TypedRingGrowing[T]) ReadOne() (data T, ok bool) {
 	if r.readable == 0 {
-		return nil, false
+		return
 	}
 	r.readable--
 	element := r.data[r.beg]
-	r.data[r.beg] = nil // Remove reference to the object to help GC
+	var zero T
+	r.data[r.beg] = zero // Remove reference to the object to help GC
 	if r.beg == r.n-1 {
 		// Was the last element
 		r.beg = 0
@@ -51,11 +77,14 @@ func (r *RingGrowing) ReadOne() (data interface{}, ok bool) {
 }
 
 // WriteOne adds an item to the end of the buffer, growing it if it is full.
-func (r *RingGrowing) WriteOne(data interface{}) {
+func (r *TypedRingGrowing[T]) WriteOne(data T) {
 	if r.readable == r.n {
 		// Time to grow
 		newN := r.n * 2
-		newData := make([]interface{}, newN)
+		if newN == 0 {
+			newN = defaultRingSize
+		}
+		newData := make([]T, newN)
 		to := r.beg + r.readable
 		if to <= r.n {
 			copy(newData, r.data[r.beg:to])
@@ -69,4 +98,73 @@ func (r *RingGrowing) WriteOne(data interface{}) {
 	}
 	r.data[(r.readable+r.beg)%r.n] = data
 	r.readable++
+}
+
+// Len returns the number of items in the buffer.
+func (r *TypedRingGrowing[T]) Len() int {
+	return r.readable
+}
+
+// Cap returns the capacity of the buffer.
+func (r *TypedRingGrowing[T]) Cap() int {
+	return r.n
+}
+
+// RingOptions sets parameters for [Ring].
+type RingOptions struct {
+	// InitialSize is the number of pre-allocated elements in the
+	// initial underlying storage buffer.
+	InitialSize int
+	// NormalSize is the number of elements to allocate for new storage
+	// buffers once the Ring is consumed and
+	// can shrink again.
+	NormalSize int
+}
+
+// Ring is a dynamically-sized ring buffer which can grow and shrink as-needed.
+// The zero value has an initial size and normal size of 0 and is ready to use.
+// Not thread safe.
+type Ring[T any] struct {
+	growing    TypedRingGrowing[T]
+	normalSize int // Limits the size of the buffer that is kept for reuse. Read-only.
+}
+
+// NewRing constructs a new Ring instance with provided parameters.
+func NewRing[T any](opts RingOptions) *Ring[T] {
+	return &Ring[T]{
+		growing:    *NewTypedRingGrowing[T](RingGrowingOptions{InitialSize: opts.InitialSize}),
+		normalSize: opts.NormalSize,
+	}
+}
+
+// ReadOne reads (consumes) first item from the buffer if it is available,
+// otherwise returns false. When the buffer has been totally consumed and has
+// grown in size beyond its normal size, it shrinks down to its normal size again.
+func (r *Ring[T]) ReadOne() (data T, ok bool) {
+	element, ok := r.growing.ReadOne()
+
+	if r.growing.readable == 0 && r.growing.n > r.normalSize {
+		// The buffer is empty. Reallocate a new buffer so the old one can be
+		// garbage collected.
+		r.growing.data = make([]T, r.normalSize)
+		r.growing.n = r.normalSize
+		r.growing.beg = 0
+	}
+
+	return element, ok
+}
+
+// WriteOne adds an item to the end of the buffer, growing it if it is full.
+func (r *Ring[T]) WriteOne(data T) {
+	r.growing.WriteOne(data)
+}
+
+// Len returns the number of items in the buffer.
+func (r *Ring[T]) Len() int {
+	return r.growing.Len()
+}
+
+// Cap returns the capacity of the buffer.
+func (r *Ring[T]) Cap() int {
+	return r.growing.Cap()
 }

--- a/vendor/k8s.io/utils/clock/testing/fake_clock.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock.go
@@ -48,7 +48,6 @@ type fakeClockWaiter struct {
 	stepInterval  time.Duration
 	skipIfBlocked bool
 	destChan      chan time.Time
-	fired         bool
 	afterFunc     func()
 }
 
@@ -198,12 +197,10 @@ func (f *FakeClock) setTimeLocked(t time.Time) {
 			if w.skipIfBlocked {
 				select {
 				case w.destChan <- t:
-					w.fired = true
 				default:
 				}
 			} else {
 				w.destChan <- t
-				w.fired = true
 			}
 
 			if w.afterFunc != nil {
@@ -224,12 +221,24 @@ func (f *FakeClock) setTimeLocked(t time.Time) {
 	f.waiters = newWaiters
 }
 
-// HasWaiters returns true if After or AfterFunc has been called on f but not yet satisfied (so you can
-// write race-free tests).
+// HasWaiters returns true if Waiters() returns non-0 (so you can write race-free tests).
 func (f *FakeClock) HasWaiters() bool {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	return len(f.waiters) > 0
+}
+
+// Waiters returns the number of "waiters" on the clock (so you can write race-free
+// tests). A waiter exists for:
+//   - every call to After that has not yet signaled its channel.
+//   - every call to AfterFunc that has not yet called its callback.
+//   - every timer created with NewTimer which is currently ticking.
+//   - every ticker created with NewTicker which is currently ticking.
+//   - every ticker created with Tick.
+func (f *FakeClock) Waiters() int {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters)
 }
 
 // Sleep is akin to time.Sleep
@@ -305,44 +314,48 @@ func (f *fakeTimer) C() <-chan time.Time {
 	return f.waiter.destChan
 }
 
-// Stop stops the timer and returns true if the timer has not yet fired, or false otherwise.
+// Stop prevents the Timer from firing. It returns true if the call stops the
+// timer, false if the timer has already expired or been stopped.
 func (f *fakeTimer) Stop() bool {
 	f.fakeClock.lock.Lock()
 	defer f.fakeClock.lock.Unlock()
 
+	active := false
 	newWaiters := make([]*fakeClockWaiter, 0, len(f.fakeClock.waiters))
 	for i := range f.fakeClock.waiters {
 		w := f.fakeClock.waiters[i]
 		if w != &f.waiter {
 			newWaiters = append(newWaiters, w)
+			continue
 		}
+		// If timer is found, it has not been fired yet.
+		active = true
 	}
 
 	f.fakeClock.waiters = newWaiters
 
-	return !f.waiter.fired
+	return active
 }
 
-// Reset resets the timer to the fake clock's "now" + d. It returns true if the timer has not yet
-// fired, or false otherwise.
+// Reset changes the timer to expire after duration d. It returns true if the
+// timer had been active, false if the timer had expired or been stopped.
 func (f *fakeTimer) Reset(d time.Duration) bool {
 	f.fakeClock.lock.Lock()
 	defer f.fakeClock.lock.Unlock()
 
-	active := !f.waiter.fired
+	active := false
 
-	f.waiter.fired = false
 	f.waiter.targetTime = f.fakeClock.time.Add(d)
 
-	var isWaiting bool
 	for i := range f.fakeClock.waiters {
 		w := f.fakeClock.waiters[i]
 		if w == &f.waiter {
-			isWaiting = true
+			// If timer is found, it has not been fired yet.
+			active = true
 			break
 		}
 	}
-	if !isWaiting {
+	if !active {
 		f.fakeClock.waiters = append(f.fakeClock.waiters, &f.waiter)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2009,7 +2009,7 @@ k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
 k8s.io/kube-openapi/pkg/validation/validate
-# k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+# k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 ## explicit; go 1.18
 k8s.io/utils/buffer
 k8s.io/utils/clock


### PR DESCRIPTION
Add readOnlyRootFilesystem flag to containers metal3-httpd, metal3-dnsmasq, metal3-ironic and barmetal-operator. Also add writable mounts for ironic cert, data, conf and tmp mounts since we need these paths are writable for the deployment to succeed.