### PR TITLE
OCPQE-32094: Address review feedback from PR #622

### DIFF
--- a/tests-extension/openshift/test/e2e/host_firmware.go
+++ b/tests-extension/openshift/test/e2e/host_firmware.go
@@ -292,6 +292,21 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(statusModified).Should(o.Equal(specModified))
 
+		compat_otp.By("Verify HFS ChangeDetected condition is False after update")
+		hfsResetErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+			if err != nil {
+				return false, err
+			}
+			if cond == "False" {
+				e2e.Logf("HFS ChangeDetected condition is False")
+				return true, nil
+			}
+			e2e.Logf("HFS ChangeDetected condition: %s, waiting for False...", cond)
+			return false, nil
+		})
+		o.Expect(hfsResetErr).NotTo(o.HaveOccurred(), "HFS ChangeDetected condition did not return to False after update")
+
 		compat_otp.By("Verify BMH operationalStatus is OK and no error")
 		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -437,6 +452,21 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("annotated"))
 
+		compat_otp.By("Verify BMH operationalStatus transitions to servicing")
+		servicingErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
+			if err != nil {
+				return false, err
+			}
+			if opStatus == "servicing" {
+				e2e.Logf("BMH operationalStatus is now 'servicing'")
+				return true, nil
+			}
+			e2e.Logf("BMH operationalStatus: %s, waiting for 'servicing'...", opStatus)
+			return false, nil
+		})
+		o.Expect(servicingErr).NotTo(o.HaveOccurred(), "BMH did not transition to servicing state")
+
 		g.By("Waiting for the node to transition to NotReady state after reboot")
 		err = wait.Poll(5*time.Second, 180*time.Second, func() (bool, error) {
 			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
@@ -482,6 +512,21 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(pollErr).NotTo(o.HaveOccurred(), "Polling for firmware version update failed")
 		o.Expect(currentVersion).NotTo(o.BeEmpty(), "Firmware version must not be empty after update")
 		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
+
+		compat_otp.By("Verify HFC ChangeDetected condition is False after update")
+		hfcResetErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+			if err != nil {
+				return false, err
+			}
+			if cond == "False" {
+				e2e.Logf("HFC ChangeDetected condition is False")
+				return true, nil
+			}
+			e2e.Logf("HFC ChangeDetected condition: %s, waiting for False...", cond)
+			return false, nil
+		})
+		o.Expect(hfcResetErr).NotTo(o.HaveOccurred(), "HFC ChangeDetected condition did not return to False after update")
 
 		compat_otp.By("Verify BMH operationalStatus is OK and no error")
 		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()

--- a/tests-extension/openshift/test/e2e/host_firmware.go
+++ b/tests-extension/openshift/test/e2e/host_firmware.go
@@ -293,19 +293,9 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(statusModified).Should(o.Equal(specModified))
 
 		compat_otp.By("Verify HFS ChangeDetected condition is False after update")
-		hfsResetErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
-			if err != nil {
-				return false, err
-			}
-			if cond == "False" {
-				e2e.Logf("HFS ChangeDetected condition is False")
-				return true, nil
-			}
-			e2e.Logf("HFS ChangeDetected condition: %s, waiting for False...", cond)
-			return false, nil
-		})
-		o.Expect(hfsResetErr).NotTo(o.HaveOccurred(), "HFS ChangeDetected condition did not return to False after update")
+		hfsCond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hfsCond).Should(o.Equal("False"), "HFS ChangeDetected condition should be False after update")
 
 		compat_otp.By("Verify BMH operationalStatus is OK and no error")
 		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()
@@ -514,19 +504,9 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(currentVersion).ShouldNot(o.Equal(initialVersion))
 
 		compat_otp.By("Verify HFC ChangeDetected condition is False after update")
