### PR TITLE
METAL-1833: migrate BMO & CBO tests

### DIFF
--- a/tests-extension/openshift/test/e2e/bmo_validations.go
+++ b/tests-extension/openshift/test/e2e/bmo_validations.go
@@ -1,0 +1,234 @@
+package baremetal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED job on BareMetal", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc           = compat_otp.NewCLI("cluster-baremetal-operator", compat_otp.KubeConfigPath())
+		iaasPlatform string
+		dirname      string
+	)
+	g.BeforeEach(func() {
+		compat_otp.SkipForSNOCluster(oc)
+		iaasPlatform = compat_otp.CheckPlatform(oc)
+		if !(iaasPlatform == "baremetal") {
+			e2e.Logf("Cluster is: %s", iaasPlatform)
+			g.Skip("For Non-baremetal cluster, this is not supported!")
+		}
+	})
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Medium-66490-Allow modification of BMC address after installation [Disruptive]", func() {
+		g.By("Get the count of BareMetalHosts")
+		bmhCount, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("baremetalhosts", "-n", machineAPINamespace, "-o=jsonpath={.items}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Check if we have at least 5 BMHs (index 4 exists)
+		if len(bmhCount) == 0 || bmhCount == "[]" {
+			g.Skip("No BareMetalHosts found in the cluster")
+		}
+
+		g.By("Running oc patch bmh -n openshift-machine-api")
+		bmhName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("baremetalhosts", "-n", machineAPINamespace, "-o=jsonpath={.items[4].metadata.name}").Output()
+		// If index 4 doesn't exist, skip the test
+		if err != nil || bmhName == "" {
+			g.Skip("Not enough BareMetalHosts (need at least 5) to run this test")
+		}
+
+		bmcAddressOrig, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("baremetalhosts", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.bmc.address}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		patchConfig := `[{"op": "replace", "path": "/spec/bmc/address", "value":"redfish-virtualmedia://10.1.234.25/redfish/v1/Systems/System.Embedded.1"}]`
+		out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=json", "-p", patchConfig).Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("denied the request: BMC address can not be changed if the BMH is not in the Registering state, or if the BMH is not detached"))
+
+		g.By("Detach the BareMetal host")
+		patch := `{"metadata":{"annotations":{"baremetalhost.metal3.io/detached": ""}}}`
+		_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=merge", "-p", patch).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Modify BMC address of BareMetal host")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=json", "-p", patchConfig).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			g.By("Revert changes")
+			patchConfig = fmt.Sprintf(`[{"op": "replace", "path": "/spec/bmc/address", "value": "%s"}]`, bmcAddressOrig)
+			_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=json", "-p", patchConfig).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			patchConfig = `[{"op": "remove", "path": "/metadata/annotations/baremetalhost.metal3.io~1detached"}]`
+			_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=json", "-p", patchConfig).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
+
+		bmcAddress, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("baremetalhosts", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.bmc.address}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmcAddress).To(o.ContainSubstring("redfish-virtualmedia://10.1.234.25/redfish/v1/Systems/System.Embedded.1"))
+
+	})
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Medium-66491-bootMACAddress can't be changed once set [Disruptive]", func() {
+		g.By("Get the first BareMetalHost")
+		bmhName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("baremetalhosts", "-n", machineAPINamespace, "-o=jsonpath={.items[0].metadata.name}").Output()
+		if err != nil || bmhName == "" {
+			g.Skip("No BareMetalHosts found in the cluster")
+		}
+
+		g.By("Running oc patch bmh -n openshift-machine-api")
+		patchConfig := `[{"op": "replace", "path": "/spec/bootMACAddress", "value":"f4:02:70:b8:d8:ff"}]`
+		out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("bmh", "-n", machineAPINamespace, bmhName, "--type=json", "-p", patchConfig).Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("bootMACAddress can not be changed once it is set"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-74940-Root device hints should accept by-path device alias [Disruptive]", func() {
+		dirname = "OCP-74940.log"
+
+		g.By("Get the 5th BareMetalHost (index 4)")
+		bmhName, getBmhErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, "-o=jsonpath={.items[4].metadata.name}").Output()
+		if getBmhErr != nil || bmhName == "" {
+			g.Skip("Not enough BareMetalHosts (need at least 5) to run this test")
+		}
+
+		baseDir := compat_otp.FixturePath("testdata", "installer")
+		bmhYaml := filepath.Join(baseDir, "baremetal", "bmh.yaml")
+		bmcAddress, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.bmc.address}").Output()
+		bootMACAddress, getBbootMACAddressErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.bootMACAddress}").Output()
+		o.Expect(getBbootMACAddressErr).NotTo(o.HaveOccurred(), "Failed to get bootMACAddress")
+		rootDeviceHints := getBypathDeviceName(oc, bmhName)
+		bmcSecretName, getBMHSecretErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.bmc.credentialsName}").Output()
+		o.Expect(getBMHSecretErr).NotTo(o.HaveOccurred(), "Failed to get bmh secret")
+		bmcSecretuser, getBmcUserErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "-n", machineAPINamespace, bmcSecretName, "-o=jsonpath={.data.username}").Output()
+		o.Expect(getBmcUserErr).NotTo(o.HaveOccurred(), "Failed to get bmh secret user")
+		bmcSecretPass, getBmcPassErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "-n", machineAPINamespace, bmcSecretName, "-o=jsonpath={.data.password}").Output()
+		o.Expect(getBmcPassErr).NotTo(o.HaveOccurred(), "Failed to get bmh secret password")
+		bmhSecretYaml := filepath.Join(baseDir, "baremetal", "bmh-secret.yaml")
+		defer func() {
+			if err := os.Remove(bmhSecretYaml); err != nil && !os.IsNotExist(err) {
+				e2e.Logf("Warning: Failed to cleanup temporary file %s: %v", bmhSecretYaml, err)
+			}
+		}()
+
+		compat_otp.ModifyYamlFileContent(bmhSecretYaml, []compat_otp.YamlReplace{
+			{
+				Path:  "data.username",
+				Value: bmcSecretuser,
+			},
+			{
+				Path:  "data.password",
+				Value: bmcSecretPass,
+			},
+			{
+				Path:  "metadata.name",
+				Value: bmcSecretName,
+			},
+		})
+
+		compat_otp.ModifyYamlFileContent(bmhYaml, []compat_otp.YamlReplace{
+			{
+				Path:  "metadata.name",
+				Value: bmhName,
+			},
+			{
+				Path:  "spec.bmc.address",
+				Value: bmcAddress,
+			},
+			{
+				Path:  "spec.bootMACAddress",
+				Value: bootMACAddress,
+			},
+			{
+				Path:  "spec.rootDeviceHints.deviceName",
+				Value: rootDeviceHints,
+			},
+			{
+				Path:  "spec.bmc.credentialsName",
+				Value: bmcSecretName,
+			},
+		})
+
+		compat_otp.By("Get machine name of host")
+		machine, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.consumerRef.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the origin number of replicas
+		machineSet, cmdErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", "-n", machineAPINamespace, "-o=jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(cmdErr).NotTo(o.HaveOccurred())
+		originReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.By("Annotate worker-01 machine for deletion")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("annotate").Args("machine", machine, "machine.openshift.io/cluster-api-delete-machine=yes", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.By("Scale down machineset")
+		originReplicas, err := strconv.Atoi(originReplicasStr)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		newReplicas := originReplicas - 1
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machineset", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%d", newReplicas)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, bmhName, "available")
+
+		compat_otp.By("Delete worker node")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("bmh", "-n", machineAPINamespace, bmhName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() {
+
+			currentReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Only scale back if the new number of replicas is different from the original
+			if currentReplicasStr != originReplicasStr {
+				compat_otp.By("Create bmh secret using saved yaml file")
+				err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", bmhSecretYaml).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				compat_otp.By("Create bmh using saved yaml file")
+				err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", bmhYaml).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				_, err := oc.AsAdmin().WithoutNamespace().Run("scale").Args("machineset", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+				compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Nodes do not recover healthy in time!")
+				clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+				compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators do not recover healthy in time!")
+			}
+		}()
+
+		waitForBMHDeletion(oc, bmhName)
+
+		compat_otp.By("Create bmh secret using saved yaml file")
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", bmhSecretYaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Create bmh using saved yaml file")
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", bmhYaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machineset", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, bmhName, "provisioned")
+		nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Nodes do not recover healthy in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators do not recover healthy in time!")
+
+		actualRootDeviceHints, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.rootDeviceHints.deviceName}").Output()
+		o.Expect(actualRootDeviceHints).Should(o.Equal(rootDeviceHints))
+
+	})
+})

