### PR TITLE
Remove machine-os-images from baremetal pod

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -116,8 +116,6 @@ var metal3Volumes = []corev1.Volume{
 		},
 	},
 	imageVolume(),
-	ironicAgentPullSecretVolume(),
-	userCABundleVolume(),
 	{
 		Name: ironicCredentialsVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -250,9 +248,6 @@ func newMetal3InitContainers(info *ProvisioningInfo) []corev1.Container {
 	if info.ProvConfig.Spec.ProvisioningIP != "" && info.ProvConfig.Spec.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
 		initContainers = append(initContainers, createInitContainerStaticIpSet(info.Images, &info.ProvConfig.Spec))
 	}
-
-	// Extract the pre-provisioning images from a container in the payload
-	initContainers = append(initContainers, createInitContainerMachineOSImages(info, "--all", imageVolumeMount, imageSharedDir))
 
 	// If the ProvisioningOSDownloadURL is set, we download the URL specified in it
 	if info.ProvConfig.Spec.ProvisioningOSDownloadURL != "" {

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -104,10 +104,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 					Image: images.StaticIpManager,
 				},
 				{
-					Name:  "machine-os-images",
-					Image: images.MachineOSImages,
-				},
-				{
 					Name:  "metal3-machine-os-downloader",
 					Image: images.MachineOsDownloader,
 				},
@@ -118,10 +114,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 			config: disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").build(),
 			expectedContainers: []corev1.Container{
 				{
-					Name:  "machine-os-images",
-					Image: images.MachineOSImages,
-				},
-				{
 					Name:  "metal3-machine-os-downloader",
 					Image: images.MachineOsDownloader,
 				},
@@ -131,10 +123,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 			name:   "disabled with provisioning ip",
 			config: disabledProvisioning().ProvisioningIP("1.2.3.4").ProvisioningNetworkCIDR("").build(),
 			expectedContainers: []corev1.Container{
-				{
-					Name:  "machine-os-images",
-					Image: images.MachineOSImages,
-				},
 				{
 					Name:  "metal3-machine-os-downloader",
 					Image: images.MachineOsDownloader,
@@ -148,10 +136,6 @@ func TestNewMetal3InitContainers(t *testing.T) {
 				{
 					Name:  "metal3-static-ip-set",
 					Image: images.StaticIpManager,
-				},
-				{
-					Name:  "machine-os-images",
-					Image: images.MachineOSImages,
 				},
 				{
 					Name:  "metal3-machine-os-downloader",


### PR DESCRIPTION
We don't need to run the init container twice.  Only image customization depends on it.  This change also has the side effect of removing two volumes from the baremetal pod.

We introduced the machine-os-images init container in the baremetal pod in 07a9877a314e7c766d214d56067a9f84df779a61.  Then, machine-os-images was moved from the cache to image-customization in 2cede0a3319c8455bda346ac8dc6560cc25fa03b.