### PR TITLE
OCPBUGS-54957: Remove recreate strategy from BMO deployment

### DIFF
--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -283,9 +283,6 @@ func newBMODeployment(info *ProvisioningInfo) (*appsv1.Deployment, error) {
 			Replicas: ptr.To[int32](1),
 			Selector: selector,
 			Template: *template,
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
-			},
 		},
 	}, nil
 }


### PR DESCRIPTION
baremetal-operator runs with leader election enabled so we don't need the recreate strategy to ensure that only one copy of the deployment is running

The recreate strategy causes problems when the node on which the
deployment runs dies.   The cluster wrongly scales the deployment down
to zero.  This change fixes that problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment rollouts now use the platform’s default strategy instead of forcing full recreation.
  * Updates can be applied more smoothly, helping reduce unnecessary disruption during deployment changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->