--- a/tests-extension/openshift/test/e2e/cbo.go
+++ b/tests-extension/openshift/test/e2e/cbo.go
@@ -1,0 +1,158 @@
+package baremetal
+
+import (
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-baremetal] INSTALLER IPI for INSTALLER_GENERAL job on BareMetal", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc           = compat_otp.NewCLI("cluster-baremetal-operator", compat_otp.KubeConfigPath())
+		iaasPlatform string
+	)
+	g.BeforeEach(func() {
+		compat_otp.SkipForSNOCluster(oc)
+		iaasPlatform = compat_otp.CheckPlatform(oc)
+		if !(iaasPlatform == "baremetal") {
+			e2e.Logf("Cluster is: %s", iaasPlatform)
+			g.Skip("For Non-baremetal cluster, this is not supported!")
+		}
+	})
+	// author: jhajyahy@redhat.com
+	// port=yes - 99.9% pass rate (724 runs last 60 days)
+	g.It("Author:jhajyahy-Medium-33516-Verify that cluster baremetal operator is active", func() {
+		g.By("Running oc get clusteroperators baremetal")
+		status, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(status).To(o.BeTrue())
+
+		g.By("Run oc describe clusteroperators baremetal")
+		output, err := oc.AsAdmin().Run("get").Args("clusteroperator", "baremetal").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).ShouldNot(o.BeEmpty())
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=yes - 99.4% pass rate (724 runs last 60 days)
+	g.It("Author:jhajyahy-Medium-36446-Verify openshift-machine-api namespace is still there and Ready", func() {
+		g.By("Running oc get project openshift-machine-api")
+		nsStatus, err := oc.AsAdmin().Run("get").Args("project", machineAPINamespace, "-o=jsonpath={.status.phase}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nsStatus).Should(o.Equal("Active"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=yes - 99.7% pass rate (724 runs last 60 days)
+	g.It("Author:jhajyahy-Medium-36909-Verify metal3 pod is controlled by cluster baremetal operator", func() {
+		g.By("Running oc get deployment -n openshift-machine-api")
+		annotations, err := oc.AsAdmin().Run("get").Args("deployment", "-n", machineAPINamespace, "metal3", "-o=jsonpath={.metadata.annotations}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(annotations).Should(o.ContainSubstring("baremetal.openshift.io/owned"))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=yes - 100.0% pass rate (724 runs last 60 days)
+	g.It("Author:jhajyahy-Medium-36445-Verify new additions to openshift-machine-api project", func() {
+		g.By("Running oc get serviceaccount -n openshift-machine-api cluster-baremetal-operator")
+		serviceAccount, err := oc.AsAdmin().Run("get").Args("serviceaccount", "-n", machineAPINamespace, "cluster-baremetal-operator", "-o=jsonpath={.metadata.name}:{.kind}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(serviceAccount).Should(o.Equal("cluster-baremetal-operator:ServiceAccount"))
+
+		g.By("Running oc get provisioning provisioning-configuration")
+		prov, err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration", "-o=jsonpath={.metadata.name}:{.kind}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(prov).Should(o.Equal("provisioning-configuration:Provisioning"))
+
+		g.By("Running oc get deploy -n openshift-machine-api metal3")
+		priority, err := oc.AsAdmin().Run("get").Args("deployment", "-n", machineAPINamespace, "metal3", "-o=jsonpath={.spec.template.spec.priorityClassName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(priority).Should(o.Equal("system-node-critical"))
+
+	})
+
+})
+
+var _ = g.Describe("[sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED job on BareMetal", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc           = compat_otp.NewCLI("cluster-baremetal-operator", compat_otp.KubeConfigPath())
+		iaasPlatform string
+	)
+	g.BeforeEach(func() {
+		compat_otp.SkipForSNOCluster(oc)
+		iaasPlatform = compat_otp.CheckPlatform(oc)
+		if !(iaasPlatform == "baremetal") {
+			e2e.Logf("Cluster is: %s", iaasPlatform)
+			g.Skip("For Non-baremetal cluster, this is not supported!")
+		}
+	})
+
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Medium-38155-Verify when deleting the Provisioning CR, the associated resources are deleted[Serial]", func() {
+		g.By("Save provisioning-configuration as yaml file")
+		filePath, err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration", "-o=yaml").OutputToFile("prov.yaml")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			err := oc.AsAdmin().Run("get").Args("provisioning", "provisioning-configuration").Execute()
+			if err != nil {
+				errApply := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", filePath).Execute()
+				o.Expect(errApply).NotTo(o.HaveOccurred())
+				waitForDeployStatus(oc, "metal3", machineAPINamespace, "True")
+				cboStatus, err := checkOperator(oc, "baremetal")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(cboStatus).To(o.BeTrue())
+			}
+		}()
+
+		g.By("Delete provisioning-configuration")
+		deleteErr := oc.AsAdmin().Run("delete").Args("provisioning", "provisioning-configuration").Execute()
+		o.Expect(deleteErr).NotTo(o.HaveOccurred())
+		waitForPodNotFound(oc, "metal3", machineAPINamespace)
+
+		g.By("Check metal3 pods, services, secrets and deployment are deleted")
+		secrets, secretErr := oc.AsAdmin().Run("get").Args("secrets", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(secretErr).NotTo(o.HaveOccurred())
+		o.Expect(secrets).ShouldNot(o.ContainSubstring("metal3"))
+
+		allResources, allErr := oc.AsAdmin().Run("get").Args("all", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(allErr).NotTo(o.HaveOccurred())
+		o.Expect(allResources).ShouldNot(o.ContainSubstring("metal3"))
+
+		g.By("Check cluster baremetal operator still available")
+		status, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(status).To(o.BeTrue())
+
+		g.By("Recreate provisioning-configuration")
+		createErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", filePath).Execute()
+		o.Expect(createErr).NotTo(o.HaveOccurred())
+
+		g.By("Check metal3 pods, services, secrets and deployment are recreated")
+		waitForDeployStatus(oc, "metal3", machineAPINamespace, "True")
+		metal3Secrets, secretErr := oc.AsAdmin().Run("get").Args("secrets", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(secretErr).NotTo(o.HaveOccurred())
+		o.Expect(metal3Secrets).Should(o.ContainSubstring("metal3"))
+
+		pods, err := oc.AsAdmin().Run("get").Args("pods", "-n", machineAPINamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		podlist := strings.Fields(pods)
+		for _, pod := range podlist {
+			podStatus := getPodStatus(oc, machineAPINamespace, pod)
+			o.Expect(podStatus).Should(o.Equal("Running"))
+		}
+
+		g.By("Check cluster baremetal operator is available")
+		cboStatus, err := checkOperator(oc, "baremetal")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cboStatus).To(o.BeTrue())
+
+	})
+})

--- a/tests-extension/openshift/test/e2e/metal3_utils.go
+++ b/tests-extension/openshift/test/e2e/metal3_utils.go
@@ -187,3 +187,11 @@ func getNicNameByVendor(vendor string) string {
 		return ""
 	}
 }
+
+// getBypathDeviceName retrieves the first storage device's by-path name from a BareMetalHost
+func getBypathDeviceName(oc *exutil.CLI, bmhName string) string {
+	deviceName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.status.hardware.storage[0].name}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get device name for BMH: %s", bmhName)
+	o.Expect(deviceName).NotTo(o.BeEmpty(), "Device name should not be empty for BMH: %s", bmhName)
+	return deviceName
+}

--- a/tests-extension/testdata/installer/baremetal/bmh-secret.yaml
+++ b/tests-extension/testdata/installer/baremetal/bmh-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  password: <pass>
+  username: <username>
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: openshift-machine-api
+type: Opaque

--- a/tests-extension/testdata/installer/baremetal/bmh.yaml
+++ b/tests-extension/testdata/installer/baremetal/bmh.yaml
@@ -1,0 +1,15 @@
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: <name>
+  namespace: openshift-machine-api
+spec:
+  online: true
+  bmc:
+    address: exampe
+    credentialsName: exampe
+    disableCertificateVerification: True
+  bootMACAddress: exampe
+  hardwareProfile: unknown
+  rootDeviceHints:
+    deviceName: exampe


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end validation coverage for Bare Metal cluster scenarios.
  * Verifies host management settings, credential handling, and storage device targeting during install and reprovisioning flows.
  * Adds reusable test fixtures for BareMetalHost and secret configuration.

* **Bug Fixes**
  * Confirms critical host fields remain protected from unsupported changes.
  * Validates cluster resources are removed and restored correctly when provisioning components are deleted and recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->