### PR TITLE
METAL-1833: Add host_fw_components tests to CBO test extension

### DIFF
--- a/tests-extension/openshift/test/e2e/host_fw_components.go
+++ b/tests-extension/openshift/test/e2e/host_fw_components.go
@@ -1,0 +1,841 @@
+package baremetal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED job on BareMetal", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc      = compat_otp.NewCLI("host-firmware-components", compat_otp.KubeConfigPath())
+		dirname string
+	)
+	g.BeforeEach(func() {
+		compat_otp.SkipForSNOCluster(oc)
+		skipIfNotBaremetal(oc)
+	})
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-75430-Update host FW via HostFirmwareComponents CRD [Disruptive]", func() {
+		dirname = "OCP-75430.log"
+		host, machineName := getWorkerBMH(oc)
+		vendor, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.hardware.firmware.bios.vendor}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		initialVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath={.status.components[?(@.component==\"bmc\")].currentVersion}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialVersion).NotTo(o.BeEmpty(), "BMC firmware version must not be empty")
+
+		oc.SetupProject()
+		testNamespace := oc.Namespace()
+
+		downloadUrl, fileName := buildFirmwareURL(vendor, initialVersion)
+
+		// Label worker node 1 to run the web-server hosting the iso
+		compat_otp.By("Add a label to first worker node ")
+		workerNode, err := compat_otp.GetClusterNodesBy(oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nginxNode := workerNode[0]
+		compat_otp.AddLabelToNode(oc, nginxNode, "nginx-node", "true")
+
+		compat_otp.By("Create web-server to host the fw file")
+		BaseDir := compat_otp.FixturePath("testdata", "installer")
+		fwConfigmap := filepath.Join(BaseDir, "baremetal", "firmware-cm.yaml")
+		nginxFW := filepath.Join(BaseDir, "baremetal", "nginx-firmware.yaml")
+		compat_otp.ModifyYamlFileContent(fwConfigmap, []compat_otp.YamlReplace{
+			{
+				Path:  "data.firmware_url",
+				Value: downloadUrl,
+			},
+			{
+				Path:  "data.component",
+				Value: "bmc",
+			},
+		})
+
+		dcErr := oc.Run("create").Args("-f", fwConfigmap, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+
+		dcErr = oc.Run("create").Args("-f", nginxFW, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		compat_otp.AssertPodToBeReady(oc, "nginx-pod", testNamespace)
+
+		compat_otp.By("Create ingress to access the iso file")
+		fileIngress := filepath.Join(BaseDir, "baremetal", "nginx-ingress.yaml")
+		nginxIngress := CopyToFile(fileIngress, "nginx-ingress.yaml")
+		clusterDomain, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ingress.config/cluster", "-o=jsonpath={.spec.domain}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fwUrl := "fw." + clusterDomain
+		defer func() {
+			if err := os.Remove(nginxIngress); err != nil && !os.IsNotExist(err) {
+				e2e.Logf("Warning: Failed to cleanup temporary file %s: %v", nginxIngress, err)
+			}
+		}()
+		compat_otp.ModifyYamlFileContent(nginxIngress, []compat_otp.YamlReplace{
+			{
+				Path:  "spec.rules.0.host",
+				Value: fwUrl,
+			},
+		})
+
+		IngErr := oc.Run("create").Args("-f", nginxIngress, "-n", testNamespace).Execute()
+		o.Expect(IngErr).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Update HFC CRD")
+		component := "bmc"
+		hfcUrl := "http://" + fwUrl + "/" + fileName
+		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"%s","url":"%s"}]}]`, component, hfcUrl)
+		patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+		o.Expect(patchErr).NotTo(o.HaveOccurred())
+		bmcUrl, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "hostfirmwarecomponents", host, "-o=jsonpath={.spec.updates[0].url}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmcUrl).Should(o.Equal(hfcUrl))
+
+		defer func() {
+			patchConfig := `[{"op": "replace", "path": "/spec/updates", "value": []}]`
+			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+			o.Expect(patchErr).NotTo(o.HaveOccurred())
+			compat_otp.DeleteLabelFromNode(oc, nginxNode, "nginx-node")
+			nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		// Get the MachineSet that owns this Machine from owner reference (machineName already fetched above)
+		machineSet, cmdErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines.machine.openshift.io", machineName, "-n", machineAPINamespace, "-o=jsonpath={.metadata.ownerReferences[?(@.kind==\"MachineSet\")].name}").Output()
+		o.Expect(cmdErr).NotTo(o.HaveOccurred())
+		o.Expect(machineSet).NotTo(o.BeEmpty(), "Machine should have a MachineSet owner")
+
+		// Get the origin number of replicas from the owning MachineSet
+		originReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Annotate worker-01 machine for deletion")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("annotate").Args("machines.machine.openshift.io", machineName, "machine.openshift.io/cluster-api-delete-machine=yes", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Scale down machineset")
+		originReplicas, err := strconv.Atoi(originReplicasStr)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		newReplicas := originReplicas - 1
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%d", newReplicas)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, host, "available")
+
+		defer func() {
+			currentReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			if currentReplicasStr != originReplicasStr {
+				_, err := oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+				compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+				clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+				compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+			}
+		}()
+
+		compat_otp.By("Scale up machineset")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, host, "provisioned")
+		nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+
+		bmcJsonPath := `{.status.components[?(@.component=="bmc")].currentVersion}`
+		var currentVersion string
+		pollErr := wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			ver, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+bmcJsonPath).Output()
+			if err != nil {
+				e2e.Logf("Error getting HostFirmwareComponents version: %v", err)
+				return false, err
+			}
+			if ver == "" {
+				e2e.Logf("HostFirmwareComponents version is empty, still waiting...")
+				return false, nil
+			}
+			if ver != initialVersion {
+				currentVersion = ver
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "Polling for firmware version update failed")
+		o.Expect(currentVersion).NotTo(o.BeEmpty(), "Firmware version must not be empty after update")
+		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-77676-DAY2 Update HFS via HostUpdatePolicy CRD [Disruptive]", func() {
+		dirname = "OCP-77676.log"
+		host, machineName := getWorkerBMH(oc)
+
+		g.By("Get node name from BMH mapping")
+		nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines.machine.openshift.io", "-n", machineAPINamespace, machineName, "-o=jsonpath={.status.nodeRef.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Create host update policy")
+		BaseDir := compat_otp.FixturePath("testdata", "installer")
+		hostUpdatePolicy := filepath.Join(BaseDir, "baremetal", "host-update-policy.yaml")
+		compat_otp.ModifyYamlFileContent(hostUpdatePolicy, []compat_otp.YamlReplace{
+			{
+				Path:  "metadata.name",
+				Value: host,
+			},
+		})
+
+		dcErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", hostUpdatePolicy, "-n", machineAPINamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		defer func() {
+			err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("HostUpdatePolicy", "-n", machineAPINamespace, host).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		compat_otp.By("Update HFS setting based on vendor")
+		vendor, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.hardware.firmware.bios.vendor}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		hfs, value, err := getHfsByVendor(oc, vendor, machineAPINamespace, host)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/settings/%s", "value": "%s"}]`, hfs, value)
+		patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("hfs", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+		o.Expect(patchErr).NotTo(o.HaveOccurred())
+		defer func() {
+			patchConfig := `[{"op": "replace", "path": "/spec/settings", "value": {}}]`
+			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("hfs", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+			o.Expect(patchErr).NotTo(o.HaveOccurred())
+		}()
+
+		specModified, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, fmt.Sprintf("-o=jsonpath={.spec.settings.%s}", hfs)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(specModified).Should(o.Equal(value))
+
+		compat_otp.By("Wait for HFS ChangeDetected condition")
+		hfsCondErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+			if err != nil {
+				return false, err
+			}
+			if cond == "True" {
+				e2e.Logf("HFS ChangeDetected condition is True")
+				return true, nil
+			}
+			e2e.Logf("HFS ChangeDetected condition: %s, waiting...", cond)
+			return false, nil
+		})
+		o.Expect(hfsCondErr).NotTo(o.HaveOccurred(), "HFS ChangeDetected condition did not become True")
+
+		compat_otp.By("Reboot BareMetalHost")
+		out, err := oc.AsAdmin().WithoutNamespace().Run("annotate").Args("baremetalhosts", host, "reboot.metal3.io=", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("annotated"))
+
+		compat_otp.By("Verify BMH operationalStatus transitions to servicing")
+		servicingErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
+			if err != nil {
+				return false, err
+			}
+			if opStatus == "servicing" {
+				e2e.Logf("BMH operationalStatus is now 'servicing'")
+				return true, nil
+			}
+			e2e.Logf("BMH operationalStatus: %s, waiting for 'servicing'...", opStatus)
+			return false, nil
+		})
+		o.Expect(servicingErr).NotTo(o.HaveOccurred(), "BMH did not transition to servicing state")
+
+		compat_otp.By("Waiting for the node to transition to NotReady state after reboot")
+		err = wait.Poll(5*time.Second, 180*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
+			if err != nil {
+				e2e.Logf("Error getting node status: %v", err)
+				return false, err
+			}
+			if string(output) == "True" {
+				e2e.Logf("Node still Ready, status: %s. Waiting for reboot to start...", output)
+				return false, nil
+			}
+			if string(output) == "Unknown" || string(output) == "False" {
+				e2e.Logf("Node is rebooting, Ready status changed to: %s", output)
+				return true, nil
+			}
+			return false, nil
+		})
+		compat_otp.AssertWaitPollNoErr(err, "Node did not transition to NotReady state after reboot annotation")
+
+		nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+
+		compat_otp.By("Verify hfs setting was actually changed")
+		statusModified, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, fmt.Sprintf("-o=jsonpath={.status.settings.%s}", hfs)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(statusModified).Should(o.Equal(specModified))
+
+		compat_otp.By("Verify BMH operationalStatus is OK and no error")
+		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(opStatus).Should(o.Equal("OK"), "BMH operationalStatus should be OK after firmware settings update")
+		bmhError, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.errorMessage}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmhError).Should(o.BeEmpty(), "BMH should have no error message after firmware settings update")
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-78361-DAY2 Update host FW via HostFirmwareComponents CRD [Disruptive]", func() {
+		dirname = "OCP-78361.log"
+		compat_otp.By("Find a provisioned worker BareMetalHost for testing")
+		host, machineName := getWorkerBMH(oc)
+		nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines.machine.openshift.io", "-n", machineAPINamespace, machineName, "-o=jsonpath={.status.nodeRef.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeName).NotTo(o.BeEmpty(), "Worker BMH has no associated node")
+
+		vendor, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.hardware.firmware.bios.vendor}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		initialVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath={.status.components[?(@.component==\"bmc\")].currentVersion}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialVersion).NotTo(o.BeEmpty(), "BMC firmware version must not be empty")
+
+		e2e.Logf("Selected BMH: %s, Node: %s, Vendor: %s, FW: %s", host, nodeName, vendor, initialVersion)
+
+		compat_otp.By("Create host update policy")
+		BaseDir := compat_otp.FixturePath("testdata", "installer")
+		hostUpdatePolicy := filepath.Join(BaseDir, "baremetal", "host-update-policy.yaml")
+		compat_otp.ModifyYamlFileContent(hostUpdatePolicy, []compat_otp.YamlReplace{
+			{
+				Path:  "metadata.name",
+				Value: host,
+			},
+		})
+
+		dcErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", hostUpdatePolicy, "-n", machineAPINamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		defer func() {
+			err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("HostUpdatePolicy", "-n", machineAPINamespace, host).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		oc.SetupProject()
+		testNamespace := oc.Namespace()
+
+		downloadUrl, fileName := buildFirmwareURL(vendor, initialVersion)
+
+		// Label worker node 1 to run the web-server hosting the iso
+		compat_otp.By("Add a label to first worker node ")
+		workerNode, err := compat_otp.GetClusterNodesBy(oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nginxNode := workerNode[0]
+		compat_otp.AddLabelToNode(oc, nginxNode, "nginx-node", "true")
+
+		compat_otp.By("Create web-server to host the fw file")
+		BaseDir = compat_otp.FixturePath("testdata", "installer")
+		fwConfigmap := filepath.Join(BaseDir, "baremetal", "firmware-cm.yaml")
+		nginxFW := filepath.Join(BaseDir, "baremetal", "nginx-firmware.yaml")
+		compat_otp.ModifyYamlFileContent(fwConfigmap, []compat_otp.YamlReplace{
+			{
+				Path:  "data.firmware_url",
+				Value: downloadUrl,
+			},
+			{
+				Path:  "data.component",
+				Value: "bmc",
+			},
+		})
+
+		dcErr = oc.Run("create").Args("-f", fwConfigmap, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+
+		dcErr = oc.Run("create").Args("-f", nginxFW, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		compat_otp.AssertPodToBeReady(oc, "nginx-pod", testNamespace)
+
+		compat_otp.By("Create ingress to access the iso file")
+		fileIngress := filepath.Join(BaseDir, "baremetal", "nginx-ingress.yaml")
+		nginxIngress := CopyToFile(fileIngress, "nginx-ingress.yaml")
+		clusterDomain, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ingress.config/cluster", "-o=jsonpath={.spec.domain}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fwUrl := "fw." + clusterDomain
+		defer func() {
+			if err := os.Remove(nginxIngress); err != nil && !os.IsNotExist(err) {
+				e2e.Logf("Warning: Failed to cleanup temporary file %s: %v", nginxIngress, err)
+			}
+		}()
+		compat_otp.ModifyYamlFileContent(nginxIngress, []compat_otp.YamlReplace{
+			{
+				Path:  "spec.rules.0.host",
+				Value: fwUrl,
+			},
+		})
+
+		IngErr := oc.Run("create").Args("-f", nginxIngress, "-n", testNamespace).Execute()
+		o.Expect(IngErr).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Update HFC CRD")
+		component := "bmc"
+		hfcUrl := "http://" + fwUrl + "/" + fileName
+		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"%s","url":"%s"}]}]`, component, hfcUrl)
+		patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+		o.Expect(patchErr).NotTo(o.HaveOccurred())
+		bmcUrl, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "hostfirmwarecomponents", host, "-o=jsonpath={.spec.updates[0].url}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmcUrl).Should(o.Equal(hfcUrl))
+
+		compat_otp.By("Wait for HFC ChangeDetected condition")
+		hfcCondErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+			if err != nil {
+				return false, err
+			}
+			if cond == "True" {
+				e2e.Logf("HFC ChangeDetected condition is True")
+				return true, nil
+			}
+			e2e.Logf("HFC ChangeDetected condition: %s, waiting...", cond)
+			return false, nil
+		})
+		o.Expect(hfcCondErr).NotTo(o.HaveOccurred(), "HFC ChangeDetected condition did not become True")
+
+		defer func() {
+			patchConfig := `[{"op": "replace", "path": "/spec/updates", "value": []}]`
+			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+			o.Expect(patchErr).NotTo(o.HaveOccurred())
+			compat_otp.DeleteLabelFromNode(oc, nginxNode, "nginx-node")
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		g.By("Reboot BareMetalHost")
+		out, err := oc.AsAdmin().WithoutNamespace().Run("annotate").Args("baremetalhosts", host, "reboot.metal3.io=", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("annotated"))
+
+		g.By("Waiting for the node to transition to NotReady state after reboot")
+		err = wait.Poll(5*time.Second, 180*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
+			if err != nil {
+				e2e.Logf("Error getting node status: %v", err)
+				return false, err
+			}
+			if string(output) == "True" {
+				e2e.Logf("Node still Ready, status: %s. Waiting for reboot to start...", output)
+				return false, nil
+			}
+			if string(output) == "Unknown" || string(output) == "False" {
+				e2e.Logf("Node is rebooting, Ready status changed to: %s", output)
+				return true, nil
+			}
+			return false, nil
+		})
+		compat_otp.AssertWaitPollNoErr(err, "Node did not transition to NotReady state after reboot annotation")
+
+		nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+
+		bmcJsonPath := `{.status.components[?(@.component=="bmc")].currentVersion}`
+		var currentVersion string
+		pollErr := wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			ver, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+bmcJsonPath).Output()
+			if err != nil {
+				e2e.Logf("Error getting HostFirmwareComponents version: %v", err)
+				return false, err
+			}
+			if ver == "" {
+				e2e.Logf("HostFirmwareComponents version is empty, still waiting...")
+				return false, nil
+			}
+			if ver != initialVersion {
+				currentVersion = ver
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "Polling for firmware version update failed")
+		o.Expect(currentVersion).NotTo(o.BeEmpty(), "Firmware version must not be empty after update")
+		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
+
+		compat_otp.By("Verify BMH operationalStatus is OK and no error")
+		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(opStatus).Should(o.Equal("OK"), "BMH operationalStatus should be OK after firmware update")
+		bmhError, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.errorMessage}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmhError).Should(o.BeEmpty(), "BMH should have no error message after firmware update")
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-84342-Update NIC FW using HostFirmwareComponents CRD [Disruptive]", func() {
+		dirname = "OCP-84342.log"
+		host, machineName := getWorkerBMH(oc)
+		vendor, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.hardware.firmware.bios.vendor}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if vendor == "HPE" {
+			e2e.Logf("vendor is: %s", vendor)
+			g.Skip("Test not supported on vendor HPE")
+		}
+
+		nicName := getNicNameByVendor(vendor)
+		nicComponent := "nic:" + nicName
+		jsonPath := fmt.Sprintf("{.status.components[?(@.component==\"%s\")].currentVersion}", nicComponent)
+		initialVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+jsonPath).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialVersion).NotTo(o.BeEmpty(), "NIC firmware version must not be empty")
+
+		compat_otp.By("Create host update policy")
+		BaseDir := compat_otp.FixturePath("testdata", "installer")
+		hostUpdatePolicy := filepath.Join(BaseDir, "baremetal", "host-update-policy.yaml")
+		compat_otp.ModifyYamlFileContent(hostUpdatePolicy, []compat_otp.YamlReplace{
+			{
+				Path:  "metadata.name",
+				Value: host,
+			},
+		})
+
+		dcErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", hostUpdatePolicy, "-n", machineAPINamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		defer func() {
+			err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("HostUpdatePolicy", "-n", machineAPINamespace, host).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		oc.SetupProject()
+		testNamespace := oc.Namespace()
+
+		downloadUrl, fileName := getNicFwDetails(vendor, initialVersion)
+
+		compat_otp.By("Get node name from BMH mapping")
+		nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines.machine.openshift.io", "-n", machineAPINamespace, machineName, "-o=jsonpath={.status.nodeRef.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Label worker node 1 to run the web-server hosting the iso
+		compat_otp.By("Add a label to first worker node ")
+		workerNode, err := compat_otp.GetClusterNodesBy(oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nginxNode := workerNode[0]
+		compat_otp.AddLabelToNode(oc, nginxNode, "nginx-node", "true")
+
+		compat_otp.By("Create web-server to host the fw file")
+		BaseDir = compat_otp.FixturePath("testdata", "installer")
+		fwConfigmap := filepath.Join(BaseDir, "baremetal", "firmware-cm.yaml")
+		nginxFW := filepath.Join(BaseDir, "baremetal", "nginx-firmware.yaml")
+		compat_otp.ModifyYamlFileContent(fwConfigmap, []compat_otp.YamlReplace{
+			{
+				Path:  "data.firmware_url",
+				Value: downloadUrl,
+			},
+			{
+				Path:  "data.component",
+				Value: "nic",
+			},
+		})
+
+		dcErr = oc.Run("create").Args("-f", fwConfigmap, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+
+		dcErr = oc.Run("create").Args("-f", nginxFW, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		compat_otp.AssertPodToBeReady(oc, "nginx-pod", testNamespace)
+
+		compat_otp.By("Create ingress to access the iso file")
+		fileIngress := filepath.Join(BaseDir, "baremetal", "nginx-ingress.yaml")
+		nginxIngress := CopyToFile(fileIngress, "nginx-ingress.yaml")
+		clusterDomain, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ingress.config/cluster", "-o=jsonpath={.spec.domain}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fwUrl := "fw." + clusterDomain
+		defer func() {
+			if err := os.Remove(nginxIngress); err != nil && !os.IsNotExist(err) {
+				e2e.Logf("Warning: Failed to cleanup temporary file %s: %v", nginxIngress, err)
+			}
+		}()
+		compat_otp.ModifyYamlFileContent(nginxIngress, []compat_otp.YamlReplace{
+			{
+				Path:  "spec.rules.0.host",
+				Value: fwUrl,
+			},
+		})
+
+		IngErr := oc.Run("create").Args("-f", nginxIngress, "-n", testNamespace).Execute()
+		o.Expect(IngErr).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Update HFC CRD")
+		nicUrl := "http://" + fwUrl + "/" + fileName
+		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"%s","url":"%s"}]}]`, nicComponent, nicUrl)
+		patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+		o.Expect(patchErr).NotTo(o.HaveOccurred())
+		bmcUrl, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "hostfirmwarecomponents", host, "-o=jsonpath={.spec.updates[0].url}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmcUrl).Should(o.Equal(nicUrl))
+
+		defer func() {
+			patchConfig := `[{"op": "replace", "path": "/spec/updates", "value": []}]`
+			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+			o.Expect(patchErr).NotTo(o.HaveOccurred())
+			compat_otp.DeleteLabelFromNode(oc, nginxNode, "nginx-node")
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		g.By("Reboot BareMetalHost")
+		out, err := oc.AsAdmin().WithoutNamespace().Run("annotate").Args("baremetalhosts", host, "reboot.metal3.io=", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("annotated"))
+
+		g.By("Waiting for the node to transition to 'NotReady' state")
+		err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
+			if err != nil {
+				e2e.Logf("Error getting node status: %v", err)
+				return false, nil
+			}
+			if output == "Unknown" || output == "False" {
+				e2e.Logf("Node is rebooting, Ready status changed to: %s", output)
+				return true, nil
+			}
+			e2e.Logf("Node still Ready, status: %s. Waiting for reboot to start...", output)
+			return false, nil
+		})
+		compat_otp.AssertWaitPollNoErr(err, "Node did not transition to NotReady state after reboot annotation")
+
+		nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+
+		// Poll for firmware version update before final assertion
+		var currentVersion string
+		pollErr := wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			ver, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+jsonPath).Output()
+			if err != nil {
+				e2e.Logf("Error getting HostFirmwareComponents version: %v", err)
+				return false, err
+			}
+			if ver == "" {
+				e2e.Logf("HostFirmwareComponents version is empty, still waiting...")
+				return false, nil
+			}
+			if ver != initialVersion {
+				currentVersion = ver
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "Polling for firmware version update failed")
+		o.Expect(currentVersion).NotTo(o.BeEmpty(), "Firmware version must not be empty after update")
+		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
+
+		compat_otp.By("Verify BMH operationalStatus is OK and no error")
+		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(opStatus).Should(o.Equal("OK"), "BMH operationalStatus should be OK after firmware update")
+		bmhError, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.errorMessage}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmhError).Should(o.BeEmpty(), "BMH should have no error message after firmware update")
+
+	})
+
+	// author: jhajyahy@redhat.com
+	// port=unknown - no data in BigQuery last 60 days
+	g.It("Author:jhajyahy-Longduration-NonPreRelease-Medium-84372-Day1-Update NIC FW using HostFirmwareComponents CRD [Disruptive]", func() {
+		dirname = "OCP-84372.log"
+		host, _ := getWorkerBMH(oc)
+		vendor, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.hardware.firmware.bios.vendor}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if vendor == "HPE" {
+			e2e.Logf("vendor is: %s", vendor)
+			g.Skip("Test not supported on vendor HPE")
+		}
+
+		nicName := getNicNameByVendor(vendor)
+		nicComponent := "nic:" + nicName
+		jsonPath := fmt.Sprintf("{.status.components[?(@.component==\"%s\")].currentVersion}", nicComponent)
+		initialVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+jsonPath).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(initialVersion).NotTo(o.BeEmpty(), "NIC firmware version must not be empty")
+
+		oc.SetupProject()
+		testNamespace := oc.Namespace()
+
+		downloadUrl, fileName := getNicFwDetails(vendor, initialVersion)
+
+		// Label worker node 1 to run the web-server hosting the iso
+		compat_otp.By("Add a label to first worker node ")
+		workerNode, err := compat_otp.GetClusterNodesBy(oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nginxNode := workerNode[0]
+		compat_otp.AddLabelToNode(oc, nginxNode, "nginx-node", "true")
+
+		compat_otp.By("Create web-server to host the fw file")
+		BaseDir := compat_otp.FixturePath("testdata", "installer")
+		fwConfigmap := filepath.Join(BaseDir, "baremetal", "firmware-cm.yaml")
+		nginxFW := filepath.Join(BaseDir, "baremetal", "nginx-firmware.yaml")
+		compat_otp.ModifyYamlFileContent(fwConfigmap, []compat_otp.YamlReplace{
+			{
+				Path:  "data.firmware_url",
+				Value: downloadUrl,
+			},
+			{
+				Path:  "data.component",
+				Value: "nic",
+			},
+		})
+
+		dcErr := oc.Run("create").Args("-f", fwConfigmap, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+
+		dcErr = oc.Run("create").Args("-f", nginxFW, "-n", testNamespace).Execute()
+		o.Expect(dcErr).NotTo(o.HaveOccurred())
+		compat_otp.AssertPodToBeReady(oc, "nginx-pod", testNamespace)
+
+		compat_otp.By("Create ingress to access the iso file")
+		fileIngress := filepath.Join(BaseDir, "baremetal", "nginx-ingress.yaml")
+		nginxIngress := CopyToFile(fileIngress, "nginx-ingress.yaml")
+		clusterDomain, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ingress.config/cluster", "-o=jsonpath={.spec.domain}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fwUrl := "fw." + clusterDomain
+		defer func() {
+			if err := os.Remove(nginxIngress); err != nil && !os.IsNotExist(err) {
+				e2e.Logf("Warning: Failed to cleanup temporary file %s: %v", nginxIngress, err)
+			}
+		}()
+		compat_otp.ModifyYamlFileContent(nginxIngress, []compat_otp.YamlReplace{
+			{
+				Path:  "spec.rules.0.host",
+				Value: fwUrl,
+			},
+		})
+
+		IngErr := oc.Run("create").Args("-f", nginxIngress, "-n", testNamespace).Execute()
+		o.Expect(IngErr).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Update HFC CRD")
+		nicUrl := "http://" + fwUrl + "/" + fileName
+		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"%s","url":"%s"}]}]`, nicComponent, nicUrl)
+		patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+		o.Expect(patchErr).NotTo(o.HaveOccurred())
+		bmcUrl, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "hostfirmwarecomponents", host, "-o=jsonpath={.spec.updates[0].url}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(bmcUrl).Should(o.Equal(nicUrl))
+
+		defer func() {
+			patchConfig := `[{"op": "replace", "path": "/spec/updates", "value": []}]`
+			patchErr := oc.AsAdmin().WithoutNamespace().Run("patch").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "--type=json", "-p", patchConfig).Execute()
+			o.Expect(patchErr).NotTo(o.HaveOccurred())
+			compat_otp.DeleteLabelFromNode(oc, nginxNode, "nginx-node")
+			nodeHealthErr := clusterNodesHealthcheck(oc, 3000)
+			compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+			clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+			compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+		}()
+
+		compat_otp.By("Get machine name of host")
+		machine, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.spec.consumerRef.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the MachineSet that owns this Machine from owner reference
+		machineSet, cmdErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines.machine.openshift.io", machine, "-n", machineAPINamespace, "-o=jsonpath={.metadata.ownerReferences[?(@.kind==\"MachineSet\")].name}").Output()
+		o.Expect(cmdErr).NotTo(o.HaveOccurred())
+		o.Expect(machineSet).NotTo(o.BeEmpty(), "Machine should have a MachineSet owner")
+
+		// Get the origin number of replicas from the owning MachineSet
+		originReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Annotate worker-01 machine for deletion")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("annotate").Args("machines.machine.openshift.io", machine, "machine.openshift.io/cluster-api-delete-machine=yes", "-n", machineAPINamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		compat_otp.By("Scale down machineset")
+		originReplicas, err := strconv.Atoi(originReplicasStr)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		newReplicas := originReplicas - 1
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%d", newReplicas)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, host, "available")
+
+		defer func() {
+			currentReplicasStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, "-o=jsonpath={.spec.replicas}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			if currentReplicasStr != originReplicasStr {
+				_, err := oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+				compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+				clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+				compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+			}
+		}()
+
+		compat_otp.By("Scale up machineset")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("machinesets.machine.openshift.io", machineSet, "-n", machineAPINamespace, fmt.Sprintf("--replicas=%s", originReplicasStr)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForBMHState(oc, host, "provisioned")
+
+		nodeHealthErr := clusterNodesHealthcheck(oc, 1500)
+		compat_otp.AssertWaitPollNoErr(nodeHealthErr, "Cluster did not recover in time!")
+		clusterOperatorHealthcheckErr := clusterOperatorHealthcheck(oc, 1500, dirname)
+		compat_otp.AssertWaitPollNoErr(clusterOperatorHealthcheckErr, "Cluster operators did not recover in time!")
+
+		// Poll for firmware version update before final assertion
+		var currentVersion string
+		pollErr := wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			ver, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+jsonPath).Output()
+			if err != nil {
+				e2e.Logf("Error getting HostFirmwareComponents version: %v", err)
+				return false, err
+			}
+			if ver == "" {
+				e2e.Logf("HostFirmwareComponents version is empty, still waiting...")
+				return false, nil
+			}
+			if ver != initialVersion {
+				currentVersion = ver
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "Polling for firmware version update failed")
+		o.Expect(currentVersion).NotTo(o.BeEmpty(), "Firmware version must not be empty after update")
+		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
+
+	})
+})

--- a/tests-extension/openshift/test/e2e/k8s_utils.go
+++ b/tests-extension/openshift/test/e2e/k8s_utils.go
@@ -219,24 +219,3 @@ func clusterNodesHealthcheck(oc *exutil.CLI, waitTime int) error {
 	return errNode
 }
 
-// checkNodeStatus
-func checkNodeStatus(oc *exutil.CLI, pollIntervalSec time.Duration, pollDurationMinute time.Duration, nodeName string, nodeStatus string) error {
-	e2e.Logf("Check status of node %s", nodeName)
-	errNode := wait.PollUntilContextTimeout(context.Background(), pollIntervalSec, pollDurationMinute, false, func(ctx context.Context) (bool, error) {
-		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
-		if err != nil || string(output) != nodeStatus {
-			e2e.Logf("Node status: %s. Trying again", output)
-			return false, nil
-		}
-		if string(output) == nodeStatus {
-			e2e.Logf("Node status: %s", output)
-			return true, nil
-		}
-		return false, nil
-	})
-	if errNode != nil {
-		err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeName).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-	}
-	return errNode
-}

--- a/tests-extension/openshift/test/e2e/metal3_utils.go
+++ b/tests-extension/openshift/test/e2e/metal3_utils.go
@@ -18,6 +18,46 @@ const (
 	machineAPINamespace = "openshift-machine-api"
 )
 
+func skipIfNotBaremetal(oc *exutil.CLI) {
+	platform := compat_otp.CheckPlatform(oc)
+	if platform != "baremetal" {
+		g.Skip(fmt.Sprintf("Cluster is %s, not baremetal - skipping", platform))
+	}
+}
+
+func getWorkerBMH(oc *exutil.CLI) (string, string) {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"machines.machine.openshift.io", "-n", machineAPINamespace,
+		"-l", "machine.openshift.io/cluster-api-machine-role=worker",
+		"-o=jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}",
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	workerMachines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(workerMachines) == 0 || workerMachines[0] == "" {
+		g.Skip("No worker machines found")
+	}
+	machineName := workerMachines[len(workerMachines)-1]
+
+	bmhOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"bmh", "-n", machineAPINamespace,
+		`-o=jsonpath={range .items[*]}{.metadata.name},{.spec.consumerRef.name}{"\n"}{end}`,
+	).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	var host string
+	for _, line := range strings.Split(strings.TrimSpace(bmhOutput), "\n") {
+		parts := strings.SplitN(line, ",", 2)
+		if len(parts) == 2 && parts[1] == machineName {
+			host = parts[0]
+			break
+		}
+	}
+	if host == "" {
+		g.Skip(fmt.Sprintf("No BMH found for worker machine %s", machineName))
+	}
+	return host, machineName
+}
+
 func waitForBMHState(oc *exutil.CLI, bmhName string, bmhStatus string) {
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		out, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "bmh", bmhName, "-o=jsonpath={.status.provisioning.state}").Output()
@@ -51,44 +91,67 @@ func waitForBMHDeletion(oc *exutil.CLI, bmhName string) {
 }
 
 func getFirstDeviceName(oc *exutil.CLI, bmhName string) string {
-	deviceName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.status.hardware.storage[0].name}").Output()
+	deviceName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.hardware.storage[0].name}").Output()
 	o.Expect(err).ShouldNot(o.HaveOccurred())
 	return deviceName
 }
 
 func buildFirmwareURL(vendor, currentVersion string) (string, string) {
+	var url, fileName string
+
+	iDRAC_71070 := "https://dl.dell.com/FOLDER11965413M/1/iDRAC_7.10.70.00_A00.exe"
 	iDRAC_71030 := "https://dl.dell.com/FOLDER11319105M/1/iDRAC_7.10.30.00_A00.exe"
 	ilo5_305 := "https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p991377599/v247527/ilo5_305.fwpkg"
 	ilo5_302 := "https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p991377599/v243854/ilo5_302.fwpkg"
 	ilo6_157 := "https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p788720876/v243858/ilo6_157.fwpkg"
 	ilo6_160 := "https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p788720876/v247531/ilo6_160.fwpkg"
 
+
 	switch vendor {
 	case "Dell Inc.":
-		fileName := "firmimgFIT.d9"
+		fileName = "firmimgFIT.d9"
 		switch currentVersion {
-		case "7.00.00.00":
-			return iDRAC_71030, fileName
+		case "7.10.70.00":
+			url = iDRAC_71030
+		case "7.10.30.00":
+			url = iDRAC_71070
 		default:
-			return iDRAC_71030, fileName // Default to latest
+			url = iDRAC_71070 // Default to 7.10.70.00
 		}
 	case "HPE":
-		switch currentVersion {
-		case "iLO 5 v3.02":
-			return ilo5_305, "ilo5_305.bin"
-		case "iLO 5 v3.05":
-			return ilo5_302, "ilo5_302.bin"
-		case "iLO 6 v1.57":
-			return ilo6_160, "ilo6_160.bin"
-		case "iLO 6 v1.60":
-			return ilo6_157, "ilo6_157.bin"
-		default:
-			return ilo6_157, "ilo6_157.bin" // Default to 1.57
+		// Extract the iLO version and assign the file name accordingly
+		if strings.Contains(currentVersion, "iLO 5") {
+			switch currentVersion {
+			case "iLO 5 v3.05":
+				url = ilo5_302
+				fileName = "ilo5_302.bin"
+			case "iLO 5 v3.02":
+				url = ilo5_305
+				fileName = "ilo5_305.bin"
+			default:
+				url = ilo5_305 // Default to v3.05
+				fileName = "ilo5_305.bin"
+			}
+		} else if strings.Contains(currentVersion, "iLO 6") {
+			switch currentVersion {
+			case "iLO 6 v1.57":
+				url = ilo6_160
+				fileName = "ilo6_160.bin"
+			case "iLO 6 v1.60":
+				url = ilo6_157
+				fileName = "ilo6_157.bin"
+			default:
+				url = ilo6_157 // Default to 1.57
+				fileName = "ilo6_157.bin"
+			}
+		} else {
+			g.Skip("Unsupported HPE BMC version")
 		}
 	default:
-		g.Skip("Unsupported vendor: " + vendor)
-		return "", ""
+		g.Skip("Unsupported vendor")
 	}
+
+	return url, fileName
 }
 
 // getHfsToggleValue returns a vendor-specific HostFirmwareSettings field name and its toggled value.
@@ -186,4 +249,18 @@ func getNicNameByVendor(vendor string) string {
 		g.Skip("Unsupported NIC vendor for name lookup: " + vendor)
 		return ""
 	}
+}
+
+// getBypathDeviceName retrieves the first storage device's by-path name from HardwareData
+func getBypathDeviceName(oc *exutil.CLI, bmhName string) string {
+	deviceName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hardwaredata", "-n", machineAPINamespace, bmhName, "-o=jsonpath={.spec.hardware.storage[0].name}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get device name from HardwareData: %s", bmhName)
+	o.Expect(deviceName).NotTo(o.BeEmpty(), "Device name should not be empty in HardwareData: %s", bmhName)
+	return deviceName
+}
+
+// getHfsByVendor returns vendor-specific HostFirmwareSettings field and its toggled value
+// This is a convenience wrapper around getHfsToggleValue for tests that use this naming
+func getHfsByVendor(oc *exutil.CLI, vendor, machineAPINamespace, host string) (string, string, error) {
+	return getHfsToggleValue(oc, vendor, machineAPINamespace, host)
 }

--- a/tests-extension/testdata/installer/baremetal/bmh-secret.yaml
+++ b/tests-extension/testdata/installer/baremetal/bmh-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+stringData:
+  password: <pass>
+  username: <username>
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: openshift-machine-api
+type: Opaque

--- a/tests-extension/testdata/installer/baremetal/bmh.yaml
+++ b/tests-extension/testdata/installer/baremetal/bmh.yaml
@@ -1,0 +1,15 @@
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: <name>
+  namespace: openshift-machine-api
+spec:
+  online: true
+  bmc:
+    address: exampe
+    credentialsName: exampe
+    disableCertificateVerification: True
+  bootMACAddress: exampe
+  hardwareProfile: unknown
+  rootDeviceHints:
+    deviceName: exampe

--- a/tests-extension/testdata/installer/baremetal/firmware-cm.yaml
+++ b/tests-extension/testdata/installer/baremetal/firmware-cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: firmware-download
+data:
+  firmware_url: example_url
+  component: example_component

--- a/tests-extension/testdata/installer/baremetal/host-update-policy.yaml
+++ b/tests-extension/testdata/installer/baremetal/host-update-policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: metal3.io/v1alpha1
+kind: HostUpdatePolicy
+metadata:
+  name: <BMH name>
+  namespace: openshift-machine-api
+spec:
+  firmwareSettings: onReboot
+  firmwareUpdates: onReboot

--- a/tests-extension/testdata/installer/baremetal/nginx-firmware.yaml
+++ b/tests-extension/testdata/installer/baremetal/nginx-firmware.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-no-ssl
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name _;
+
+        location / {
+            root /usr/share/nginx/html;
+            autoindex on;
+        }
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  labels:
+    app: nginx
+spec:
+  nodeSelector:
+    nginx-node: "true"
+  volumes:
+    - name: firmware-dir
+      emptyDir: {}  # Empty directory to hold the downloaded firmware files
+    - name: firmware-config
+      configMap:
+        name: firmware-download
+    - name: nginx-conf
+      configMap:
+        name: nginx-no-ssl
+    - name: nginx-cache
+      emptyDir: {}
+    - name: nginx-run
+      emptyDir: {}
+  initContainers:
+    - name: init-download-firmware
+      image: ghcr.io/crazy-max/7zip
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: FIRMWARE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: firmware-download
+              key: firmware_url
+        - name: COMPONENT
+          valueFrom:
+            configMapKeyRef:
+              name: firmware-download
+              key: component
+      command:
+      - /bin/sh
+      - -c
+      - |
+        set -xe
+        rm -f /fw/*
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36" \
+          --directory-prefix=/fw \
+          "${FIRMWARE_URL}"
+
+        if [ "${COMPONENT}" != "nic" ]; then
+          7za e /fw/* -o/fw
+        fi
+      volumeMounts:
+        - name: firmware-config
+          mountPath: /config
+        - name: firmware-dir
+          mountPath: /fw
+  containers:
+    - name: nginx
+      image: quay.io/openshifttest/nginx-alpine:armbm
+      volumeMounts:
+        - name: firmware-dir
+          mountPath: /usr/share/nginx/html
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d/
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/tests-extension/testdata/installer/baremetal/nginx-ingress.yaml
+++ b/tests-extension/testdata/installer/baremetal/nginx-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: sample-entry
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 80

--- a/tests-extension/vendor/github.com/openshift/origin/test/extended/util/compat_otp/testdata/bindata.go
+++ b/tests-extension/vendor/github.com/openshift/origin/test/extended/util/compat_otp/testdata/bindata.go
@@ -11021,6 +11021,22 @@ func testExtendedTestdataInstallerBaremetalHostUpdatePolicyYaml() (*asset, error
 
 var _testExtendedTestdataInstallerBaremetalNginxFirmwareYaml = []byte(`---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-no-ssl
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name _;
+
+        location / {
+            root /usr/share/nginx/html;
+            autoindex on;
+        }
+    }
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-pod
@@ -11035,6 +11051,13 @@ spec:
     - name: firmware-config
       configMap:
         name: firmware-download
