### PR TITLE
OCPBUGS-66101: set Progressing=True during cluster update

### DIFF
--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -180,7 +180,9 @@ func (r *ProvisioningReconciler) createClusterOperator() (*osconfigv1.ClusterOpe
 	return r.OSClient.ConfigV1().ClusterOperators().Create(context.Background(), defaultCO, metav1.CreateOptions{})
 }
 
-// ensureClusterOperator makes sure that the CO exists
+// ensureClusterOperator makes sure that the CO exists.
+// When the operator version changes (i.e. an upgrade), Progressing=True is set
+// alongside the version update so that any subsequent status update can clear it.
 func (r *ProvisioningReconciler) ensureClusterOperator() error {
 	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -195,13 +197,18 @@ func (r *ProvisioningReconciler) ensureClusterOperator() error {
 		needsUpdate = true
 		co.Status.RelatedObjects = relatedObjects()
 	}
-	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
-		needsUpdate = true
-		co.Status.Versions = operandVersions(r.ReleaseVersion)
-	}
 	if len(co.Status.Conditions) == 0 {
 		needsUpdate = true
 		co.Status.Conditions = defaultStatusConditions()
+	}
+	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
+		needsUpdate = true
+		if len(co.Status.Versions) > 0 {
+			v1helpers.SetStatusCondition(&co.Status.Conditions,
+				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(ReasonSyncing), "Operator upgraded"),
+				clock.RealClock{})
+		}
+		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 
 	if needsUpdate {

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -84,34 +84,6 @@ func TestUpdateCOStatus(t *testing.T) {
 }
 
 func TestEnsureClusterOperator(t *testing.T) {
-	var defaultConditions = []osconfigv1.ClusterOperatorStatusCondition{
-		setStatusCondition(
-			osconfigv1.OperatorProgressing,
-			osconfigv1.ConditionFalse,
-			"", "",
-		),
-		setStatusCondition(
-			osconfigv1.OperatorDegraded,
-			osconfigv1.ConditionFalse,
-			"", "",
-		),
-		setStatusCondition(
-			osconfigv1.OperatorAvailable,
-			osconfigv1.ConditionFalse,
-			"", "",
-		),
-		setStatusCondition(
-			osconfigv1.OperatorUpgradeable,
-			osconfigv1.ConditionTrue,
-			"", "",
-		),
-		setStatusCondition(
-			OperatorDisabled,
-			osconfigv1.ConditionFalse,
-			"", "",
-		),
-	}
-
 	var conditions = []osconfigv1.ClusterOperatorStatusCondition{
 		setStatusCondition(
 			osconfigv1.OperatorProgressing,
@@ -154,14 +126,20 @@ func TestEnsureClusterOperator(t *testing.T) {
 					},
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
-					Conditions:     defaultConditions,
+					Conditions: []osconfigv1.ClusterOperatorStatusCondition{
+						setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(ReasonSyncing), "Operator upgraded"),
+						setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
+						setStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionFalse, "", ""),
+						setStatusCondition(osconfigv1.OperatorUpgradeable, osconfigv1.ConditionTrue, "", ""),
+						setStatusCondition(OperatorDisabled, osconfigv1.ConditionFalse, "", ""),
+					},
 					RelatedObjects: relatedObjects(),
 					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
 				},
 			},
 		},
 		{
-			name: "Get existing clusteroperator",
+			name: "Existing clusteroperator with no version does not set Progressing",
 			existingCO: &osconfigv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterOperatorName,
@@ -184,6 +162,72 @@ func TestEnsureClusterOperator(t *testing.T) {
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
 					Conditions:     conditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+		},
+		{
+			name: "Existing clusteroperator with same version does not set Progressing",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+					Annotations: map[string]string{
+						"include.release.openshift.io/self-managed-high-availability": "true",
+						"include.release.openshift.io/single-node-developer":          "true",
+					},
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     conditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+					Annotations: map[string]string{
+						"include.release.openshift.io/self-managed-high-availability": "true",
+						"include.release.openshift.io/single-node-developer":          "true",
+					},
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     conditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+		},
+		{
+			name: "Existing clusteroperator with old version sets Progressing on upgrade",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+					Annotations: map[string]string{
+						"include.release.openshift.io/self-managed-high-availability": "true",
+						"include.release.openshift.io/single-node-developer":          "true",
+					},
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     conditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+				},
+			},
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+					Annotations: map[string]string{
+						"include.release.openshift.io/self-managed-high-availability": "true",
+						"include.release.openshift.io/single-node-developer":          "true",
+					},
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions: []osconfigv1.ClusterOperatorStatusCondition{
+						setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(ReasonSyncing), "Operator upgraded"),
+						setStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
+						{Type: "Available", Status: "true", Reason: "", Message: ""},
+					},
 					RelatedObjects: relatedObjects(),
 					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
 				},

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -691,7 +691,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if enabled {
 		baremetalConfig, err := r.readProvisioningCR(context.Background())
 		if err != nil || baremetalConfig == nil {
-			err = r.updateCOStatus(ReasonProvisioningCRNotFound, "Waiting for Provisioning CR on BareMetal Platform", "")
+			err = r.updateCOStatus(ReasonProvisioningCRNotFound, "Waiting for Provisioning CR", "")
 			if err != nil {
 				return fmt.Errorf("unable to put %q ClusterOperator in Available state: %w", clusterOperatorName, err)
 			}


### PR DESCRIPTION
Assited-By: Claude Code 4.6 opus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of operator version changes; status now updates operand versions immediately when different.
  * Sync progress shows "Updating operands to new version" when only the operator version changed.
  * Deployment availability logic tightened to avoid reporting available during rollouts.

* **Refactor**
  * Version-change handling reorganized to better coordinate status updates and operand rollouts.

* **Tests**
  * New unit tests for version-change detection, status reporting during rollouts/progressing/unsupported, and deployment-condition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->