### PR TITLE
OCPBUGS-82531: Bind the plain HTTP 8080 metrics port to localhost

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,8 @@ func main() {
 	var imagesJSONFilename string
 
 	klog.InitFlags(nil)
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	// Changing default metrics interface to loopback, so that we don't bypass kube-rbac-proxy
+	flag.StringVar(&metricsAddr, "metrics-addr", "[::1]:8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&imagesJSONFilename, "images-json", "/etc/cluster-baremetal-operator/images/images.json",


### PR DESCRIPTION
Right now we bind the metrics server to 0.0.0.0 address which exposes it to all the interfaces, such as pod ip, localhost. This is a security risk, especially from the standpoint of enforcing centralized tls profile work.

With this fix, it will be only exposed on localhost and only the kube-rbac-proxy sidecar, running on HTTPS 8443 port, can listen to it.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>