### PR TITLE
OCPBUGS-86888: Mount IDMS mirror config into machine-os-images init container

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - imagedigestmirrorsets
   - infrastructures
   - networks
   - proxies

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -103,6 +103,7 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:namespace=openshift-machine-api,groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=create;watch;get;list;patch;delete;update
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch
@@ -336,6 +337,7 @@ func (r *ProvisioningReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	for _, ensureResource := range []ensureFunc{
 		provisioning.EnsureAllSecrets,
+		provisioning.EnsureMirrorConfig,
 		provisioning.EnsureMetal3Deployment,
 		provisioning.EnsureBaremetalOperatorDeployment,
 		provisioning.EnsureMetal3StateService,
@@ -753,6 +755,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&osconfigv1.ClusterOperator{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.Proxy{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.APIServer{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
+		Watches(&osconfigv1.ImageDigestMirrorSet{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton), builder.WithPredicates(pullSecretFilter)).
 		Complete(r)
 }

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -138,6 +138,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - imagedigestmirrorsets
   - infrastructures
   - networks
   - proxies

--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -167,6 +167,7 @@ var metal3Volumes = []corev1.Volume{
 	imageVolume(),
 	ironicAgentPullSecretVolume(),
 	caTrustDirVolume(),
+	mirrorConfigVolume(),
 	{
 		Name: ironicCredentialsVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -811,9 +812,17 @@ func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string)
 		nodeSelector = map[string]string{"node-role.kubernetes.io/master": ""}
 	}
 
+	annotations := make(map[string]string, len(podTemplateAnnotations)+1)
+	for k, v := range podTemplateAnnotations {
+		annotations[k] = v
+	}
+	if info.MirrorConfigHash != "" {
+		annotations[mirrorConfigHashAnnotation] = info.MirrorConfigHash
+	}
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: podTemplateAnnotations,
+			Annotations: annotations,
 			Labels:      *labels,
 		},
 		Spec: corev1.PodSpec{

--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -279,9 +279,17 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 		nodeSelector = map[string]string{"node-role.kubernetes.io/master": ""}
 	}
 
+	annotations := make(map[string]string, len(podTemplateAnnotations)+1)
+	for k, v := range podTemplateAnnotations {
+		annotations[k] = v
+	}
+	if info.MirrorConfigHash != "" {
+		annotations[mirrorConfigHashAnnotation] = info.MirrorConfigHash
+	}
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: podTemplateAnnotations,
+			Annotations: annotations,
 			Labels:      *labels,
 		},
 		Spec: corev1.PodSpec{
@@ -298,6 +306,7 @@ func newImageCustomizationPodTemplateSpec(info *ProvisioningInfo, labels *map[st
 				imageVolume(),
 				ironicAgentPullSecretVolume(),
 				caTrustDirVolume(),
+				mirrorConfigVolume(),
 			},
 		},
 	}

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -20,6 +20,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			dest,
 			ironicAgentPullSecretMount,
 			caTrustDirVolumeMount,
+			mirrorConfigVolumeMount,
 		},
 		ImagePullPolicy: "IfNotPresent",
 		Env: []corev1.EnvVar{

--- a/provisioning/mirror_config.go
+++ b/provisioning/mirror_config.go
@@ -1,0 +1,94 @@
+package provisioning
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+)
+
+const mirrorConfigHashAnnotation = "machine-os-images-mirror-config/hash"
+
+const mirrorConfigName = "machine-os-images-mirror-config"
+
+var mirrorConfigVolumeMount = corev1.VolumeMount{
+	Name:      mirrorConfigName,
+	MountPath: "/etc/image-mirrors",
+	ReadOnly:  true,
+}
+
+func mirrorConfigVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: mirrorConfigName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: mirrorConfigName},
+				Items:                []corev1.KeyToPath{{Key: "idms.yaml", Path: "idms.yaml"}},
+				Optional:             ptr.To(true),
+			},
+		},
+	}
+}
+
+// EnsureMirrorConfig lists all cluster ImageDigestMirrorSet resources,
+// serializes them into a ConfigMap, and applies it so that the
+// machine-os-images init container can pass --idms-file to oc image extract
+// in disconnected environments.
+func EnsureMirrorConfig(info *ProvisioningInfo) (bool, error) {
+	ctx := context.Background()
+
+	idmsList, err := info.OSClient.ConfigV1().ImageDigestMirrorSets().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list ImageDigestMirrorSets: %w", err)
+	}
+
+	if len(idmsList.Items) == 0 {
+		info.MirrorConfigHash = ""
+		err := client.IgnoreNotFound(
+			info.Client.CoreV1().ConfigMaps(info.Namespace).Delete(ctx, mirrorConfigName, metav1.DeleteOptions{}),
+		)
+		if err != nil {
+			return false, fmt.Errorf("failed to delete mirror config ConfigMap: %w", err)
+		}
+		return false, nil
+	}
+
+	idmsYAML, err := yaml.Marshal(idmsList)
+	if err != nil {
+		return false, fmt.Errorf("failed to serialize ImageDigestMirrorSets: %w", err)
+	}
+
+	info.MirrorConfigHash = fmt.Sprintf("%x", sha256.Sum256(idmsYAML))
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mirrorConfigName,
+			Namespace: info.Namespace,
+			Labels: map[string]string{
+				"k8s-app":    metal3AppName,
+				cboLabelName: imageCustomizationService,
+			},
+		},
+		Data: map[string]string{
+			"idms.yaml": string(idmsYAML),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(info.ProvConfig, configMap, info.Scheme); err != nil {
+		return false, fmt.Errorf("unable to set controllerReference on mirror config ConfigMap: %w", err)
+	}
+
+	_, updated, err := resourceapply.ApplyConfigMap(ctx, info.Client.CoreV1(), info.EventRecorder, configMap)
+	if err != nil {
+		return false, fmt.Errorf("failed to apply mirror config ConfigMap: %w", err)
+	}
+	return updated, nil
+}

