### PR TITLE
METAL-1833: Add cbo OTE test

### DIFF
--- a/tests-extension/openshift/test/e2e/additionalNTPServers.go
+++ b/tests-extension/openshift/test/e2e/additionalNTPServers.go
@@ -18,17 +18,11 @@ import (
 var _ = g.Describe("[OTP][sig-baremetal] IPI BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("additional-ntp-servers", compat_otp.KubeConfigPath())
-		iaasPlatform string
+		oc = compat_otp.NewCLI("additional-ntp-servers", compat_otp.KubeConfigPath())
 	)
 
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if iaasPlatform != "baremetal" {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("This feature is not supported for Non-baremetal cluster!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 	})
 
 	// author: sgoveas@redhat.com

--- a/tests-extension/openshift/test/e2e/cbo.go
+++ b/tests-extension/openshift/test/e2e/cbo.go
@@ -1,0 +1,144 @@
+package baremetal
+
+import (
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+)
+
+var _ = g.Describe("[OTP][sig-baremetal] IPI BareMetal", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = compat_otp.NewCLI("cluster-baremetal-operator", compat_otp.KubeConfigPath())
+	)
+	g.BeforeEach(func() {
+		SkipIfNotBaremetalCluster(oc)
+	})
+	// author: jhajyahy@redhat.com
+	g.It("Author:jhajyahy-Medium-33516-Verify that cluster baremetal operator is active", func() {
+		g.By("Running oc get clusteroperators baremetal")
+		status, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(status).To(o.BeTrue())
+
+		g.By("Run oc describe clusteroperators baremetal")
+		output, err := oc.AsAdmin().Run("get").Args("clusteroperator", "baremetal").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).ShouldNot(o.BeEmpty())
+	})
+
+	// author: jhajyahy@redhat.com
+	g.It("Author:jhajyahy-Medium-36446-Verify openshift-machine-api namespace is still there and Ready", func() {
+		g.By("Running oc get project openshift-machine-api")
+		nsStatus, err := oc.AsAdmin().Run("get").Args("project", machineAPINamespace, "-o=jsonpath={.status.phase}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nsStatus).Should(o.Equal("Active"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	g.It("Author:jhajyahy-Medium-36909-Verify metal3 pod is controlled by cluster baremetal operator", func() {
+		g.By("Running oc get deployment -n openshift-machine-api")
+		annotations, err := oc.AsAdmin().Run("get").Args("deployment", "-n", machineAPINamespace, "metal3", "-o=jsonpath={.metadata.annotations}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(annotations).Should(o.ContainSubstring("baremetal.openshift.io/owned"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	g.It("Author:jhajyahy-Medium-36445-Verify new additions to openshift-machine-api project", func() {
+		g.By("Running oc get serviceaccount -n openshift-machine-api cluster-baremetal-operator")
+		serviceAccount, err := oc.AsAdmin().Run("get").Args("serviceaccount", "-n", machineAPINamespace, "cluster-baremetal-operator", "-o=jsonpath={.metadata.name}:{.kind}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(serviceAccount).Should(o.Equal("cluster-baremetal-operator:ServiceAccount"))
+
+		g.By("Running oc get provisioning provisioning-configuration")
+		prov, err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration", "-o=jsonpath={.metadata.name}:{.kind}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(prov).Should(o.Equal("provisioning-configuration:Provisioning"))
+
+		g.By("Running oc get deploy -n openshift-machine-api metal3")
+		priority, err := oc.AsAdmin().Run("get").Args("deployment", "-n", machineAPINamespace, "metal3", "-o=jsonpath={.spec.template.spec.priorityClassName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(priority).Should(o.Equal("system-node-critical"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	g.It("Author:jhajyahy-Medium-38155-Verify when deleting the Provisioning CR, the associated resources are deleted [Disruptive]", func() {
+		g.By("Save provisioning-configuration as yaml file")
+		filePath, err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration", "-o=yaml").OutputToFile("prov.yaml")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration").Execute()
+			if err != nil {
+				errApply := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", filePath).Execute()
+				o.Expect(errApply).NotTo(o.HaveOccurred())
+				waitForDeployStatus(oc, "metal3", machineAPINamespace, "True")
+				cboStatus, err := checkOperator(oc, "baremetal")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(cboStatus).To(o.BeTrue())
+			}
+		}()
+
+		g.By("Delete provisioning-configuration")
+		deleteErr := oc.AsAdmin().Run("delete").Args("provisioning", "provisioning-configuration").Execute()
+		o.Expect(deleteErr).NotTo(o.HaveOccurred())
+		waitForPodsWithPrefixDeleted(oc, "metal3", machineAPINamespace)
+
+		g.By("Check metal3 pods, services, secrets and deployment are deleted")
+		secrets, secretErr := oc.AsAdmin().Run("get").Args("secrets", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(secretErr).NotTo(o.HaveOccurred())
+		o.Expect(secrets).ShouldNot(o.ContainSubstring("metal3"))
+
+		allResources, allErr := oc.AsAdmin().Run("get").Args("all", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(allErr).NotTo(o.HaveOccurred())
+		o.Expect(allResources).ShouldNot(o.ContainSubstring("metal3"))
+
+		g.By("Check cluster-baremetal-operator deployment still exists and is available")
+		bmoDeployStatus, bmoErr := oc.AsAdmin().Run("get").Args("deployment", "-n", machineAPINamespace, "cluster-baremetal-operator", "-o=jsonpath={.status.conditions[?(@.type=='Available')].status}").Output()
+		o.Expect(bmoErr).NotTo(o.HaveOccurred())
+		o.Expect(bmoDeployStatus).To(o.Equal("True"), "BMO deployment should remain available after Provisioning CR deletion")
+
+		g.By("Check cluster baremetal operator still available")
+		status, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(status).To(o.BeTrue())
+
+		g.By("Recreate provisioning-configuration")
+		createErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", filePath).Execute()
+		o.Expect(createErr).NotTo(o.HaveOccurred())
+
+		g.By("Check metal3 pods, services, secrets and deployment are recreated")
+		waitForDeployStatus(oc, "metal3", machineAPINamespace, "True")
+		waitForDeployStatus(oc, "metal3-baremetal-operator", machineAPINamespace, "True")
+		metal3Secrets, secretErr := oc.AsAdmin().Run("get").Args("secrets", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(secretErr).NotTo(o.HaveOccurred())
+		o.Expect(metal3Secrets).Should(o.ContainSubstring("metal3"))
+
+		pods, err := oc.AsAdmin().Run("get").Args("pods", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		podlist := strings.Fields(pods)
+		// Filter to only check metal3-related pods to avoid failures from unrelated pods
+		metal3Pods := []string{}
+		for _, pod := range podlist {
+			if strings.HasPrefix(pod, "metal3-") {
+				metal3Pods = append(metal3Pods, pod)
+			}
+		}
+		for _, pod := range metal3Pods {
+			podStatus := getPodStatus(oc, machineAPINamespace, pod)
+			o.Expect(podStatus).Should(o.Equal("Running"))
+		}
+
+		g.By("Check cluster baremetal operator is available")
+		cboStatus, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cboStatus).To(o.BeTrue())
+
+	})
+
+})

--- a/tests-extension/openshift/test/e2e/common_utils.go
+++ b/tests-extension/openshift/test/e2e/common_utils.go
@@ -13,7 +13,9 @@ import (
 	"strings"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
 	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -21,6 +23,17 @@ const (
 	clusterProfileDir = "CLUSTER_PROFILE_DIR"
 	proxyFile         = "proxy"
 )
+
+// SkipIfNotBaremetalCluster skips the test if the cluster is SNO or not baremetal platform
+// This is a common helper for baremetal tests that need both checks
+func SkipIfNotBaremetalCluster(oc *exutil.CLI) {
+	compat_otp.SkipForSNOCluster(oc)
+	iaasPlatform := compat_otp.CheckPlatform(oc)
+	if iaasPlatform != "baremetal" {
+		e2e.Logf("Cluster is: %s", iaasPlatform)
+		g.Skip("For Non-baremetal cluster , this is not supported!")
+	}
+}
 
 // getCertificateValidityDays calculates the validity period of a certificate in days
 // Returns the number of days between notBefore and notAfter dates

--- a/tests-extension/openshift/test/e2e/deployment_sanity.go
+++ b/tests-extension/openshift/test/e2e/deployment_sanity.go
@@ -14,16 +14,10 @@ import (
 var _ = g.Describe("[OTP][sig-baremetal] IPI BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("baremetal-deployment-sanity", compat_otp.KubeConfigPath())
-		iaasPlatform string
+		oc = compat_otp.NewCLI("baremetal-deployment-sanity", compat_otp.KubeConfigPath())
 	)
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if iaasPlatform != "baremetal" {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("For Non-baremetal cluster , this is not supported!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 	})
 	// author: jhajyahy@redhat.com
 	// port=yes - 99.7% pass rate (724 runs last 60 days)

--- a/tests-extension/openshift/test/e2e/ironic_auth.go
+++ b/tests-extension/openshift/test/e2e/ironic_auth.go
@@ -6,24 +6,17 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_GENERAL job on BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("baremetal-ironic-authentication", compat_otp.KubeConfigPath())
-		iaasPlatform string
-		endpointIP   []string
-		userPass     string
+		oc         = compat_otp.NewCLI("baremetal-ironic-authentication", compat_otp.KubeConfigPath())
+		endpointIP []string
+		userPass   string
 	)
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if !(iaasPlatform == "baremetal") {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("For Non-baremetal cluster , this is not supported!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 
 		user := getUserFromSecret(oc, machineAPINamespace, "metal3-ironic-password")
 		pass := getPassFromSecret(oc, machineAPINamespace, "metal3-ironic-password")

--- a/tests-extension/openshift/test/e2e/ironic_prometheus_exporter.go
+++ b/tests-extension/openshift/test/e2e/ironic_prometheus_exporter.go
@@ -15,16 +15,10 @@ import (
 var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_GENERAL job on BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("ironic-prometheus-exporter", compat_otp.KubeConfigPath())
-		iaasPlatform string
+		oc = compat_otp.NewCLI("ironic-prometheus-exporter", compat_otp.KubeConfigPath())
 	)
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if !(iaasPlatform == "baremetal") {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("For Non-baremetal cluster , this is not supported!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 	})
 
 	// author: jhajyahy@redhat.com

--- a/tests-extension/openshift/test/e2e/ironic_tls_certificate.go
+++ b/tests-extension/openshift/test/e2e/ironic_tls_certificate.go
@@ -24,16 +24,10 @@ import (
 var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_GENERAL job on BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("ironic-tls-certificate", compat_otp.KubeConfigPath())
-		iaasPlatform string
+		oc = compat_otp.NewCLI("ironic-tls-certificate", compat_otp.KubeConfigPath())
 	)
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if !(iaasPlatform == "baremetal") {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("For Non-baremetal cluster, this is not supported!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 	})
 
 	// author: jhajyahy@redhat.com

--- a/tests-extension/openshift/test/e2e/k8s_utils.go
+++ b/tests-extension/openshift/test/e2e/k8s_utils.go
@@ -136,17 +136,26 @@ func checkOperator(oc *exutil.CLI, operatorName string) (bool, error) {
 	return available == "True", nil
 }
 
-func waitForPodNotFound(oc *exutil.CLI, podName string, nameSpace string) {
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
-		_, err := oc.AsAdmin().Run("get").Args("-n", nameSpace, "pod", podName).Output()
+// waitForPodsWithPrefixDeleted waits for all pods with names starting with the prefix to be deleted
+func waitForPodsWithPrefixDeleted(oc *exutil.CLI, podPrefix string, nameSpace string) {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		output, err := oc.AsAdmin().Run("get").Args("pods", "-n", nameSpace, "-o=jsonpath={.items[*].metadata.name}").Output()
 		if err != nil {
-			e2e.Logf("pod %v doesn't exist", podName)
-			return true, nil
+			e2e.Logf("Error getting pods: %v", err)
+			return false, err
 		}
-		e2e.Logf("pod %v exist, Trying again", podName)
-		return false, nil
+		// Split output into individual pod names and check each with HasPrefix
+		podNames := strings.Fields(output)
+		for _, podName := range podNames {
+			if strings.HasPrefix(podName, podPrefix) {
+				e2e.Logf("Pods with prefix %q still exist in namespace %s, waiting...", podPrefix, nameSpace)
+				return false, nil
+			}
+		}
+		e2e.Logf("No pods with prefix %q found in namespace %s", podPrefix, nameSpace)
+		return true, nil
 	})
-	compat_otp.AssertWaitPollNoErr(err, "The test deployment job is running")
+	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("Pods with prefix %q were not deleted within timeout", podPrefix))
 }
 
 func getUserFromSecret(oc *exutil.CLI, namespace string, secretName string) string {

--- a/tests-extension/openshift/test/e2e/readonly_filesystem.go
+++ b/tests-extension/openshift/test/e2e/readonly_filesystem.go
@@ -13,17 +13,11 @@ import (
 var _ = g.Describe("[OTP][sig-baremetal] IPI BareMetal", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = compat_otp.NewCLI("readonly-filesystem", compat_otp.KubeConfigPath())
-		iaasPlatform string
+		oc = compat_otp.NewCLI("readonly-filesystem", compat_otp.KubeConfigPath())
 	)
 
 	g.BeforeEach(func() {
-		compat_otp.SkipForSNOCluster(oc)
-		iaasPlatform = compat_otp.CheckPlatform(oc)
-		if iaasPlatform != "baremetal" {
-			e2e.Logf("Cluster is: %s", iaasPlatform)
-			g.Skip("This feature is not supported for Non-baremetal cluster!")
-		}
+		SkipIfNotBaremetalCluster(oc)
 	})
 
 	// author: sgoveas@redhat.com


### PR DESCRIPTION
- cbo.go:
  * 68254: CBO deployment available and running

Uses utils: checkOperator, getPodStatus, waitForDeployStatus, waitForPodNotFound

No testdata dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for baremetal clusters, validating the baremetal ClusterOperator, Machine API project status, and key Machine API resources (including Metal3 ownership and priority class).
  * Added disruptive scenario testing to ensure proper reconciliation after deleting and recreating provisioning configuration, including readiness and Metal3 resource cleanup/recovery checks.
  * Enhanced end-to-end test utilities to reliably wait for all pods matching a name prefix to be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->