### PR TITLE
NO-ISSUE: fix typo: 'occured' -> 'occurred' in error message

### DIFF
--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -165,7 +165,7 @@ func EnsureAllSecrets(info *ProvisioningInfo) (bool, error) {
 	}
 	// Delete ironic-inspector Secret if it still exists
 	if err := client.IgnoreNotFound(info.Client.CoreV1().Secrets(info.Namespace).Delete(context.Background(), inspectorSecretName, metav1.DeleteOptions{})); err != nil {
-		return false, errors.Wrap(err, "Error occured while deleting Ironic Inspector Secret")
+		return false, errors.Wrap(err, "Error occurred while deleting Ironic Inspector Secret")
 	}
 	return false, nil // ApplySecret does not use Generation, so just return false for updated
 }


### PR DESCRIPTION
Fixes `occured` -> `occurred` typo in the error message wrapped when deleting the Ironic Inspector Secret in `provisioning/baremetal_secrets.go`.