### PR TITLE
OCPBUGS-99278: Apply cluster TLS profile to ironic-proxy container

### DIFF
--- a/provisioning/ironic_proxy.go
+++ b/provisioning/ironic_proxy.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 
@@ -31,7 +32,7 @@ const (
 	ironicProxyPortEnvVar    = "IRONIC_PROXY_PORT"
 )
 
-func createContainerIronicProxy(ironicIP string, images *Images) corev1.Container {
+func createContainerIronicProxy(ironicIP string, images *Images, tlsProfileSpec *configv1.TLSProfileSpec) corev1.Container {
 	container := corev1.Container{
 		Name:            "ironic-proxy",
 		Image:           images.Ironic,
@@ -87,6 +88,11 @@ func createContainerIronicProxy(ironicIP string, images *Images) corev1.Containe
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
+
+	if tlsProfileSpec != nil {
+		container.Env = append(container.Env, tlsProfileToApacheEnvVars(*tlsProfileSpec)...)
+	}
+
 	return container
 }
 
@@ -98,7 +104,7 @@ func newIronicProxyPodTemplateSpec(info *ProvisioningInfo) (*corev1.PodTemplateS
 
 	containers := []corev1.Container{
 		// Even in a dual-stack environment, we don't really care which IP address to use since both are accessible internally.
-		createContainerIronicProxy(ironicIPs[0], info.Images),
+		createContainerIronicProxy(ironicIPs[0], info.Images, info.TLSProfileSpec),
 	}
 
 	tolerations := []corev1.Toleration{


### PR DESCRIPTION
The ironic-proxy container was missed when centralized TLS profile support was added. It terminates TLS via Apache but was not receiving the cluster TLS profile env vars (IRONIC_SSL_PROTOCOL, ciphers), falling back to ironic-image defaults instead of honoring the cluster-wide TLS security profile.

Pass TLSProfileSpec to createContainerIronicProxy() and inject the same tlsProfileToApacheEnvVars() env vars that metal3-httpd and metal3-ironic already receive.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying optional TLS profiles to the Ironic proxy.
  * When a TLS profile is provided, TLS- and Apache-related settings are automatically injected into the Ironic proxy container configuration, enabling secure connectivity without additional manual setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->