### PR TITLE
METAL-1459: add default PrometheusRule deployment for IPE and watch Servicemonitor

### DIFF
--- a/api/v1alpha1/provisioning_types.go
+++ b/api/v1alpha1/provisioning_types.go
@@ -90,6 +90,11 @@ type PrometheusExporter struct {
 	// +kubebuilder:default=60
 	// +kubebuilder:validation:Minimum=60
 	SensorCollectionInterval int `json:"sensorCollectionInterval,omitempty"`
+
+	// DisableDefaultPrometheusRules controls whether default hardware health
+	// alerting rules should NOT be deployed alongside the prometheus exporter.
+	// When false (default), default prometheus rules are deployed.
+	DisableDefaultPrometheusRules bool `json:"disableDefaultPrometheusRules,omitempty"`
 }
 
 // ProvisioningSpec defines the desired state of Provisioning

--- a/config/crd/bases/metal3.io_provisionings.yaml
+++ b/config/crd/bases/metal3.io_provisionings.yaml
@@ -99,6 +99,12 @@ spec:
                   ironic-prometheus-exporter container, and creates supporting resources
                   (ServiceMonitor, Service ports) to expose hardware sensor metrics for Prometheus.
                 properties:
+                  disableDefaultPrometheusRules:
+                    description: |-
+                      DisableDefaultPrometheusRules controls whether default hardware health
+                      alerting rules should NOT be deployed alongside the prometheus exporter.
+                      When false (default), default prometheus rules are deployed.
+                    type: boolean
                   enabled:
                     description: |-
                       Enabled controls whether sensor data collection is active.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -353,6 +353,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - prometheusrules
   - servicemonitors
   verbs:
   - create

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -105,6 +107,28 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{
 				controllers.ComponentNamespace:        {},
 				provisioning.OpenshiftConfigNamespace: {},
+			},
+			ByObject: map[client.Object]cache.ByObject{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "monitoring.coreos.com/v1",
+						"kind":       "ServiceMonitor",
+					},
+				}: {
+					Namespaces: map[string]cache.Config{
+						controllers.ComponentNamespace: {},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "monitoring.coreos.com/v1",
+						"kind":       "PrometheusRule",
+					},
+				}: {
+					Namespaces: map[string]cache.Config{
+						controllers.ComponentNamespace: {},
+					},
+				},
 			},
 		},
 	}

--- a/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_02_metal3provisioning.crd.yaml
@@ -101,6 +101,12 @@ spec:
                   ironic-prometheus-exporter container, and creates supporting resources
                   (ServiceMonitor, Service ports) to expose hardware sensor metrics for Prometheus.
                 properties:
+                  disableDefaultPrometheusRules:
+                    description: |-
+                      DisableDefaultPrometheusRules controls whether default hardware health
+                      alerting rules should NOT be deployed alongside the prometheus exporter.
+                      When false (default), default prometheus rules are deployed.
+                    type: boolean
                   enabled:
                     description: |-
                       Enabled controls whether sensor data collection is active.

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -46,6 +46,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - prometheusrules
   - servicemonitors
   verbs:
   - create


### PR DESCRIPTION
This builds on https://github.com/openshift/cluster-baremetal-operator/pull/490, to deploy default set of promrules. 

```
oc patch provisioning provisioning-configuration --type=merge -p '{"spec":{"prometheusExporter":{"disableDefaultPrometheusRules":false}}}'
```

This also allows the operator to watch the IPE Servicemonitor 