### PR TITLE
OCPBUGS-85496: Fix webhook to validate the actual admission request object

### DIFF
--- a/api/v1alpha1/provisioning_webhook.go
+++ b/api/v1alpha1/provisioning_webhook.go
@@ -43,23 +43,26 @@ var _ webhook.CustomValidator = &Provisioning{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (r *Provisioning) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	provisioninglog.Info("validate create", "name", r.Name)
+	prov := obj.(*Provisioning)
+	provisioninglog.Info("validate create", "name", prov.Name)
 
-	if r.Name != ProvisioningSingletonName {
+	if prov.Name != ProvisioningSingletonName {
 		return nil, fmt.Errorf("Provisioning object is a singleton and must be named \"%s\"", ProvisioningSingletonName)
 	}
 
-	return nil, r.ValidateBaremetalProvisioningConfig(enabledFeatures)
+	return nil, prov.ValidateBaremetalProvisioningConfig(enabledFeatures)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Provisioning) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	provisioninglog.Info("validate update", "name", r.Name)
-	return nil, r.ValidateBaremetalProvisioningConfig(enabledFeatures)
+	prov := newObj.(*Provisioning)
+	provisioninglog.Info("validate update", "name", prov.Name)
+	return nil, prov.ValidateBaremetalProvisioningConfig(enabledFeatures)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *Provisioning) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	provisioninglog.Info("validate delete", "name", r.Name)
+	prov := obj.(*Provisioning)
+	provisioninglog.Info("validate delete", "name", prov.Name)
 	return nil, nil
 }

--- a/api/v1alpha1/provisioning_webhook_test.go
+++ b/api/v1alpha1/provisioning_webhook_test.go
@@ -60,7 +60,7 @@ func TestProvisioningValidateCreate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.p.Spec = *disabledProvisioning().build()
-			if _, err := tt.p.ValidateCreate(context.TODO(), nil); !errorContains(err, tt.wantErr) {
+			if _, err := tt.p.ValidateCreate(context.TODO(), tt.p); !errorContains(err, tt.wantErr) {
 				t.Errorf("Provisioning.ValidateCreate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
The webhook ValidateCreate/ValidateUpdate/ValidateDelete methods were using the receiver (r) instead of the obj/newObj parameters passed by the controller-runtime framework. Since the receiver is the empty Provisioning{} registered at setup time, the webhook was validating a stale empty object rather than the actual incoming admission request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Corrected provisioning configuration validation to properly handle and validate create, update, and delete operations for more reliable provisioning management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->