### PR TITLE
Revert "METAL-1351: Add readOnlyRootFilesystem flag to baremetal containers deployed using CBO"

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -61,13 +61,6 @@ const (
 	cboOwnedAnnotation               = "baremetal.openshift.io/owned"
 	cboLabelName                     = "baremetal.openshift.io/cluster-baremetal-operator"
 	externalTrustBundleConfigMapName = "cbo-trusted-ca"
-	ironicConfigVolume               = "metal3-ironic-conf"
-	ironicDataVolume                 = "metal3-ironic-data"
-	ironicConfigPath                 = "/conf"
-	ironicDataPath                   = "/data"
-	ironicTmpVolume                  = "metal3-ironic-tmp"
-	ironicTmpPath                    = "/tmp"
-	ironicCertVolume                 = "metal3-ironic-cacert"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -94,26 +87,6 @@ var ironicTlsMount = corev1.VolumeMount{
 	ReadOnly:  true,
 }
 
-var ironicCertMount = corev1.VolumeMount{
-	Name:      ironicCertVolume,
-	MountPath: metal3TlsRootDir + "/ca/ironic",
-}
-
-var ironicConfigMount = corev1.VolumeMount{
-	Name:      ironicConfigVolume,
-	MountPath: ironicConfigPath,
-}
-
-var ironicDataMount = corev1.VolumeMount{
-	Name:      ironicDataVolume,
-	MountPath: ironicDataPath,
-}
-
-var ironicTmpMount = corev1.VolumeMount{
-	Name:      ironicTmpVolume,
-	MountPath: ironicTmpPath,
-}
-
 var vmediaTlsMount = corev1.VolumeMount{
 	Name:      vmediaTlsVolume,
 	MountPath: metal3TlsRootDir + "/vmedia",
@@ -138,30 +111,6 @@ func trustedCAVolume() corev1.Volume {
 var metal3Volumes = []corev1.Volume{
 	{
 		Name: baremetalSharedVolume,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	},
-	{
-		Name: ironicConfigVolume,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	},
-	{
-		Name: ironicDataVolume,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	},
-	{
-		Name: ironicTmpVolume,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	},
-	{
-		Name: ironicCertVolume,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
@@ -344,7 +293,6 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 		Command:         []string{command},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -371,7 +319,6 @@ func createInitContainerStaticIpSet(images *Images, config *metal3iov1alpha1.Pro
 		Command:         []string{"/set-static-ip"},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"NET_ADMIN"},
@@ -460,7 +407,6 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -476,8 +422,6 @@ func createContainerMetal3Dnsmasq(images *Images, config *metal3iov1alpha1.Provi
 		VolumeMounts: []corev1.VolumeMount{
 			sharedVolumeMount,
 			imageVolumeMount,
-			ironicConfigMount,
-			ironicDataMount,
 		},
 		Env: envVars,
 		Resources: corev1.ResourceRequirements{
@@ -510,9 +454,6 @@ func createContainerMetal3Httpd(images *Images, info *ProvisioningInfo) corev1.C
 		ironicCredentialsMount,
 		imageVolumeMount,
 		ironicTlsMount,
-		ironicDataMount,
-		ironicConfigMount,
-		ironicCertMount,
 	}
 	ports := []corev1.ContainerPort{
 		{
@@ -541,7 +482,6 @@ func createContainerMetal3Httpd(images *Images, info *ProvisioningInfo) corev1.C
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -588,10 +528,6 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 		sharedVolumeMount,
 		imageVolumeMount,
 		ironicTlsMount,
-		ironicCertMount,
-		ironicDataMount,
-		ironicConfigMount,
-		ironicTmpMount,
 	}
 	if !config.DisableVirtualMediaTLS {
 		volumes = append(volumes, vmediaTlsMount)
@@ -602,7 +538,6 @@ func createContainerMetal3Ironic(images *Images, info *ProvisioningInfo, config 
 		Image:           images.Ironic,
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
@@ -677,7 +612,6 @@ func createContainerMetal3RamdiskLogs(images *Images) corev1.Container {
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add: []corev1.Capability{
@@ -728,7 +662,6 @@ func createContainerMetal3StaticIpManager(images *Images, config *metal3iov1alph
 		Command:         []string{"/refresh-static-ip"},
 		ImagePullPolicy: "IfNotPresent",
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for mounting /proc to set the addr_gen_mode
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -106,9 +106,6 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 			"-retry-period-seconds", "26",
 		},
 		ImagePullPolicy: "IfNotPresent",
-		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
-		},
 		VolumeMounts: []corev1.VolumeMount{
 			ironicCredentialsMount,
 			ironicTlsMount,

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -148,7 +148,6 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 		// TODO: This container does not have to run in privileged mode when the i-c-c has
 		// its own volume and does not have to use the imageCacheSharedVolume
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{

--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -37,7 +37,8 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 		Image:           images.Ironic,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			// Set this for ironic-proxy with custom dirs
+			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
@@ -45,9 +46,6 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 		Command: []string{"/bin/runironic-proxy"},
 		VolumeMounts: []corev1.VolumeMount{
 			ironicTlsMount,
-			ironicCertMount,
-			ironicConfigMount,
-			ironicDataMount,
 		},
 		Ports: []corev1.ContainerPort{
 			{
@@ -156,24 +154,6 @@ func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateS
 							},
 							Optional: ptr.To(true),
 						},
-					},
-				},
-				{
-					Name: ironicCertVolume,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: ironicConfigVolume,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: ironicDataVolume,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 			},

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -39,9 +39,6 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			// TODO(hroyrh): re-enable this flag after fixing machine-os-images
-			// runtime copying in readOnly /coreos directory.
-			// ReadOnlyRootFilesystem: ptr.To(true),
 			// Needed for hostPath image volume mount
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
Reverts openshift/cluster-baremetal-operator#497
Opening this PR because PR#497 is causing the inspection (and deployment) of worker nodes to fail in dev-scripts, using the registry.ci.openshift.org/ocp/release:4.20.0-0.nightly-2025-11-27-212931 nightly. 
the metal3-ironic container in the metal3 pod has this error:
                                                                                                                                                                            
```
2025-11-28 14:27:17.346 1 ERROR ironic.conductor.task_manager [None req-ef860707-6807-4f47-8b46-18f0ce355fe7 - - - - - -] Node 14c9c8c0-81da-4ee6-9366-4e6b9d2f00db moved  to provision state "inspect failed" from state "inspecting"; target provision state is "manageable": ironic.common.exception.HardwareInspectionFailure: Failed to inspect hardware. Reason: unable to start inspection: [Errno 30] Read-only file system: '/var/lib/ironic/master_iso_images'                                                    
2025-11-28 14:27:17.347 1 ERROR ironic.conductor.inspection [None req-ef860707-6807-4f47-8b46-18f0ce355fe7 - - - - - -] Failed to inspect node 14c9c8c0-81da-4ee6-9366-4e6b9d2f00db: Failed to inspect hardware. Reason: unable to start inspection: [Errno 30] Read-only file system: '/var/lib/ironic/master_iso_images': ironic.common.exception.HardwareInspectionFailure: Failed to inspect hardware. Reason: unable to start inspection: [Errno 30] Read-only file system: '/var/lib/ironic/master_iso_images'
```

And the ironic-proxy pod is also in a CrashLoop, with this error message observed in logs:
```
+ sed -i 's/^Listen .*$/Listen [::]:6385/' /etc/httpd/conf/httpd.conf
sed: couldn't open temporary file /etc/httpd/conf/sed16mMCN: Read-only file system 
```

While we fix these issues, I need a revert to test https://github.com/openshift/cluster-baremetal-operator/pull/531, which is needed because upgrade jobs on GCP are failing.