### PR TITLE
WIP Fix baremetal co progressing during upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,14 @@ TMP_DIR := $(shell mktemp -d -t manifests-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 IMAGES_JSON ?= /etc/cluster-baremetal-operator/images/images.json
 
 # Set VERBOSE to -v to make tests produce more output
-VERBOSE ?= ""
+VERBOSE ?=
 
 all: generate lint build
 
 # Run unit tests
+TEST_PKGS := $(shell go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./...)
 unit:
-	go test $(VERBOSE) ./... -coverprofile cover.out
+	go test $(VERBOSE) $(TEST_PKGS) -coverprofile cover.out
 
 # Run tests
 test: generate lint manifests unit

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,7 @@ rules:
   resources:
   - clusteroperators
   - clusteroperators/status
+  - clusterversions
   verbs:
   - create
   - delete

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -24,7 +24,8 @@ import (
 type StatusReason string
 
 const (
-	clusterOperatorName = "baremetal"
+	clusterOperatorName              = "baremetal"
+	machineConfigClusterOperatorName = "machine-config"
 
 	// OperatorDisabled represents a Disabled ClusterStatusConditionTypes
 	OperatorDisabled osconfigv1.ClusterStatusConditionType = "Disabled"
@@ -180,9 +181,127 @@ func (r *ProvisioningReconciler) createClusterOperator() (*osconfigv1.ClusterOpe
 	return r.OSClient.ConfigV1().ClusterOperators().Create(context.Background(), defaultCO, metav1.CreateOptions{})
 }
 
+func getReportedOperatorVersion(co *osconfigv1.ClusterOperator) string {
+	for _, version := range co.Status.Versions {
+		if version.Name == "operator" {
+			return version.Version
+		}
+	}
+	return ""
+}
+
+func (r *ProvisioningReconciler) getClusterDesiredVersion(ctx context.Context) (string, error) {
+	cv, err := r.OSClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return cv.Status.Desired.Version, nil
+}
+
+// isOperatorVersionUpgradePending reports whether the baremetal ClusterOperator
+// still needs to finish an upgrade. This compares the reported operator version
+// against both the local RELEASE_VERSION and the cluster desired version so
+// upgrades are surfaced even before the new CBO pod is rolled out.
+func (r *ProvisioningReconciler) isOperatorVersionUpgradePending(ctx context.Context, co *osconfigv1.ClusterOperator) (bool, string, error) {
+	reported := getReportedOperatorVersion(co)
+	if reported == "" {
+		return false, "", nil
+	}
+
+	if r.ReleaseVersion != "" && reported != r.ReleaseVersion {
+		return true, r.ReleaseVersion, nil
+	}
+
+	desired, err := r.getClusterDesiredVersion(ctx)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	if desired != "" && reported != desired {
+		return true, desired, nil
+	}
+
+	return false, "", nil
+}
+
+func upgradeProgressMessage(targetVersion string) string {
+	return fmt.Sprintf("Upgrading to release version %s", targetVersion)
+}
+
+func (r *ProvisioningReconciler) isMachineConfigOperatorProgressing(ctx context.Context) (bool, error) {
+	mco, err := r.OSClient.ConfigV1().ClusterOperators().Get(ctx, machineConfigClusterOperatorName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return v1helpers.IsStatusConditionTrue(mco.Status.Conditions, osconfigv1.OperatorProgressing), nil
+}
+
+func setOperatorVersionUpgradeProgressing(co *osconfigv1.ClusterOperator, reported, target string, clusterUpgrade bool) {
+	if clusterUpgrade {
+		klog.InfoS("Cluster version upgrade pending, setting Progressing=True",
+			"reportedVersion", reported,
+			"targetVersion", target)
+	} else {
+		klog.InfoS("Version upgrade pending, setting Progressing=True",
+			"reportedVersion", reported,
+			"targetVersion", target)
+	}
+	v1helpers.SetStatusCondition(&co.Status.Conditions,
+		setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue,
+			string(ReasonSyncing),
+			upgradeProgressMessage(target)),
+		clock.RealClock{})
+}
+
+func (r *ProvisioningReconciler) reconcileOperatorVersionStatus(ctx context.Context, co *osconfigv1.ClusterOperator, justCreated bool) (bool, error) {
+	reported := getReportedOperatorVersion(co)
+	if r.ReleaseVersion != "" && reported != r.ReleaseVersion {
+		if justCreated || reported == "" {
+			co.Status.Versions = operandVersions(r.ReleaseVersion)
+			return true, nil
+		}
+		updated, err := r.setVersionUpgradeProgressingIfAllowed(ctx, co, reported, r.ReleaseVersion, false)
+		if err != nil {
+			return false, err
+		}
+		return updated, nil
+	}
+
+	if justCreated {
+		return false, nil
+	}
+
+	pending, target, err := r.isOperatorVersionUpgradePending(ctx, co)
+	if err != nil {
+		return false, err
+	}
+	if !pending {
+		return false, nil
+	}
+
+	return r.setVersionUpgradeProgressingIfAllowed(ctx, co, reported, target, true)
+}
+
+func (r *ProvisioningReconciler) setVersionUpgradeProgressingIfAllowed(ctx context.Context, co *osconfigv1.ClusterOperator, reported, target string, clusterUpgrade bool) (bool, error) {
+	mcoProgressing, err := r.isMachineConfigOperatorProgressing(ctx)
+	if err != nil {
+		return false, err
+	}
+	if mcoProgressing {
+		return false, nil
+	}
+	setOperatorVersionUpgradeProgressing(co, reported, target, clusterUpgrade)
+	return true, nil
+}
+
 // ensureClusterOperator makes sure that the CO exists
-func (r *ProvisioningReconciler) ensureClusterOperator() error {
-	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+func (r *ProvisioningReconciler) ensureClusterOperator(ctx context.Context) error {
+	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(ctx, clusterOperatorName, metav1.GetOptions{})
 	justCreated := false
 	if k8serrors.IsNotFound(err) {
 		co, err = r.createClusterOperator()
@@ -197,27 +316,19 @@ func (r *ProvisioningReconciler) ensureClusterOperator() error {
 		needsUpdate = true
 		co.Status.RelatedObjects = relatedObjects()
 	}
-	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
-		needsUpdate = true
-		if len(co.Status.Versions) > 0 && !justCreated {
-			klog.InfoS("Version change detected, setting Progressing=True",
-				"oldVersion", co.Status.Versions[0].Version,
-				"newVersion", r.ReleaseVersion)
-			v1helpers.SetStatusCondition(&co.Status.Conditions,
-				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue,
-					string(ReasonSyncing),
-					fmt.Sprintf("Upgrading to release version %s", r.ReleaseVersion)),
-				clock.RealClock{})
-		}
-		co.Status.Versions = operandVersions(r.ReleaseVersion)
-	}
 	if len(co.Status.Conditions) == 0 {
 		needsUpdate = true
 		co.Status.Conditions = defaultStatusConditions()
 	}
 
+	versionNeedsUpdate, err := r.reconcileOperatorVersionStatus(ctx, co, justCreated)
+	if err != nil {
+		return err
+	}
+	needsUpdate = needsUpdate || versionNeedsUpdate
+
 	if needsUpdate {
-		_, err = r.OSClient.ConfigV1().ClusterOperators().UpdateStatus(context.Background(), co, metav1.UpdateOptions{})
+		_, err = r.OSClient.ConfigV1().ClusterOperators().UpdateStatus(ctx, co, metav1.UpdateOptions{})
 	}
 	return err
 }
@@ -267,15 +378,18 @@ func getStatusConditionsDiff(oldConditions []osconfigv1.ClusterOperatorStatusCon
 }
 
 // syncStatus applies the new condition to the CBO ClusterOperator object.
-func (r *ProvisioningReconciler) syncStatus(co *osconfigv1.ClusterOperator, conds []osconfigv1.ClusterOperatorStatusCondition) error {
+func (r *ProvisioningReconciler) syncStatus(co *osconfigv1.ClusterOperator, conds []osconfigv1.ClusterOperatorStatusCondition, reason StatusReason) error {
 	diff := getStatusConditionsDiff(co.Status.Conditions, conds)
 
 	for _, c := range conds {
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c, clock.RealClock{})
 	}
 
-	if len(co.Status.Versions) < 1 {
-		klog.Info("updating ClusterOperator Status Versions field")
+	if reason == ReasonComplete {
+		klog.Info("upgrade complete, updating ClusterOperator Status Versions field")
+		co.Status.Versions = operandVersions(r.ReleaseVersion)
+	} else if len(co.Status.Versions) < 1 && r.ReleaseVersion != "" {
+		klog.Info("initializing ClusterOperator Status Versions field")
 		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 
@@ -319,5 +433,5 @@ func (r *ProvisioningReconciler) updateCOStatus(newReason StatusReason, msg, pro
 		v1helpers.SetStatusCondition(&conds, setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(newReason), progressMsg), clk)
 	}
 
-	return r.syncStatus(co, conds)
+	return r.syncStatus(co, conds, newReason)
 }

--- a/controllers/clusteroperator.go
+++ b/controllers/clusteroperator.go
@@ -183,8 +183,10 @@ func (r *ProvisioningReconciler) createClusterOperator() (*osconfigv1.ClusterOpe
 // ensureClusterOperator makes sure that the CO exists
 func (r *ProvisioningReconciler) ensureClusterOperator() error {
 	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+	justCreated := false
 	if k8serrors.IsNotFound(err) {
 		co, err = r.createClusterOperator()
+		justCreated = true
 	}
 	if err != nil {
 		return err
@@ -197,6 +199,16 @@ func (r *ProvisioningReconciler) ensureClusterOperator() error {
 	}
 	if !equality.Semantic.DeepEqual(co.Status.Versions, operandVersions(r.ReleaseVersion)) {
 		needsUpdate = true
+		if len(co.Status.Versions) > 0 && !justCreated {
+			klog.InfoS("Version change detected, setting Progressing=True",
+				"oldVersion", co.Status.Versions[0].Version,
+				"newVersion", r.ReleaseVersion)
+			v1helpers.SetStatusCondition(&co.Status.Conditions,
+				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue,
+					string(ReasonSyncing),
+					fmt.Sprintf("Upgrading to release version %s", r.ReleaseVersion)),
+				clock.RealClock{})
+		}
 		co.Status.Versions = operandVersions(r.ReleaseVersion)
 	}
 	if len(co.Status.Conditions) == 0 {

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -131,6 +131,35 @@ func TestEnsureClusterOperator(t *testing.T) {
 		},
 	}
 
+	var progressingUpgradeConditions = []osconfigv1.ClusterOperatorStatusCondition{
+		setStatusCondition(
+			osconfigv1.OperatorProgressing,
+			osconfigv1.ConditionTrue,
+			string(ReasonSyncing),
+			"Upgrading to release version test-version",
+		),
+		setStatusCondition(
+			osconfigv1.OperatorDegraded,
+			osconfigv1.ConditionFalse,
+			"", "",
+		),
+		setStatusCondition(
+			osconfigv1.OperatorAvailable,
+			osconfigv1.ConditionFalse,
+			"", "",
+		),
+		setStatusCondition(
+			osconfigv1.OperatorUpgradeable,
+			osconfigv1.ConditionTrue,
+			"", "",
+		),
+		setStatusCondition(
+			OperatorDisabled,
+			osconfigv1.ConditionFalse,
+			"", "",
+		),
+	}
+
 	testCases := []struct {
 		name       string
 		existingCO *osconfigv1.ClusterOperator
@@ -184,6 +213,75 @@ func TestEnsureClusterOperator(t *testing.T) {
 				},
 				Status: osconfigv1.ClusterOperatorStatus{
 					Conditions:     conditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+		},
+		{
+			name: "Version upgrade sets Progressing",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+				},
+			},
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     progressingUpgradeConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+		},
+		{
+			name: "First version set does not set Progressing",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{},
+				},
+			},
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+		},
+		{
+			name: "Same version does not update",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+				},
+			},
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
 					RelatedObjects: relatedObjects(),
 					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
 				},

--- a/controllers/clusteroperator_test.go
+++ b/controllers/clusteroperator_test.go
@@ -6,12 +6,16 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	"github.com/openshift/cluster-baremetal-operator/provisioning"
+	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
 
 func TestUpdateCOStatus(t *testing.T) {
@@ -161,9 +165,10 @@ func TestEnsureClusterOperator(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name       string
-		existingCO *osconfigv1.ClusterOperator
-		expectedCO *osconfigv1.ClusterOperator
+		name            string
+		existingCO      *osconfigv1.ClusterOperator
+		machineConfigCO *osconfigv1.ClusterOperator
+		expectedCO      *osconfigv1.ClusterOperator
 	}{
 		{
 			name:       "No clusteroperator",
@@ -237,7 +242,31 @@ func TestEnsureClusterOperator(t *testing.T) {
 				Status: osconfigv1.ClusterOperatorStatus{
 					Conditions:     progressingUpgradeConditions,
 					RelatedObjects: relatedObjects(),
-					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "test-version"}},
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+				},
+			},
+		},
+		{
+			name: "Version upgrade waits for MCO",
+			existingCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+				},
+			},
+			machineConfigCO: machineConfigClusterOperatorProgressing(),
+			expectedCO: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterOperatorName,
+				},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions:     defaultConditions,
+					RelatedObjects: relatedObjects(),
+					Versions:       []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
 				},
 			},
 		},