-		hfcResetErr := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-			cond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
-			if err != nil {
-				return false, err
-			}
-			if cond == "False" {
-				e2e.Logf("HFC ChangeDetected condition is False")
-				return true, nil
-			}
-			e2e.Logf("HFC ChangeDetected condition: %s, waiting for False...", cond)
-			return false, nil
-		})
-		o.Expect(hfcResetErr).NotTo(o.HaveOccurred(), "HFC ChangeDetected condition did not return to False after update")
+		hfcCond, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, `-o=jsonpath={.status.conditions[?(@.type=="ChangeDetected")].status}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hfcCond).Should(o.Equal("False"), "HFC ChangeDetected condition should be False after update")
 
 		compat_otp.By("Verify BMH operationalStatus is OK and no error")
 		opStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("bmh", "-n", machineAPINamespace, host, "-o=jsonpath={.status.operationalStatus}").Output()

--- a/tests-extension/openshift/test/e2e/metal3_utils.go
+++ b/tests-extension/openshift/test/e2e/metal3_utils.go
@@ -115,7 +115,7 @@ func buildFirmwareURL(vendor, currentVersion string) (string, string) {
 		case "7.10.30.00":
 			url = iDRAC_71070
 		default:
-			url = iDRAC_71070 // Default to 7.10.70.00
+			e2e.Failf("Unsupported Dell iDRAC version: %s", currentVersion)
 		}
 	case "HPE":
 		// Extract the iLO version and assign the file name accordingly
@@ -128,8 +128,7 @@ func buildFirmwareURL(vendor, currentVersion string) (string, string) {
 				url = ilo5_305
 				fileName = "ilo5_305.bin"
 			default:
-				url = ilo5_305 // Default to v3.05
-				fileName = "ilo5_305.bin"
+				e2e.Failf("Unsupported iLO 5 version: %s", currentVersion)
 			}
 		} else if strings.Contains(currentVersion, "iLO 6") {
 			switch currentVersion {
@@ -140,8 +139,7 @@ func buildFirmwareURL(vendor, currentVersion string) (string, string) {
 				url = ilo6_157
 				fileName = "ilo6_157.bin"
 			default:
-				url = ilo6_157 // Default to 1.57
-				fileName = "ilo6_157.bin"
+				e2e.Failf("Unsupported iLO 6 version: %s", currentVersion)
 			}
 		} else {
 			e2e.Failf("Unsupported HPE BMC version: %s", currentVersion)
@@ -220,7 +218,8 @@ func getNicFwDetails(vendor, currentVersion string) (string, string) {
 		case "22.6.250":
 			return bcm_226_226, "bcm5751x-v22.6.226-esxi.zip"
 		default:
-			return bcm_226_250, "bcm5751x-v22.6.250-esxi.zip" // Default to latest
+			e2e.Failf("Unsupported Broadcom NIC firmware version: %s", currentVersion)
+			return "", ""
 		}
 	case "Mellanox Technologies":
 		switch currentVersion {
@@ -229,7 +228,8 @@ func getNicFwDetails(vendor, currentVersion string) (string, string) {
 		case "28.39.1014":
 			return mlx_28_40_1000, "fw-ConnectX7-rel-28_40_1000.bin"
 		default:
-			return mlx_28_40_1000, "fw-ConnectX7-rel-28_40_1000.bin" // Default to latest
+			e2e.Failf("Unsupported Mellanox NIC firmware version: %s", currentVersion)
+			return "", ""
 		}
 	default:
 		e2e.Failf("Unsupported NIC vendor: %s", vendor)

--- a/tests-extension/openshift/test/e2e/metal3_utils.go
+++ b/tests-extension/openshift/test/e2e/metal3_utils.go
@@ -25,7 +25,7 @@ func skipIfNotBaremetal(oc *exutil.CLI) {
 	}
 }
 
-func getWorkerBMH(oc *exutil.CLI) (string, string) {
+func getWorkerBMH(oc *exutil.CLI) (host string, machineName string) {
 	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 		"machines.machine.openshift.io", "-n", machineAPINamespace,
 		"-l", "machine.openshift.io/cluster-api-machine-role=worker",
@@ -36,7 +36,7 @@ func getWorkerBMH(oc *exutil.CLI) (string, string) {
 	if len(workerMachines) == 0 || workerMachines[0] == "" {
 		g.Skip("No worker machines found")
 	}
-	machineName := workerMachines[len(workerMachines)-1]
+	machineName = workerMachines[len(workerMachines)-1]
 
 	bmhOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 		"bmh", "-n", machineAPINamespace,
@@ -44,7 +44,6 @@ func getWorkerBMH(oc *exutil.CLI) (string, string) {
 	).Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	var host string
 	for _, line := range strings.Split(strings.TrimSpace(bmhOutput), "\n") {
 		parts := strings.SplitN(line, ",", 2)
 		if len(parts) == 2 && parts[1] == machineName {
@@ -53,7 +52,7 @@ func getWorkerBMH(oc *exutil.CLI) (string, string) {
 		}
 	}
 	if host == "" {
-		g.Skip(fmt.Sprintf("No BMH found for worker machine %s", machineName))
+		e2e.Failf("No BMH found for worker machine %s", machineName)
 	}
 	return host, machineName
 }
@@ -145,10 +144,10 @@ func buildFirmwareURL(vendor, currentVersion string) (string, string) {
 				fileName = "ilo6_157.bin"
 			}
 		} else {
-			g.Skip("Unsupported HPE BMC version")
+			e2e.Failf("Unsupported HPE BMC version: %s", currentVersion)
 		}
 	default:
-		g.Skip("Unsupported vendor")
+		e2e.Failf("Unsupported vendor: %s", vendor)
 	}
 
 	return url, fileName
@@ -169,8 +168,7 @@ func getHfsToggleValue(oc *exutil.CLI, vendor, machineAPINamespace, host string)
 	case "HPE":
 		settingName = "NetworkBootRetry"
 	default:
-		g.Skip("Unsupported vendor")
-		return "", "", nil
+		e2e.Failf("Unsupported vendor: %s", vendor)
 	}
 
 	currentValue, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("hfs", "-n", machineAPINamespace, host, fmt.Sprintf("-o=jsonpath={.status.settings.%s}", settingName)).Output()
@@ -234,7 +232,7 @@ func getNicFwDetails(vendor, currentVersion string) (string, string) {
 			return mlx_28_40_1000, "fw-ConnectX7-rel-28_40_1000.bin" // Default to latest
 		}
 	default:
-		g.Skip("Unsupported NIC vendor: " + vendor)
+		e2e.Failf("Unsupported NIC vendor: %s", vendor)
 		return "", ""
 	}
 }
@@ -246,7 +244,7 @@ func getNicNameByVendor(vendor string) string {
 	case "Mellanox Technologies":
 		return "ConnectX-7"
 	default:
-		g.Skip("Unsupported NIC vendor for name lookup: " + vendor)
+		e2e.Failf("Unsupported NIC vendor for name lookup: %s", vendor)
 		return ""
 	}
 }


### PR DESCRIPTION
- Use named return args for getWorkerBMH (host, machineName)
- Replace g.Skip with e2e.Failf for unsupported vendor/BMC failures on baremetal hardware (buildFirmwareURL, getHfsToggleValue, getNicFwDetails, getNicNameByVendor, getWorkerBMH)
- Rename host_fw_components.go to host_firmware.go since the file contains both HFS and HFC tests
- Add servicing operationalStatus check to HFC test 78361
- Add ChangeDetected=False verification after firmware updates for both HFS test 77676 and HFC test 78361

[OCPQE-32094](https://redhat.atlassian.net/browse/OCPQE-32094)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update validation by waiting for status conditions and host servicing transitions before confirming results.
  * Firmware-related end-to-end tests now more reliably verify condition resets and host operational states.
  * Unsupported hardware configurations and missing worker hosts now produce clear test failures instead of being skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->