### PR TITLE
OCPBUGS-69399: Allow ProvisioningCIDR for unmanaged network

### DIFF
--- a/api/v1alpha1/provisioning_validation.go
+++ b/api/v1alpha1/provisioning_validation.go
@@ -159,7 +159,7 @@ func validateProvisioningNetworkSettings(ip string, cidr string, dhcpRange strin
 		return errs
 	}
 
-	if provisioningNetworkMode != ProvisioningNetworkManaged {
+	if provisioningNetworkMode == ProvisioningNetworkDisabled {
 		return errs
 	}
 	// Verify Network CIDR

--- a/api/v1alpha1/provisioning_validation_test.go
+++ b/api/v1alpha1/provisioning_validation_test.go
@@ -210,6 +210,14 @@ func TestValidateUnmanagedProvisioningConfig(t *testing.T) {
 			expectedMsg:   "provisioningIP",
 		},
 		{
+			// ProvisioningIP is not in the NetworkCIDR
+			name:          "InvalidUnmanagedProvisioningIPCIDR",
+			spec:          unmanagedProvisioning().ProvisioningIP("172.30.30.3").build(),
+			expectedError: true,
+			expectedMode:  ProvisioningNetworkUnmanaged,
+			expectedMsg:   "is not in the range defined by the provisioningNetworkCIDR",
+		},
+		{
 			// Missing provisioning IP.
 			name:          "MissingProvisioningIP",
 			spec:          unmanagedProvisioning().ProvisioningIP("").ProvisioningDHCPExternal(true).build(),

--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -80,7 +80,9 @@ func getProvisioningIPWithPrefix(config *metal3iov1alpha1.ProvisioningSpec) *str
 }
 
 func getProvisioningIP(config *metal3iov1alpha1.ProvisioningSpec) *string {
-	if config.ProvisioningNetwork == metal3iov1alpha1.ProvisioningNetworkManaged {
+	// Use provisioningCIDR for unmanaged provisioning network as well so that corresponding networking configuration
+	// happens at the time of deployment.
+	if config.ProvisioningNetwork != metal3iov1alpha1.ProvisioningNetworkDisabled {
 		return getProvisioningIPWithPrefix(config)
 	}
 

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -47,6 +47,12 @@ func TestGetMetal3DeploymentConfig(t *testing.T) {
 			expectedValue: ptr.To("eth0"),
 		},
 		{
+			name:          "Unmanaged ProvisioningIPCIDR",
+			configName:    provisioningIP,
+			spec:          unmanagedProvisioning().build(),
+			expectedValue: ptr.To("172.30.20.3/24"),
+		},
+		{
 			name:          "Unmanaged DeployKernelUrl",
 			configName:    deployKernelUrl,
 			spec:          unmanagedProvisioning().build(),

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -47,6 +47,15 @@ func TestBuildEnvVar(t *testing.T) {
 			},
 		},
 		{
+			name:       "Unanaged ProvisioningIPCIDR",
+			configName: provisioningIP,
+			spec:       unmanagedProvisioning().build(),
+			expectedEnvVar: corev1.EnvVar{
+				Name:  provisioningIP,
+				Value: "172.30.20.3/24",
+			},
+		},
+		{
 			name:       "Unmanaged ProvisioningInterface",
 			configName: provisioningInterface,
 			spec:       unmanagedProvisioning().build(),
@@ -390,10 +399,10 @@ func TestNewMetal3Containers(t *testing.T) {
 			name:   "UnmanagedSpec",
 			config: unmanagedProvisioning().build(),
 			expectedContainers: []corev1.Container{
-				withEnv(containers["metal3-httpd"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3")),
-				withEnv(containers["metal3-ironic"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3")),
+				withEnv(containers["metal3-httpd"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3/24")),
+				withEnv(containers["metal3-ironic"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3/24")),
 				containers["metal3-ramdisk-logs"],
-				withEnv(containers["metal3-static-ip-manager"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3")),
+				withEnv(containers["metal3-static-ip-manager"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("PROVISIONING_IP", "172.30.20.3/24")),
 				withEnv(containers["metal3-dnsmasq"], envWithValue("PROVISIONING_INTERFACE", "ensp0"), envWithValue("DHCP_RANGE", "")),
 			},
 			sshkey: "",


### PR DESCRIPTION
As provisioningCIDR was used only for managed network, it caused broken networking for unmanaged provisioning networking scenarios because all routes were not created. To fix the issue, this pr allows provisioningCIDR for both managed and unmanaged networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unmanaged provisioning configurations now perform validation to ensure provisioning IP addresses fall within the defined CIDR range.
  * Provisioning IP addresses for unmanaged configurations are now consistently formatted with CIDR notation for proper network handling.

* **Tests**
  * Added test coverage validating IP CIDR range enforcement and CIDR formatting for unmanaged provisioning configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->