--- a/provisioning/mirror_config_test.go
+++ b/provisioning/mirror_config_test.go
@@ -1,0 +1,125 @@
+package provisioning
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/clock"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+var mirrorTestScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		os.Exit(1)
+	}
+	if err := metal3iov1alpha1.AddToScheme(s); err != nil {
+		os.Exit(1)
+	}
+	return s
+}()
+
+func newTestProvisioningInfo(idmsSets ...osconfigv1.ImageDigestMirrorSet) *ProvisioningInfo {
+	objects := make([]runtime.Object, 0, len(idmsSets))
+	for i := range idmsSets {
+		objects = append(objects, &idmsSets[i])
+	}
+	return &ProvisioningInfo{
+		Client:        fakekube.NewSimpleClientset(),
+		EventRecorder: events.NewLoggingEventRecorder("test", clock.RealClock{}),
+		OSClient:      fakeconfigclientset.NewSimpleClientset(objects...),
+		Namespace:     "openshift-machine-api",
+		Scheme:        mirrorTestScheme,
+		ProvConfig: &metal3iov1alpha1.Provisioning{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Provisioning",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		},
+	}
+}
+
+func TestEnsureMirrorConfigNoIDMS(t *testing.T) {
+	info := newTestProvisioningInfo()
+
+	updated, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.False(t, updated)
+	assert.Empty(t, info.MirrorConfigHash, "hash should be empty when no IDMS resources exist")
+
+	cms, err := info.Client.CoreV1().ConfigMaps(info.Namespace).List(
+		t.Context(), metav1.ListOptions{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, cms.Items, "no ConfigMap should exist when there are no IDMS resources")
+}
+
+func TestEnsureMirrorConfigWithIDMS(t *testing.T) {
+	idms := osconfigv1.ImageDigestMirrorSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mirror",
+		},
+		Spec: osconfigv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+				{
+					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+					Mirrors: []osconfigv1.ImageMirror{"mirror.local/openshift/release"},
+				},
+			},
+		},
+	}
+	info := newTestProvisioningInfo(idms)
+
+	updated, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.True(t, updated)
+
+	cm, err := info.Client.CoreV1().ConfigMaps(info.Namespace).Get(
+		t.Context(), mirrorConfigName, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	yamlData, ok := cm.Data["idms.yaml"]
+	assert.True(t, ok, "ConfigMap should contain idms.yaml key")
+	assert.Contains(t, yamlData, "quay.io/openshift-release-dev/ocp-v4.0-art-dev")
+	assert.Contains(t, yamlData, "mirror.local/openshift/release")
+	assert.NotEmpty(t, info.MirrorConfigHash, "hash should be set when IDMS resources exist")
+	assert.Len(t, info.MirrorConfigHash, 64, "hash should be a SHA-256 hex string")
+}
+
+func TestEnsureMirrorConfigIdempotent(t *testing.T) {
+	idms := osconfigv1.ImageDigestMirrorSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mirror",
+		},
+		Spec: osconfigv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+				{
+					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+					Mirrors: []osconfigv1.ImageMirror{"mirror.local/openshift/release"},
+				},
+			},
+		},
+	}
+	info := newTestProvisioningInfo(idms)
+
+	_, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+
+	updated, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.False(t, updated, "second call should be a no-op")
+}

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -53,4 +53,5 @@ type ProvisioningInfo struct {
 	OSClient                osclientset.Interface
 	ResourceCache           resourceapply.ResourceCache
 	IsHyperShift            bool
+	MirrorConfigHash        string
 }


### PR DESCRIPTION
List cluster ImageDigestMirrorSet resources at reconcile time,
serialize them into a ConfigMap, and mount it as
/etc/image-mirrors/idms.yaml in the machine-os-images init container.
This allows oc image extract in disconnected environments to resolve
image references through local mirror registries via --idms-file.

A SHA-256 hash of the serialized IDMS data is added as a pod template
annotation so that mirror configuration changes trigger a rollout,
rerunning the init container with the updated config.

The ConfigMap is optional so connected clusters are unaffected.
A watch on ImageDigestMirrorSet triggers reconciliation when mirror
configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image mirror provisioning by mounting mirror configuration into bare metal and image customization pods (including init containers).
  * Ensured mirror configuration changes propagate reliably through annotation updates and watch-driven reconciliation.

* **New Features**
  * Added automated syncing of image digest mirror sets into a ConfigMap, including computing and storing a mirror configuration hash.
  * Updated reconciliation to react when mirror configuration objects change.

* **Tests**
  * Added coverage for create/update, deletion when none exist, and idempotency of the syncing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->