### PR TITLE
OCPBUGS-66144: Enable readOnlyRootFS flag for machine-os-images container

### DIFF
--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -39,9 +39,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			// TODO(hroyrh): re-enable this flag after fixing machine-os-images
-			// runtime copying in readOnly /coreos directory.
-			// ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
This is a follow up pr of the #497 pr and fixes the issue -
Enable the `ReadOnlyRootFilesystem` flag for machine-os-images container, it depends on pr [machine-os-images#72](https://github.com/openshift/machine-os-images/pull/72) ( already merged )