### PR TITLE
TRT-2441: Revert #529 "METAL-1664: Remove regular cluster profile from hostedcluster CBO deployment"

### DIFF
--- a/config/cluster-baremetal-operator-hostedcluster/kustomization.yaml
+++ b/config/cluster-baremetal-operator-hostedcluster/kustomization.yaml
@@ -1,6 +1,6 @@
 commonAnnotations:
   include.release.openshift.io/ibm-cloud-managed: "true"
-  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
   include.release.openshift.io/single-node-developer: "true"
   capability.openshift.io/name: baremetal
 

--- a/manifests/0000_31_cluster-baremetal-operator_06_deployment-hostedcluster.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_06_deployment-hostedcluster.yaml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   annotations:
     capability.openshift.io/name: baremetal
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:
     k8s-app: cluster-baremetal-operator
@@ -21,8 +21,8 @@ spec:
     metadata:
       annotations:
         capability.openshift.io/name: baremetal
-        include.release.openshift.io/hypershift: "true"
         include.release.openshift.io/ibm-cloud-managed: "true"
+        include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
         openshift.io/required-scc: anyuid
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'


### PR DESCRIPTION

Reverts #529 ; tracked by [TRT-2441](https://issues.redhat.com//browse/TRT-2441)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR is suspect of breaking micro (4.21 -> 4.21) updates on CI payloads, starting with https://amd64.ocp.releases.ci.openshift.org/releasestream/4.21.0-0.ci/release/4.21.0-0.ci-2025-11-26-095308

Most recent failing payload: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.21.0-0.ci/release/4.21.0-0.ci-2025-11-27-095308

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-e2e-gcp-ovn-upgrade/1993983637070024704

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-ci-4.21-e2e-gcp-ovn-upgrade

The failure does not seem entirely deterministic, it may require multiple executions or an aggregated one
```

CC: @MahnoorAsghar

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
