### PR TITLE
OCPBUGS-72548: Fix ironic-proxy service routing for port 6385

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -337,6 +337,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		provisioning.EnsureImageCustomizationService,
 		provisioning.EnsureImageCustomizationDeployment,
 		provisioning.EnsureIronicProxy,
+		provisioning.EnsureIronicProxyService,
 		provisioning.EnsureIronicServiceMonitor,
 		provisioning.EnsureIronicPrometheusRule,
 	} {
@@ -511,6 +512,9 @@ func (r *ProvisioningReconciler) deleteMetal3Resources(info *provisioning.Provis
 	}
 	if err := provisioning.DeleteIronicProxy(info); err != nil {
 		return errors.Wrap(err, "failed to delete ironic proxy")
+	}
+	if err := provisioning.DeleteIronicProxyService(info); err != nil {
+		return errors.Wrap(err, "failed to delete ironic proxy service")
 	}
 	if err := provisioning.DeleteIronicServiceMonitor(info); err != nil {
 		return errors.Wrap(err, "failed to delete ironic service monitor")

--- a/provisioning/ironic_proxy_test.go
+++ b/provisioning/ironic_proxy_test.go
@@ -1,0 +1,107 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestUseIronicProxy(t *testing.T) {
+	tCases := []struct {
+		name     string
+		info     *ProvisioningInfo
+		expected bool
+	}{
+		{
+			name: "ProvisioningNetwork Disabled",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				IsHyperShift: false,
+			},
+			expected: true,
+		},
+		{
+			name: "VirtualMediaViaExternalNetwork enabled",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
+				},
+				IsHyperShift: false,
+			},
+			expected: true,
+		},
+		{
+			name: "Managed provisioning without VirtualMediaViaExternalNetwork",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *managedProvisioning().build(),
+				},
+				IsHyperShift: false,
+			},
+			expected: false,
+		},
+		{
+			name: "HyperShift mode - ironic proxy disabled even with disabled network",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				IsHyperShift: true,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := UseIronicProxy(tc.info)
+			assert.Equal(t, tc.expected, actual, "UseIronicProxy result mismatch")
+		})
+	}
+}
+
+func TestNewIronicProxyService(t *testing.T) {
+	info := &ProvisioningInfo{
+		ProvConfig: &metal3iov1alpha1.Provisioning{
+			Spec: *disabledProvisioning().build(),
+		},
+		Namespace: "openshift-machine-api",
+	}
+
+	svc := newIronicProxyService(info)
+
+	// Verify metadata
+	assert.Equal(t, ironicProxyService, svc.Name, "Service name mismatch")
+	assert.Equal(t, "openshift-machine-api", svc.Namespace, "Namespace mismatch")
+	assert.Equal(t, ironicProxyService, svc.Labels[cboLabelName], "Label mismatch")
+
+	// Verify spec
+	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type, "Service type should be ClusterIP")
+	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP, "ClusterIP should be None (headless)")
+	assert.Equal(t, ironicProxyService, svc.Spec.Selector[cboLabelName], "Selector mismatch")
+
+	// Verify ports
+	assert.Len(t, svc.Spec.Ports, 1, "Should have exactly one port")
+	assert.Equal(t, "ironic-api", svc.Spec.Ports[0].Name, "Port name mismatch")
+	assert.Equal(t, int32(baremetalIronicPort), svc.Spec.Ports[0].Port, "Port should be 6385")
+}