@@ -291,16 +320,21 @@ func TestEnsureClusterOperator(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var osClient *fakeconfigclientset.Clientset
-			if tc.existingCO != nil {
+			switch {
+			case tc.existingCO != nil && tc.machineConfigCO != nil:
+				osClient = fakeconfigclientset.NewSimpleClientset(tc.existingCO, tc.machineConfigCO)
+			case tc.existingCO != nil:
 				osClient = fakeconfigclientset.NewSimpleClientset(tc.existingCO)
-			} else {
+			case tc.machineConfigCO != nil:
+				osClient = fakeconfigclientset.NewSimpleClientset(tc.machineConfigCO)
+			default:
 				osClient = fakeconfigclientset.NewSimpleClientset()
 			}
 			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
 			reconciler.OSClient = osClient
 			reconciler.ReleaseVersion = "test-version"
 
-			err := reconciler.ensureClusterOperator()
+			err := reconciler.ensureClusterOperator(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -315,6 +349,305 @@ func TestEnsureClusterOperator(t *testing.T) {
 				t.Error(cmp.Diff(tc.expectedCO, co))
 			}
 		})
+	}
+}
+
+func machineConfigClusterOperatorProgressing() *osconfigv1.ClusterOperator {
+	return &osconfigv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: machineConfigClusterOperatorName},
+		Status: osconfigv1.ClusterOperatorStatus{
+			Conditions: []osconfigv1.ClusterOperatorStatusCondition{
+				setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionTrue, string(ReasonSyncing), "Updating nodes"),
+			},
+		},
+	}
+}
+
+func TestIsMachineConfigOperatorProgressing(t *testing.T) {
+	testCases := []struct {
+		name        string
+		mco         *osconfigv1.ClusterOperator
+		progressing bool
+	}{
+		{
+			name:        "missing machine-config CO",
+			progressing: false,
+		},
+		{
+			name:        "machine-config progressing",
+			mco:         machineConfigClusterOperatorProgressing(),
+			progressing: true,
+		},
+		{
+			name: "machine-config not progressing",
+			mco: &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: machineConfigClusterOperatorName},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions: []osconfigv1.ClusterOperatorStatusCondition{
+						setStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(ReasonComplete), ""),
+					},
+				},
+			},
+			progressing: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := []runtime.Object{}
+			if tc.mco != nil {
+				objects = append(objects, tc.mco)
+			}
+			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
+			reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(objects...)
+
+			progressing, err := reconciler.isMachineConfigOperatorProgressing(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if progressing != tc.progressing {
+				t.Fatalf("expected progressing=%v, got %v", tc.progressing, progressing)
+			}
+		})
+	}
+}
+
+func TestIsOperatorVersionUpgradePending(t *testing.T) {
+	clusterVersion := &osconfigv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: osconfigv1.ClusterVersionStatus{
+			Desired: osconfigv1.Release{Version: "cluster-target-version"},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		releaseVersion  string
+		reportedVersion string
+		clusterVersion  *osconfigv1.ClusterVersion
+		pending         bool
+		target          string
+	}{
+		{
+			name:            "release version mismatch",
+			releaseVersion:  "new-version",
+			reportedVersion: "old-version",
+			clusterVersion:  clusterVersion,
+			pending:         true,
+			target:          "new-version",
+		},
+		{
+			name:            "cluster desired version mismatch",
+			releaseVersion:  "old-version",
+			reportedVersion: "old-version",
+			clusterVersion:  clusterVersion,
+			pending:         true,
+			target:          "cluster-target-version",
+		},
+		{
+			name:            "upgrade complete",
+			releaseVersion:  "target-version",
+			reportedVersion: "target-version",
+			clusterVersion: &osconfigv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Status: osconfigv1.ClusterVersionStatus{
+					Desired: osconfigv1.Release{Version: "target-version"},
+				},
+			},
+			pending: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			co := &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Versions: []osconfigv1.OperandVersion{{Name: "operator", Version: tc.reportedVersion}},
+				},
+			}
+			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
+			reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(co, tc.clusterVersion)
+			reconciler.ReleaseVersion = tc.releaseVersion
+
+			pending, target, err := reconciler.isOperatorVersionUpgradePending(context.Background(), co)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if pending != tc.pending {
+				t.Fatalf("expected pending=%v, got %v", tc.pending, pending)
+			}
+			if pending && target != tc.target {
+				t.Fatalf("expected target=%q, got %q", tc.target, target)
+			}
+		})
+	}
+}
+
+func TestUpdateCOProgressingStatusDuringUpgrade(t *testing.T) {
+	clusterVersion := &osconfigv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: osconfigv1.ClusterVersionStatus{
+			Desired: osconfigv1.Release{Version: "new-version"},
+		},
+	}
+
+	testCases := []struct {
+		name              string
+		rolloutInProgress bool
+		deploymentState   appsv1.DeploymentConditionType
+		bmoState          appsv1.DeploymentConditionType
+		machineConfigCO   *osconfigv1.ClusterOperator
+		expectProgressing bool
+		expectReportedVer string
+	}{
+		{
+			name:              "rollout in progress",
+			rolloutInProgress: true,
+			deploymentState:   appsv1.DeploymentAvailable,
+			bmoState:          appsv1.DeploymentAvailable,
+			expectProgressing: true,
+			expectReportedVer: "old-version",
+		},
+		{
+			name:              "operands rolled out",
+			rolloutInProgress: false,
+			deploymentState:   appsv1.DeploymentAvailable,
+			bmoState:          appsv1.DeploymentAvailable,
+			expectProgressing: false,
+			expectReportedVer: "new-version",
+		},
+		{
+			name:              "operands not ready",
+			rolloutInProgress: false,
+			deploymentState:   appsv1.DeploymentProgressing,
+			bmoState:          appsv1.DeploymentAvailable,
+			expectProgressing: true,
+			expectReportedVer: "old-version",
+		},
+		{
+			name:              "while MCO progressing",
+			rolloutInProgress: true,
+			machineConfigCO:   machineConfigClusterOperatorProgressing(),
+			deploymentState:   appsv1.DeploymentAvailable,
+			bmoState:          appsv1.DeploymentAvailable,
+			expectProgressing: false,
+			expectReportedVer: "old-version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			co := &osconfigv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName},
+				Status: osconfigv1.ClusterOperatorStatus{
+					Conditions: defaultStatusConditions(),
+					Versions:   []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+				},
+			}
+
+			reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
+			objects := []runtime.Object{co, clusterVersion}
+			if tc.machineConfigCO != nil {
+				objects = append(objects, tc.machineConfigCO)
+			}
+			reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(objects...)
+			reconciler.ReleaseVersion = "new-version"
+
+			err := reconciler.updateCOProgressingStatus(
+				context.Background(),
+				tc.rolloutInProgress,
+				tc.deploymentState,
+				tc.bmoState,
+				provisioning.DaemonSetAvailable,
+				provisioning.DaemonSetAvailable,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotCO, err := reconciler.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			progressing := v1helpers.FindStatusCondition(gotCO.Status.Conditions, osconfigv1.OperatorProgressing)
+			if tc.expectProgressing {
+				if progressing == nil || progressing.Status != osconfigv1.ConditionTrue {
+					t.Fatalf("expected Progressing=True, got %#v", progressing)
+				}
+			} else if progressing == nil || progressing.Status != osconfigv1.ConditionFalse {
+				t.Fatalf("expected Progressing=False, got %#v", progressing)
+			}
+			if got := getReportedOperatorVersion(gotCO); got != tc.expectReportedVer {
+				t.Fatalf("expected reported version %q, got %q", tc.expectReportedVer, got)
+			}
+		})
+	}
+}
+
+func TestUpdateCOProgressingStatusClusterVersionUpgrade(t *testing.T) {
+	co := &osconfigv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName},
+		Status: osconfigv1.ClusterOperatorStatus{
+			Conditions: defaultStatusConditions(),
+			Versions:   []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}},
+		},
+	}
+	clusterVersion := &osconfigv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: osconfigv1.ClusterVersionStatus{
+			Desired: osconfigv1.Release{Version: "new-version"},
+		},
+	}
+
+	reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
+	reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(co, clusterVersion)
+	reconciler.ReleaseVersion = "old-version"
+
+	err := reconciler.updateCOProgressingStatus(
+		context.Background(),
+		false,
+		appsv1.DeploymentAvailable,
+		appsv1.DeploymentAvailable,
+		provisioning.DaemonSetAvailable,
+		provisioning.DaemonSetAvailable,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotCO, err := reconciler.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	progressing := v1helpers.FindStatusCondition(gotCO.Status.Conditions, osconfigv1.OperatorProgressing)
+	if progressing == nil || progressing.Status != osconfigv1.ConditionTrue {
+		t.Fatalf("expected Progressing=True while waiting for newer CBO pod, got %#v", progressing)
+	}
+	if got := getReportedOperatorVersion(gotCO); got != "old-version" {
+		t.Fatalf("expected reported version to remain %q, got %q", "old-version", got)
+	}
+}
+
+func TestUpdateCOStatusSetsVersionOnComplete(t *testing.T) {
+	reconciler := newFakeProvisioningReconciler(setUpSchemeForReconciler(), &osconfigv1.Infrastructure{})
+	co, _ := reconciler.createClusterOperator()
+	co.Status.Versions = []osconfigv1.OperandVersion{{Name: "operator", Version: "old-version"}}
+	reconciler.OSClient = fakeconfigclientset.NewSimpleClientset(co)
+	reconciler.ReleaseVersion = "new-version"
+
+	if err := reconciler.updateCOStatus(ReasonComplete, "metal3 pod is running", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotCO, err := reconciler.OSClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getReportedOperatorVersion(gotCO); got != "new-version" {
+		t.Fatalf("expected version %q after complete, got %q", "new-version", got)
 	}
 }
 

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -107,7 +107,7 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status;clusterversions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;list;patch
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets;services,verbs=get;list;watch;create;update;patch;delete
@@ -229,7 +229,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Make sure ClusterOperator exists
-	err := r.ensureClusterOperator()
+	err := r.ensureClusterOperator(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -349,9 +349,15 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		if updated {
-			klog.Info("Resource updated during ensure loop, setting Progressing=True")
-			if coErr := r.updateCOStatus(ReasonSyncing, "", "Applying metal3 resources"); coErr != nil {
-				return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Syncing state: %w", clusterOperatorName, coErr)
+			mcoProgressing, mcoErr := r.isMachineConfigOperatorProgressing(ctx)
+			if mcoErr != nil {
+				return ctrl.Result{}, mcoErr
+			}
+			if !mcoProgressing {
+				klog.Info("Resource updated during ensure loop, setting Progressing=True")
+				if coErr := r.updateCOStatus(ReasonSyncing, "", "Applying metal3 resources"); coErr != nil {
+					return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Syncing state: %w", clusterOperatorName, coErr)
+				}
 			}
 			return result, r.Client.Status().Update(ctx, baremetalConfig)
 		}
@@ -426,7 +432,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		rolloutInProgress = true
 	}
 
-	if err := r.updateCOProgressingStatus(rolloutInProgress, deploymentState, bmoState, imageCacheState, ironicProxyState); err != nil {
+	if err := r.updateCOProgressingStatus(ctx, rolloutInProgress, deploymentState, bmoState, imageCacheState, ironicProxyState); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -434,16 +440,47 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *ProvisioningReconciler) updateCOProgressingStatus(
+	ctx context.Context,
 	rolloutInProgress bool,
 	deploymentState appsv1.DeploymentConditionType,
 	bmoState appsv1.DeploymentConditionType,
 	imageCacheState appsv1.DaemonSetConditionType,
 	ironicProxyState appsv1.DaemonSetConditionType,
 ) error {
-	if rolloutInProgress {
-		return r.updateCOStatus(ReasonSyncing, "", "Waiting for metal3 resources to rollout")
+	co, err := r.OSClient.ConfigV1().ClusterOperators().Get(ctx, clusterOperatorName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get clusterOperator %q: %w", clusterOperatorName, err)
 	}
-	if deploymentState != appsv1.DeploymentAvailable || bmoState != appsv1.DeploymentAvailable {
+
+	mcoProgressing, err := r.isMachineConfigOperatorProgressing(ctx)
+	if err != nil {
+		return err
+	}
+	if mcoProgressing {
+		return nil
+	}
+
+	pending, target, err := r.isOperatorVersionUpgradePending(ctx, co)
+	if err != nil {
+		return err
+	}
+
+	operandsReady := deploymentState == appsv1.DeploymentAvailable && bmoState == appsv1.DeploymentAvailable
+	reported := getReportedOperatorVersion(co)
+	// A reported-vs-local release mismatch can be resolved once this CBO instance
+	// has finished rolling out operands. Cluster-version-only mismatches mean a
+	// newer CBO pod is still required and must keep Progressing=True.
+	releaseUpgradePending := r.ReleaseVersion != "" && reported != r.ReleaseVersion
+	versionUpgradeBlocking := pending && (rolloutInProgress || !operandsReady || !releaseUpgradePending)
+
+	if versionUpgradeBlocking || rolloutInProgress {
+		progressMsg := upgradeProgressMessage(target)
+		if rolloutInProgress {
+			progressMsg = "Waiting for metal3 resources to rollout"
+		}
+		return r.updateCOStatus(ReasonSyncing, "", progressMsg)
+	}
+	if !operandsReady {
 		return nil
 	}
 	msg := getSuccessStatus(imageCacheState, ironicProxyState)
@@ -700,7 +737,7 @@ func (r *ProvisioningReconciler) updateProvisioningMacAddresses(ctx context.Cont
 // SetupWithManager configures the manager to run the controller
 func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
-	err := r.ensureClusterOperator()
+	err := r.ensureClusterOperator(ctx)
 	if err != nil {
 		return errors.Wrap(err, "unable to set get baremetal ClusterOperator")
 	}
@@ -780,6 +817,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(serviceMonitor).
 		Owns(prometheusRule).
 		Watches(&osconfigv1.ClusterOperator{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
+		Watches(&osconfigv1.ClusterVersion{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.Proxy{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.APIServer{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton), builder.WithPredicates(pullSecretFilter)).

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -329,6 +329,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	rolloutInProgress := false
 	for _, ensureResource := range []ensureFunc{
 		provisioning.EnsureAllSecrets,
 		provisioning.EnsureMetal3Deployment,
@@ -348,6 +349,10 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 		if updated {
+			klog.Info("Resource updated during ensure loop, setting Progressing=True")
+			if coErr := r.updateCOStatus(ReasonSyncing, "", "Applying metal3 resources"); coErr != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Syncing state: %w", clusterOperatorName, coErr)
+			}
 			return result, r.Client.Status().Update(ctx, baremetalConfig)
 		}
 	}
@@ -375,6 +380,10 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %w", clusterOperatorName, err)
 		}
 	}
+	if deploymentState == appsv1.DeploymentProgressing {
+		klog.Info("metal3 deployment is progressing")
+		rolloutInProgress = true
+	}
 
 	// Determine the status of the BMO deployment
 	bmoState, err := provisioning.GetBaremetalOperatorDeploymentState(r.KubeClient.AppsV1(), ComponentNamespace, baremetalConfig)
@@ -391,6 +400,10 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Degraded state: %w", clusterOperatorName, err)
 		}
 	}
+	if bmoState == appsv1.DeploymentProgressing {
+		klog.Info("baremetal-operator deployment is progressing")
+		rolloutInProgress = true
+	}
 
 	// Determine the status of the image cache DaemonSet
 	imageCacheState, err := provisioning.GetImageCacheState(r.KubeClient.AppsV1(), ComponentNamespace, baremetalConfig)
@@ -398,24 +411,46 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if imageCacheState == provisioning.DaemonSetProgressing {
+		klog.Info("image cache daemonset is progressing")
+		rolloutInProgress = true
+	}
 
 	ironicProxyState, err := provisioning.GetIronicProxyState(r.KubeClient.AppsV1(), ComponentNamespace, info)
 	err = r.checkDaemonSet(ironicProxyState, err, "ironic proxy", func() error { return provisioning.DeleteIronicProxy(info) })
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if ironicProxyState == provisioning.DaemonSetProgressing {
+		klog.Info("ironic proxy daemonset is progressing")
+		rolloutInProgress = true
+	}
 
-	if deploymentState == appsv1.DeploymentAvailable && bmoState == appsv1.DeploymentAvailable {
-		msg := getSuccessStatus(imageCacheState, ironicProxyState)
-		if msg != "" {
-			err = r.updateCOStatus(ReasonComplete, msg, "")
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("unable to put %q ClusterOperator in Progressing state: %w", clusterOperatorName, err)
-			}
-		}
+	if err := r.updateCOProgressingStatus(rolloutInProgress, deploymentState, bmoState, imageCacheState, ironicProxyState); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return result, nil
+}
+
+func (r *ProvisioningReconciler) updateCOProgressingStatus(
+	rolloutInProgress bool,
+	deploymentState appsv1.DeploymentConditionType,
+	bmoState appsv1.DeploymentConditionType,
+	imageCacheState appsv1.DaemonSetConditionType,
+	ironicProxyState appsv1.DaemonSetConditionType,
+) error {
+	if rolloutInProgress {
+		return r.updateCOStatus(ReasonSyncing, "", "Waiting for metal3 resources to rollout")
+	}
+	if deploymentState != appsv1.DeploymentAvailable || bmoState != appsv1.DeploymentAvailable {
+		return nil
+	}
+	msg := getSuccessStatus(imageCacheState, ironicProxyState)
+	if msg == "" {
+		return nil
+	}
+	return r.updateCOStatus(ReasonComplete, msg, "")
 }
 
 func (r *ProvisioningReconciler) provisioningInfo(ctx context.Context, provConfig *metal3iov1alpha1.Provisioning, images *provisioning.Images, sshkey string) (*provisioning.ProvisioningInfo, error) {

--- a/controllers/provisioning_controller_test.go
+++ b/controllers/provisioning_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -315,4 +316,69 @@ func TestUpdateProvisioningMacAddresses(t *testing.T) {
 	err := r.updateProvisioningMacAddresses(context.TODO(), &baremetalCR)
 	assert.NoError(t, err, "ProvisioningReconciler.updateProvisioningMacAddresses()")
 	assert.ElementsMatch(t, baremetalCR.Spec.ProvisioningMacAddresses, want)
+}
+
+func TestGetSuccessStatus(t *testing.T) {
+	testCases := []struct {
+		name             string
+		imageCacheState  appsv1.DaemonSetConditionType
+		ironicProxyState appsv1.DaemonSetConditionType
+		expectedMsg      string
+	}{
+		{
+			name:             "All available",
+			imageCacheState:  provisioning.DaemonSetAvailable,
+			ironicProxyState: provisioning.DaemonSetAvailable,
+			expectedMsg:      "metal3 pod, image cache, ironic proxy are running",
+		},
+		{
+			name:             "Image cache disabled, ironic proxy available",
+			imageCacheState:  provisioning.DaemonSetDisabled,
+			ironicProxyState: provisioning.DaemonSetAvailable,
+			expectedMsg:      "metal3 pod, ironic proxy are running",
+		},
+		{
+			name:             "Image cache available, ironic proxy disabled",
+			imageCacheState:  provisioning.DaemonSetAvailable,
+			ironicProxyState: provisioning.DaemonSetDisabled,
+			expectedMsg:      "metal3 pod, image cache are running",
+		},
+		{
+			name:             "Both disabled",
+			imageCacheState:  provisioning.DaemonSetDisabled,
+			ironicProxyState: provisioning.DaemonSetDisabled,
+			expectedMsg:      "metal3 pod is running",
+		},
+		{
+			name:             "Image cache progressing blocks success",
+			imageCacheState:  provisioning.DaemonSetProgressing,
+			ironicProxyState: provisioning.DaemonSetAvailable,
+			expectedMsg:      "",
+		},
+		{
+			name:             "Ironic proxy progressing blocks success",
+			imageCacheState:  provisioning.DaemonSetAvailable,
+			ironicProxyState: provisioning.DaemonSetProgressing,
+			expectedMsg:      "",
+		},
+		{
+			name:             "Both progressing blocks success",
+			imageCacheState:  provisioning.DaemonSetProgressing,
+			ironicProxyState: provisioning.DaemonSetProgressing,
+			expectedMsg:      "",
+		},
+		{
+			name:             "Image cache replica failure blocks success",
+			imageCacheState:  provisioning.DaemonSetReplicaFailure,
+			ironicProxyState: provisioning.DaemonSetAvailable,
+			expectedMsg:      "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := getSuccessStatus(tc.imageCacheState, tc.ironicProxyState)
+			assert.Equal(t, tc.expectedMsg, msg)
+		})
+	}
 }

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -150,6 +150,7 @@ rules:
   resources:
   - clusteroperators
   - clusteroperators/status
+  - clusterversions
   verbs:
   - create
   - delete


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ClusterOperator status reporting during operator/rollout upgrades with clearer progressing and completion behavior.
  * Added watches and RBAC support to react to ClusterVersion changes and keep status synchronized.

* **Bug Fixes**
  * Avoids premature `status.versions` updates while an upgrade is pending.
  * Keeps the reported operand/operator version stable until upgrade completion, reducing confusing status flips.

* **Tests**
  * Added/extended unit tests for progressing/upgrade-pending detection and correct version updates on `ReasonComplete`.
  * Added success-status coverage for image-cache and ironic-proxy condition combinations.

* **Chores**
  * Updated the unit test target to run only packages containing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->