### PR TITLE
OCPBUGS-99220: static-ip-manager should be optional

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -1009,6 +1009,8 @@ func DeleteMetal3Deployment(info *ProvisioningInfo) error {
 // OperandImagesMatch checks whether the container images in the running
 // metal3 and BMO deployments match the desired images. Returns false when
 // images differ or deployments are absent, indicating a sync is needed.
+// metal3-static-ip-manager is optional (only when provisioning network is
+// enabled with a provisioning IP); its absence is not a mismatch.
 func OperandImagesMatch(client appsclientv1.DeploymentsGetter, targetNamespace string, images *Images) (bool, error) {
 	metal3, err := client.Deployments(targetNamespace).Get(context.Background(), baremetalDeploymentName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -1018,7 +1020,6 @@ func OperandImagesMatch(client appsclientv1.DeploymentsGetter, targetNamespace s
 		return false, err
 	}
 	foundIronic := false
-	foundStaticIP := false
 	for _, c := range metal3.Spec.Template.Spec.Containers {
 		switch c.Name {
 		case "metal3-ironic":
@@ -1027,13 +1028,12 @@ func OperandImagesMatch(client appsclientv1.DeploymentsGetter, targetNamespace s
 				return false, nil
 			}
 		case "metal3-static-ip-manager":
-			foundStaticIP = true
 			if c.Image != images.StaticIpManager {
 				return false, nil
 			}
 		}
 	}
-	if !foundIronic || !foundStaticIP {
+	if !foundIronic {
 		return false, nil
 	}
 

--- a/provisioning/baremetal_pod_test.go
+++ b/provisioning/baremetal_pod_test.go
@@ -1003,7 +1003,16 @@ func TestOperandImagesMatch(t *testing.T) {
 		BaremetalOperator: "registry.example.com/bmo:v2",
 	}
 
-	metal3Deployment := func(ironicImage, staticIPImage string) *appsv1.Deployment {
+	metal3Deployment := func(ironicImage string, staticIPImage *string) *appsv1.Deployment {
+		containers := []corev1.Container{
+			{Name: "metal3-ironic", Image: ironicImage},
+		}
+		if staticIPImage != nil {
+			containers = append(containers, corev1.Container{
+				Name:  "metal3-static-ip-manager",
+				Image: *staticIPImage,
+			})
+		}
 		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      baremetalDeploymentName,
@@ -1012,10 +1021,7 @@ func TestOperandImagesMatch(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{Name: "metal3-ironic", Image: ironicImage},
-							{Name: "metal3-static-ip-manager", Image: staticIPImage},
-						},
+						Containers: containers,
 					},
 				},
 			},
@@ -1040,6 +1046,9 @@ func TestOperandImagesMatch(t *testing.T) {
 		}
 	}
 
+	staticIP := desiredImages.StaticIpManager
+	oldStaticIP := "registry.example.com/static-ip:v1"
+
 	tCases := []struct {
 		name     string
 		objects  []*appsv1.Deployment
@@ -1053,7 +1062,18 @@ func TestOperandImagesMatch(t *testing.T) {
 		{
 			name: "all images match",
 			objects: []*appsv1.Deployment{
-				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				metal3Deployment(desiredImages.Ironic, &staticIP),
+				bmoDeployment(desiredImages.BaremetalOperator),
+			},
+			expected: true,
+		},
+		{
+			// Matches newMetal3Containers when ProvisioningNetwork is Disabled
+			// (vmedia): metal3-static-ip-manager is omitted and must not force
+			// OperandImagesMatch to return false.
+			name: "static-ip-manager is optional when absent",
+			objects: []*appsv1.Deployment{
+				metal3Deployment(desiredImages.Ironic, nil),
 				bmoDeployment(desiredImages.BaremetalOperator),
 			},
 			expected: true,
@@ -1061,15 +1081,15 @@ func TestOperandImagesMatch(t *testing.T) {
 		{
 			name: "ironic image differs",
 			objects: []*appsv1.Deployment{
-				metal3Deployment("registry.example.com/ironic:v1", desiredImages.StaticIpManager),
+				metal3Deployment("registry.example.com/ironic:v1", &staticIP),
 				bmoDeployment(desiredImages.BaremetalOperator),
 			},
 			expected: false,
 		},
 		{
-			name: "static-ip-manager image differs",
+			name: "static-ip-manager image differs when present",
 			objects: []*appsv1.Deployment{
-				metal3Deployment(desiredImages.Ironic, "registry.example.com/static-ip:v1"),
+				metal3Deployment(desiredImages.Ironic, &oldStaticIP),
 				bmoDeployment(desiredImages.BaremetalOperator),
 			},
 			expected: false,
@@ -1077,7 +1097,7 @@ func TestOperandImagesMatch(t *testing.T) {
 		{
 			name: "bmo image differs",
 			objects: []*appsv1.Deployment{
-				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				metal3Deployment(desiredImages.Ironic, &staticIP),
 				bmoDeployment("registry.example.com/bmo:v1"),
 			},
 			expected: false,
@@ -1085,7 +1105,7 @@ func TestOperandImagesMatch(t *testing.T) {
 		{
 			name: "only metal3 exists and matches",
 			objects: []*appsv1.Deployment{
-				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				metal3Deployment(desiredImages.Ironic, &staticIP),
 			},
 			expected: false,
 		},
@@ -1097,7 +1117,7 @@ func TestOperandImagesMatch(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "metal3 missing required container",
+			name: "metal3 missing ironic container",
 			objects: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1108,7 +1128,7 @@ func TestOperandImagesMatch(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
-									{Name: "metal3-ironic", Image: desiredImages.Ironic},
+									{Name: "metal3-static-ip-manager", Image: desiredImages.StaticIpManager},
 								},
 							},
 						},
@@ -1121,7 +1141,7 @@ func TestOperandImagesMatch(t *testing.T) {
 		{
 			name: "bmo missing required container",
 			objects: []*appsv1.Deployment{
-				metal3Deployment(desiredImages.Ironic, desiredImages.StaticIpManager),
+				metal3Deployment(desiredImages.Ironic, &staticIP),
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      bmoDeploymentName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provisioning validation now allows the Static IP Manager container to be absent when it is not required.
  * Image matching continues to require the Ironic container and verifies the Static IP Manager image when that container is present.
* **Tests**
  * Updated coverage for deployments with and without the optional Static IP Manager container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->