--- a/provisioning/state_service_test.go
+++ b/provisioning/state_service_test.go
@@ -1,0 +1,134 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestNewMetal3StateService(t *testing.T) {
+	tCases := []struct {
+		name                    string
+		info                    *ProvisioningInfo
+		expectedIronicPort      int32
+		expectedIronicAPIPort   int32
+		expectedIronicAPITarget int32
+		hasIronicAPIPort        bool
+	}{
+		{
+			name: "Managed provisioning - no ironic-proxy",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *managedProvisioning().build(),
+				},
+				Namespace:    "openshift-machine-api",
+				IsHyperShift: false,
+			},
+			expectedIronicPort: int32(baremetalIronicPort), // 6385
+			hasIronicAPIPort:   false,                      // No separate ironic-api port when ironic-proxy is disabled
+		},
+		{
+			name: "Disabled provisioning - with ironic-proxy",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				Namespace:    "openshift-machine-api",
+				IsHyperShift: false,
+			},
+			expectedIronicPort:      int32(ironicPrivatePort), // 6388
+			hasIronicAPIPort:        true,
+			expectedIronicAPIPort:   int32(baremetalIronicPort), // 6385
+			expectedIronicAPITarget: int32(ironicPrivatePort),   // 6388 (routes to the private port)
+		},
+		{
+			name: "VirtualMediaViaExternalNetwork enabled - with ironic-proxy",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *managedProvisioning().VirtualMediaViaExternalNetwork(true).build(),
+				},
+				Namespace:    "openshift-machine-api",
+				IsHyperShift: false,
+			},
+			expectedIronicPort:      int32(ironicPrivatePort), // 6388
+			hasIronicAPIPort:        true,
+			expectedIronicAPIPort:   int32(baremetalIronicPort), // 6385
+			expectedIronicAPITarget: int32(ironicPrivatePort),   // 6388 (routes to the private port)
+		},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newMetal3StateService(tc.info)
+
+			// Verify service metadata
+			assert.Equal(t, stateService, svc.Name, "Service name mismatch")
+			assert.Equal(t, tc.info.Namespace, svc.Namespace, "Namespace mismatch")
+			assert.Equal(t, stateService, svc.Labels[cboLabelName], "Label mismatch")
+
+			// Verify selector
+			assert.Equal(t, stateService, svc.Spec.Selector[cboLabelName], "Selector mismatch")
+
+			// Find the ironic port
+			var ironicPort *corev1.ServicePort
+			var ironicAPIPort *corev1.ServicePort
+			for i := range svc.Spec.Ports {
+				switch svc.Spec.Ports[i].Name {
+				case "ironic":
+					ironicPort = &svc.Spec.Ports[i]
+				case "ironic-api":
+					ironicAPIPort = &svc.Spec.Ports[i]
+				}
+			}
+
+			// Verify the main ironic port
+			assert.NotNil(t, ironicPort, "ironic port should exist")
+			assert.Equal(t, tc.expectedIronicPort, ironicPort.Port, "ironic port value mismatch")
+
+			// Verify the ironic-api port when ironic-proxy is enabled
+			if tc.hasIronicAPIPort {
+				assert.NotNil(t, ironicAPIPort, "ironic-api port should exist when ironic-proxy is enabled")
+				assert.Equal(t, tc.expectedIronicAPIPort, ironicAPIPort.Port, "ironic-api port value mismatch")
+				assert.Equal(t, tc.expectedIronicAPITarget, ironicAPIPort.TargetPort.IntVal, "ironic-api targetPort should route to private port (6388)")
+			} else {
+				assert.Nil(t, ironicAPIPort, "ironic-api port should not exist when ironic-proxy is disabled")
+			}
+		})
+	}
+}
+
+func TestMetal3StateServiceSelector(t *testing.T) {
+	// Verify that the metal3-state service selects metal3-state pods, not ironic-proxy pods
+	info := &ProvisioningInfo{
+		ProvConfig: &metal3iov1alpha1.Provisioning{
+			Spec: *disabledProvisioning().build(),
+		},
+		Namespace: "openshift-machine-api",
+	}
+
+	svc := newMetal3StateService(info)
+
+	// The selector should be for metal3-state (stateService), NOT ironicProxyService
+	assert.Equal(t, stateService, svc.Spec.Selector[cboLabelName],
+		"metal3-state service should select metal3-state pods, not ironic-proxy pods")
+	assert.NotEqual(t, ironicProxyService, svc.Spec.Selector[cboLabelName],
+		"metal3-state service should NOT select ironic-proxy pods")
+}


### PR DESCRIPTION
When ProvisioningNetwork=Disabled or VirtualMediaViaExternalNetwork=true, the ironic-proxy DaemonSet is deployed and listens on port 6385, while the metal3 pod listens on the private port 6388. The metal3-state service was exposing port 6385 but the selector only matched metal3 pods, causing connection failures when clients tried to reach Ironic via the service.

This fix:
- Creates a new headless service for ironic-proxy with the correct selector (baremetal.openshift.io/cluster-baremetal-operator: ironic-proxy) targeting port 6385
- Updates the metal3-state service to use targetPort 6388 for port 6385 when ironic-proxy is enabled, so traffic to metal3-state:6385 routes correctly to the metal3 pod's private port

This ensures that port 6385 is accessible via Kubernetes services and routes to pods that actually listen on that port.

Assisted-By: Claude 4.5 Opus High