+    - name: nginx-conf
+      configMap:
+        name: nginx-no-ssl
+    - name: nginx-cache
+      emptyDir: {}
+    - name: nginx-run
+      emptyDir: {}
   initContainers:
     - name: init-download-firmware
       image: ghcr.io/crazy-max/7zip
@@ -11045,22 +11068,41 @@ spec:
             configMapKeyRef:
               name: firmware-download
               key: firmware_url
+        - name: COMPONENT
+          valueFrom:
+            configMapKeyRef:
+              name: firmware-download
+              key: component
       command:
       - /bin/sh
       - -c
       - |
-        rm -f /html/fw/* && wget $FIRMWARE_URL -P /html/fw && 7za e /html/fw/* -o/html/fw
+        set -xe
+        rm -f /fw/*
+        wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36" \
+          --directory-prefix=/fw \
+          "${FIRMWARE_URL}"
+
+        if [ "${COMPONENT}" != "nic" ]; then
+          7za e /fw/* -o/fw
+        fi
       volumeMounts:
         - name: firmware-config
           mountPath: /config
         - name: firmware-dir
-          mountPath: /html/fw
+          mountPath: /fw
   containers:
     - name: nginx
-      image: quay.io/openshifttest/nginx-alpine:latest
+      image: quay.io/openshifttest/nginx-alpine:armbm
       volumeMounts:
         - name: firmware-dir
-          mountPath: /data/http
+          mountPath: /usr/share/nginx/html
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d/
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Added a BareMetal e2e Ginkgo suite that runs only on BareMetal platforms (skips SNO) and validates disruptive firmware updates.
  - Introduced five scenarios covering BMC and vendor NIC firmware, including Hosted delivery, reboot/disruption triggering, cluster recovery, and `currentVersion` assertions.

- **Test Fixtures / Supporting Resources**
  - Added BareMetal installer manifests (BareMetalHost, Secret, HostUpdatePolicy, firmware ConfigMap) plus nginx/ingress fixtures for serving firmware in-cluster.

- **Bug Fixes / Improvements**
  - Improved firmware URL/version selection and added helpers for storage device discovery and vendor HFS lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Tested locally:
 ✅ 77676 (HFS Day 2 reboot) — PASSED
 ✅ 78361 (BMC FW Day 2 reboot) — PASSED (944s)
 ✅ 75430 (BMC FW Day 1 reprovision) — PASSED (previous cluster)
 ⏭️  84342 (NIC FW) — SKIPPED (Dell hardware, HPE-only test)