### PR TITLE
OCPBUGS-86555: Remove trailing dot from BMO Ironic endpoint

### DIFF
--- a/provisioning/baremetal_config.go
+++ b/provisioning/baremetal_config.go
@@ -105,7 +105,7 @@ func getControlPlanePort(info *ProvisioningInfo) (ironicPort int) {
 
 func getControlPlaneEndpoint(info *ProvisioningInfo) (ironicEndpoint string) {
 	ironicPort := getControlPlanePort(info)
-	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local.:%d/%s", stateService, info.Namespace, ironicPort, baremetalIronicEndpointSubpath)
+	ironicEndpoint = fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/%s", stateService, info.Namespace, ironicPort, baremetalIronicEndpointSubpath)
 	return
 }
 

--- a/provisioning/baremetal_config_test.go
+++ b/provisioning/baremetal_config_test.go
@@ -303,7 +303,7 @@ func TestWatchAllNamespaces(t *testing.T) {
 	}
 }
 
-func TestControlPlaneEndpointFQDNTrailingDot(t *testing.T) {
+func TestControlPlaneEndpointFQDNNoTrailingDot(t *testing.T) {
 	tCases := []struct {
 		name                 string
 		namespace            string
@@ -343,12 +343,12 @@ func TestControlPlaneEndpointFQDNTrailingDot(t *testing.T) {
 
 			endpoint := getControlPlaneEndpoint(info)
 
-			// Verify the endpoint contains trailing dot in FQDN
-			expectedPattern := fmt.Sprintf("https://metal3-state.%s.svc.cluster.local.:%d/v1/", tc.namespace, tc.expectedEndpointPort)
+			// Verify the endpoint does not contain trailing dot in FQDN.
+			expectedPattern := fmt.Sprintf("https://metal3-state.%s.svc.cluster.local:%d/v1/", tc.namespace, tc.expectedEndpointPort)
 			assert.Equal(t, expectedPattern, endpoint,
-				"Control plane endpoint FQDN should have trailing dot to prevent DNS search domain appending")
-			assert.Contains(t, endpoint, ".svc.cluster.local.:",
-				"FQDN should end with trailing dot before the port")
+				"Control plane endpoint FQDN should not have a trailing dot")
+			assert.NotContains(t, endpoint, ".svc.cluster.local.:",
+				"FQDN should not end with trailing dot before the port")
 		})
 	}
 }

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -41,7 +41,7 @@ func TestNewBMOContainers(t *testing.T) {
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
 				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "DEPLOY_KERNEL_URL", Value: "file:///shared/html/images/ironic-python-agent.kernel"},
-				{Name: "IRONIC_ENDPOINT", Value: "https://metal3-state.openshift-machine-api.svc.cluster.local.:6385/v1/"},
+				{Name: "IRONIC_ENDPOINT", Value: "https://metal3-state.openshift-machine-api.svc.cluster.local:6385/v1/"},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},
 				{Name: "METAL3_AUTH_ROOT_DIR", Value: "/auth"},
 				{Name: "IRONIC_EXTERNAL_IP", Value: ""},
@@ -111,7 +111,7 @@ func TestNewBMOContainers(t *testing.T) {
 					envWithFieldValue("IRONIC_EXTERNAL_IP", "status.hostIP"),
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 					// Private ports because of the proxy
-					envWithValue("IRONIC_ENDPOINT", "https://metal3-state.openshift-machine-api.svc.cluster.local.:6388/v1/"),
+					envWithValue("IRONIC_ENDPOINT", "https://metal3-state.openshift-machine-api.svc.cluster.local:6388/v1/"),
 				),
 			},
 			sshkey: "sshkey",
@@ -125,7 +125,7 @@ func TestNewBMOContainers(t *testing.T) {
 					envWithValue("IRONIC_EXTERNAL_IP", ""),
 					envWithValue("IRONIC_EXTERNAL_URL_V6", "https://[fd2e:6f44:5dd8:c956::16]:6183"),
 					// Private ports because of the proxy
-					envWithValue("IRONIC_ENDPOINT", "https://metal3-state.openshift-machine-api.svc.cluster.local.:6388/v1/"),
+					envWithValue("IRONIC_ENDPOINT", "https://metal3-state.openshift-machine-api.svc.cluster.local:6388/v1/"),
 					envWithValue("PROVISIONING_NETWORK_DISABLED", "true"),
 				),
 			},


### PR DESCRIPTION
Avoid setting IRONIC_ENDPOINT with an absolute-FQDN trailing dot in release-4.20.
The trailing dot prevents standard NO_PROXY suffix matching (.svc/.cluster.local), causing BMO->Ironic traffic to be proxied and fail with 403.
This change aligns 4.20 behavior with 4.21 and 4.22.