### PR TITLE
OCPBUGS-66101: Set Progressing=True during cluster update

### DIFF
--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -307,7 +307,12 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	specChanged := baremetalConfig.Generation != baremetalConfig.Status.ObservedGeneration
-	if specChanged {
+	imagesMatch, err := provisioning.OperandImagesMatch(r.KubeClient.AppsV1(), ComponentNamespace, info.Images)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to check operand images: %w", err)
+	}
+
+	if specChanged || !imagesMatch {
 		if baremetalConfig.Spec.UnsupportedConfigOverrides != nil {
 			klog.Warningf("using unsupportedConfigOverrides in the configuration: %+v", *baremetalConfig.Spec.UnsupportedConfigOverrides)
 		}

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -1003,4 +1004,58 @@ func GetDeploymentState(client appsclientv1.DeploymentsGetter, targetNamespace s
 
 func DeleteMetal3Deployment(info *ProvisioningInfo) error {
 	return client.IgnoreNotFound(info.Client.AppsV1().Deployments(info.Namespace).Delete(context.Background(), baremetalDeploymentName, metav1.DeleteOptions{}))
+}
+
+// OperandImagesMatch checks whether the container images in the running
+// metal3 and BMO deployments match the desired images. Returns false when
+// images differ or deployments are absent, indicating a sync is needed.
+func OperandImagesMatch(client appsclientv1.DeploymentsGetter, targetNamespace string, images *Images) (bool, error) {
+	metal3, err := client.Deployments(targetNamespace).Get(context.Background(), baremetalDeploymentName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	foundIronic := false
+	foundStaticIP := false
+	for _, c := range metal3.Spec.Template.Spec.Containers {
+		switch c.Name {
+		case "metal3-ironic":
+			foundIronic = true
+			if c.Image != images.Ironic {
+				return false, nil
+			}
+		case "metal3-static-ip-manager":
+			foundStaticIP = true
+			if c.Image != images.StaticIpManager {
+				return false, nil
+			}
+		}
+	}
+	if !foundIronic || !foundStaticIP {
+		return false, nil
+	}
+
+	bmo, err := client.Deployments(targetNamespace).Get(context.Background(), bmoDeploymentName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	foundBMO := false
+	for _, c := range bmo.Spec.Template.Spec.Containers {
+		if c.Name == "metal3-baremetal-operator" {
+			foundBMO = true
+			if c.Image != images.BaremetalOperator {
+				return false, nil
+			}
+		}
+	}
+	if !foundBMO {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -988,6 +990,168 @@ func TestCreateInitContainerMachineOsDownloader(t *testing.T) {
 			assert.NotNil(t, container.SecurityContext.ReadOnlyRootFilesystem)
 			assert.True(t, *container.SecurityContext.ReadOnlyRootFilesystem,
 				"ReadOnlyRootFilesystem should be true")
+		})
+	}
+}
+
+func TestOperandImagesMatch(t *testing.T) {
+	const namespace = "openshift-machine-api"
+
+	desiredImages := &Images{
+		Ironic:            "registry.example.com/ironic:v2",
+		StaticIpManager:   "registry.example.com/static-ip:v2",
+		BaremetalOperator: "registry.example.com/bmo:v2",
+	}
+
+	metal3Deployment := func(ironicImage, staticIPImage string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      baremetalDeploymentName,
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "metal3-ironic", Image: ironicImage},
+							{Name: "metal3-static-ip-manager", Image: staticIPImage},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	bmoDeployment := func(bmoImage string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bmoDeploymentName,
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "metal3-baremetal-operator", Image: bmoImage},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tCases := []struct {
+		name     string
+		objects  []*appsv1.Deployment
+		expected bool
+	}{
+		{
+			name:     "no deployments exist",
+			objects:  nil,
+			expected: false,
+		},
+		{
+			name: "all images match",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				bmoDeployment(desiredImages.BaremetalOperator),
+			},
+			expected: true,
+		},
+		{
+			name: "ironic image differs",
+			objects: []*appsv1.Deployment{
+				metal3Deployment("registry.example.com/ironic:v1", desiredImages.StaticIpManager),
+				bmoDeployment(desiredImages.BaremetalOperator),
+			},
+			expected: false,
+		},
+		{
+			name: "static-ip-manager image differs",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, "registry.example.com/static-ip:v1"),
+				bmoDeployment(desiredImages.BaremetalOperator),
+			},
+			expected: false,
+		},
+		{
+			name: "bmo image differs",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				bmoDeployment("registry.example.com/bmo:v1"),
+			},
+			expected: false,
+		},
+		{
+			name: "only metal3 exists and matches",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+			},
+			expected: false,
+		},
+		{
+			name: "only bmo exists and differs",
+			objects: []*appsv1.Deployment{
+				bmoDeployment("registry.example.com/bmo:v1"),
+			},
+			expected: false,
+		},
+		{
+			name: "metal3 missing required container",
+			objects: []*appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      baremetalDeploymentName,
+						Namespace: namespace,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "metal3-ironic", Image: desiredImages.Ironic},
+								},
+							},
+						},
+					},
+				},
+				bmoDeployment(desiredImages.BaremetalOperator),
+			},
+			expected: false,
+		},
+		{
+			name: "bmo missing required container",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      bmoDeploymentName,
+						Namespace: namespace,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "unrelated-container", Image: "some-image"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var kubeObjects []runtime.Object
+			for _, d := range tc.objects {
+				kubeObjects = append(kubeObjects, d)
+			}
+			kubeClient := fakekube.NewSimpleClientset(kubeObjects...)
+			result, err := OperandImagesMatch(kubeClient.AppsV1(), namespace, desiredImages)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
During cluster upgrades, only the images ConfigMap changes — the Provisioning CR spec stays the same. The operator never reported Progressing=True because it only checked spec generation changes.

Add OperandImagesMatch() to compare container images in the running metal3 and BMO deployments against desired images from the ConfigMap. Set Progressing=True when images differ, alongside the existing spec-change check.

This avoids false Progressing=True during MCO node reboots, where Ensure* functions return updated=true for webhook configs and deployment annotations due to service-ca cert rotation — not actual image changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reconciliation so the ClusterOperator transitions to **Syncing** when either the provisioning specification changes or the required operand container images differ from the desired set.
  * Improved error reporting when the **Syncing** status update cannot be applied, making failures clearer.
  * Added image-consistency checks across the relevant metal3 and baremetal-operator deployments to ensure **Syncing** is triggered when needed.
* **Tests**
  * Added coverage for operand image matching scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->