### PR TITLE
OCPBUGS-85824: Fix empty IRONIC_BASE_URL

### DIFF
--- a/provisioning/utils.go
+++ b/provisioning/utils.go
@@ -150,7 +150,7 @@ func GetIronicIPs(info *ProvisioningInfo) (ironicIPs []string, err error) {
 			return
 		}
 
-		if ironicIPs == nil {
+		if len(ironicIPs) == 0 {
 			ironicIPs = podIPs
 		}
 	} else {

--- a/provisioning/utils_test.go
+++ b/provisioning/utils_test.go
@@ -1,0 +1,191 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestGetIronicIPs(t *testing.T) {
+	metal3Pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-machine-api",
+			Labels: map[string]string{
+				"k8s-app":    metal3AppName,
+				cboLabelName: stateService,
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIPs: []corev1.PodIP{
+				{IP: "192.168.111.22"},
+			},
+		},
+	}
+
+	tCases := []struct {
+		name        string
+		info        *ProvisioningInfo
+		expectedIPs []string
+		expectError bool
+	}{
+		{
+			name: "ExternalIPs set, returns externalIPs directly",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().ExternalIPs([]string{"1.2.3.4"}).build(),
+				},
+				Namespace: "openshift-machine-api",
+				Client:    fakekube.NewSimpleClientset(metal3Pod),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+						Status: osconfigv1.InfrastructureStatus{
+							PlatformStatus: &osconfigv1.PlatformStatus{
+								Type:    osconfigv1.VSpherePlatformType,
+								VSphere: &osconfigv1.VSpherePlatformStatus{APIServerInternalIPs: []string{}},
+							},
+						},
+					}),
+			},
+			expectedIPs: []string{"1.2.3.4"},
+		},
+		{
+			name: "VSphere with empty apiServerInternalIPs falls back to pod IPs",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				Namespace: "openshift-machine-api",
+				Client:    fakekube.NewSimpleClientset(metal3Pod),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+						Status: osconfigv1.InfrastructureStatus{
+							PlatformStatus: &osconfigv1.PlatformStatus{
+								Type:    osconfigv1.VSpherePlatformType,
+								VSphere: &osconfigv1.VSpherePlatformStatus{APIServerInternalIPs: []string{}},
+							},
+						},
+					}),
+			},
+			expectedIPs: []string{"192.168.111.22"},
+		},
+		{
+			name: "VSphere with nil platformStatus falls back to pod IPs",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				Namespace: "openshift-machine-api",
+				Client:    fakekube.NewSimpleClientset(metal3Pod),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+						Status: osconfigv1.InfrastructureStatus{
+							PlatformStatus: &osconfigv1.PlatformStatus{
+								Type:    osconfigv1.VSpherePlatformType,
+								VSphere: nil,
+							},
+						},
+					}),
+			},
+			expectedIPs: []string{"192.168.111.22"},
+		},
+		{
+			name: "BareMetal with populated apiServerInternalIPs uses those IPs",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				Namespace: "openshift-machine-api",
+				Client:    fakekube.NewSimpleClientset(metal3Pod),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+						Status: osconfigv1.InfrastructureStatus{
+							PlatformStatus: &osconfigv1.PlatformStatus{
+								Type: osconfigv1.BareMetalPlatformType,
+								BareMetal: &osconfigv1.BareMetalPlatformStatus{
+									APIServerInternalIPs: []string{"192.168.1.1"},
+								},
+							},
+						},
+					}),
+			},
+			expectedIPs: []string{"192.168.1.1"},
+		},
+		{
+			name: "BareMetal with empty apiServerInternalIPs falls back to pod IPs",
+			info: &ProvisioningInfo{
+				ProvConfig: &metal3iov1alpha1.Provisioning{
+					Spec: *disabledProvisioning().build(),
+				},
+				Namespace: "openshift-machine-api",
+				Client:    fakekube.NewSimpleClientset(metal3Pod),
+				OSClient: fakeconfigclientset.NewSimpleClientset(
+					&osconfigv1.Infrastructure{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Infrastructure",
+							APIVersion: "config.openshift.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+						Status: osconfigv1.InfrastructureStatus{
+							PlatformStatus: &osconfigv1.PlatformStatus{
+								Type: osconfigv1.BareMetalPlatformType,
+								BareMetal: &osconfigv1.BareMetalPlatformStatus{
+									APIServerInternalIPs: []string{},
+								},
+							},
+						},
+					}),
+			},
+			expectedIPs: []string{"192.168.111.22"},
+		},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ips, err := GetIronicIPs(tc.info)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedIPs, ips)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the `apiServerInternalIPs`is an empty list in the Infrastructure CR, the `GetIronicIPs`failed to fall back to use the metal3 pod IP. This caused the metal3-image-customization to be createdy with empty `IRONIC_BASE_URL`, resulting in the following error in the `PreprovisioningImage` CR:
'Could not add ironic agent to image: ironicBaseURL is required'

The problem was that `GetIronicIPs` did not account for empty list.

Assisted-By: Claude 4.6 Opus High

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge case in IP provisioning logic to properly handle empty configurations with consistent fallback behavior.

* **Tests**
  * Added comprehensive unit test coverage for provisioning utilities, validating IP retrieval behavior across multiple platform scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->