### PR TITLE
[release-4.21] OCPBUGS-74204: Fix libguestfs /tmp access in machine-os-downloader init container 

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -359,7 +359,7 @@ func createInitContainerMachineOsDownloader(info *ProvisioningInfo, imageURLs st
 				Drop: []corev1.Capability{"ALL"},
 			},
 		},
-		VolumeMounts: []corev1.VolumeMount{imageVolumeMount, sharedVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{imageVolumeMount, sharedVolumeMount, ironicTmpMount},
 		Env:          env,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -869,13 +869,16 @@ func TestCreateInitContainerMachineOsDownloader(t *testing.T) {
 			assert.Equal(t, tc.expectedContainerName, container.Name)
 			assert.Equal(t, []string{tc.expectedCommand}, container.Command)
 
-			// Verify that both imageVolumeMount and sharedVolumeMount are present
+			// Verify that imageVolumeMount, sharedVolumeMount, and ironicTmpMount are present
 			// This is critical because the scripts need to write to /shared/tmp
-			// while having ReadOnlyRootFilesystem enabled
+			// while having ReadOnlyRootFilesystem enabled. ironicTmpMount provides
+			// a writable /tmp for libguestfs tools.
 			assert.Contains(t, container.VolumeMounts, imageVolumeMount,
 				"imageVolumeMount should be present for /shared/html/images")
 			assert.Contains(t, container.VolumeMounts, sharedVolumeMount,
 				"sharedVolumeMount should be present for /shared/tmp writes")
+			assert.Contains(t, container.VolumeMounts, ironicTmpMount,
+				"ironicTmpMount should be present for /tmp writes (required by libguestfs)")
 
 			// Verify ReadOnlyRootFilesystem is enabled
 			assert.NotNil(t, container.SecurityContext)

--- a/provisioning/image_cache.go
+++ b/provisioning/image_cache.go
@@ -70,6 +70,12 @@ func getImageVolumes() []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		{
+			Name: ironicTmpVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 
 	return volumes

--- a/provisioning/image_cache_test.go
+++ b/provisioning/image_cache_test.go
@@ -32,6 +32,7 @@ func TestGetImageVolumes(t *testing.T) {
 		ironicConfigVolume,
 		ironicDataVolume,
 		baremetalSharedVolume, // emptyDir for /shared (needed for /shared/tmp)
+		ironicTmpVolume,       // emptyDir for /tmp (needed by libguestfs)
 	}
 
 	actualVolumeNames := make([]string, len(volumes))


### PR DESCRIPTION
(cherry picked from commit 7dc20e463afd8f2b3aa9b4f1b539321ce478ec40)