### PR TITLE
OCPBUGS-60498: Always have a service for ironic-api port

### DIFF
--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -36,6 +36,14 @@ func newMetal3StateService(info *ProvisioningInfo) *corev1.Service {
 			Port: int32(port),
 		},
 	}
+	// Always expose port 6385 since it's always available as a hostPort
+	// either directly from the main pod or via the ironic-proxy DaemonSet
+	if ironicPort != baremetalIronicPort {
+		ports = append(ports, corev1.ServicePort{
+			Name: "ironic-api",
+			Port: int32(baremetalIronicPort),
+		})
+	}
 	if !info.ProvConfig.Spec.DisableVirtualMediaTLS {
 		ports = append(ports, corev1.ServicePort{
 			Name: vmediaHttpsPortName,


### PR DESCRIPTION
The current metal3-state service exposes different ports based on whether the proxy is enabled, port 6385 if without proxy, port 6388 (the private port) if with proxy.
Since port 6385 is exposed as a hostPort in both cases, there should always be a service exposing port 6385, regardless of the proxy configuration.