### PR TITLE
METAL-1664: Remove regular cluster profile from hostedcluster CBO deployment

### DIFF
--- a/config/cluster-baremetal-operator-hostedcluster/kustomization.yaml
+++ b/config/cluster-baremetal-operator-hostedcluster/kustomization.yaml
@@ -1,6 +1,6 @@
 commonAnnotations:
   include.release.openshift.io/ibm-cloud-managed: "true"
-  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/hypershift: "true"
   include.release.openshift.io/single-node-developer: "true"
   capability.openshift.io/name: baremetal
 

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment-hostedcluster.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment-hostedcluster.yaml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   annotations:
     capability.openshift.io/name: baremetal
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     k8s-app: cluster-baremetal-operator
@@ -21,8 +21,8 @@ spec:
     metadata:
       annotations:
         capability.openshift.io/name: baremetal
+        include.release.openshift.io/hypershift: "true"
         include.release.openshift.io/ibm-cloud-managed: "true"
-        include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
         openshift.io/required-scc: anyuid
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'


### PR DESCRIPTION
Remove regular cluster profile from hostedcluster CBO deployment.
This should prevent creating the cluster-baremetal-operator-hostedcluster deployment on regular (non-hypershift/hosted clusters) openshift clusters.