### PR TITLE
METAL-1656: Remove entity_id from PrometheusRule alert descriptions

### DIFF
--- a/provisioning/state_service.go
+++ b/provisioning/state_service.go
@@ -189,7 +189,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Temperature warning on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
 								},
 							},
 							map[string]interface{}{
@@ -201,7 +201,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Temperature critical on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
 								},
 							},
 							// Power alerts
@@ -214,7 +214,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Power warning on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
 								},
 							},
 							map[string]interface{}{
@@ -226,7 +226,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Power critical on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
 								},
 							},
 							// Fan alerts
@@ -239,7 +239,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Fan warning on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
 								},
 							},
 							map[string]interface{}{
@@ -251,7 +251,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Fan critical on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
 								},
 							},
 							// Drive alerts
@@ -264,7 +264,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Drive warning on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Warning status on {{ $labels.node_name }}",
 								},
 							},
 							map[string]interface{}{
@@ -276,7 +276,7 @@ func NewIronicPrometheusRule(namespace string) *unstructured.Unstructured {
 								},
 								"annotations": map[string]interface{}{
 									"summary":     "Drive critical on {{ $labels.node_name }}",
-									"description": "{{ $labels.entity_id }} sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
+									"description": "Sensor {{ $labels.sensor_id }} reports Critical status on {{ $labels.node_name }}",
 								},
 							},
 						},


### PR DESCRIPTION
The entity_id label is not provided by IPE due to a [bug](https://bugs.launchpad.net/ironic-prometheus-exporter/+bug/2130275). Remove it from all alert descriptions to avoid showing empty values in alerts.

Before
```
sensor 2@System.Embedded.1 reports Warning status on cnfdf27~cnfdf27.telco5gran.eng.rdu2.redhat.com
```

After
```
Sensor 2@System.Embedded.1 reports Warning status on cnfdf27~cnfdf27.telco5gran.eng.rdu2.redhat.com
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

/cc @dtantsur @iurygregory 