### PR TITLE
OCPBUGS-61477: Enable runtime extraction of aarch64 images

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -116,6 +116,8 @@ var metal3Volumes = []corev1.Volume{
 		},
 	},
 	imageVolume(),
+	ironicAgentPullSecretVolume(),
+	userCABundleVolume(),
 	{
 		Name: ironicCredentialsVolume,
 		VolumeSource: corev1.VolumeSource{

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -18,12 +18,18 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 		Command: []string{"/bin/copy-metal", whichImages, destPath},
 		VolumeMounts: []corev1.VolumeMount{
 			dest,
+			ironicAgentPullSecretMount,
+			userCaBundleVolumeMount,
 		},
 		ImagePullPolicy: "IfNotPresent",
 		Env: []corev1.EnvVar{
 			{
 				Name:  ipOptions,
 				Value: ipOptionValue,
+			},
+			{
+				Name:  "MACHINE_OS_IMAGES_IMAGE",
+				Value: info.Images.MachineOSImages,
 			},
 		},
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
The machine-os-images init container will now acquire aarch64 images by extracting them from the release payload instead of downloading them at build time.  This change adds the necessary configuration to the container.