### PR TITLE
OCPBUGS-105455: Fix infinite reconciliation loop in EnsureMirrorConfig

### DIFF
--- a/provisioning/mirror_config.go
+++ b/provisioning/mirror_config.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 
+	osconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 )
 
@@ -61,6 +62,8 @@ func EnsureMirrorConfig(info *ProvisioningInfo) (bool, error) {
 		return false, nil
 	}
 
+	stripVolatileMetadata(idmsList)
+
 	idmsYAML, err := yaml.Marshal(idmsList)
 	if err != nil {
 		return false, fmt.Errorf("failed to serialize ImageDigestMirrorSets: %w", err)
@@ -91,4 +94,20 @@ func EnsureMirrorConfig(info *ProvisioningInfo) (bool, error) {
 		return false, fmt.Errorf("failed to apply mirror config ConfigMap: %w", err)
 	}
 	return updated, nil
+}
+
+// stripVolatileMetadata removes server-set metadata fields (resourceVersion,
+// uid, generation, creationTimestamp, managedFields) from every item in the
+// list so that the serialized YAML is stable across API reads. Without this,
+// resourceVersion changes on every ConfigMap write and causes an infinite
+// reconciliation loop.
+func stripVolatileMetadata(list *osconfigv1.ImageDigestMirrorSetList) {
+	list.ResourceVersion = ""
+	for i := range list.Items {
+		list.Items[i].ResourceVersion = ""
+		list.Items[i].UID = ""
+		list.Items[i].Generation = 0
+		list.Items[i].CreationTimestamp = metav1.Time{}
+		list.Items[i].ManagedFields = nil
+	}
 }

--- a/provisioning/mirror_config_test.go
+++ b/provisioning/mirror_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/clock"
@@ -122,4 +123,72 @@ func TestEnsureMirrorConfigIdempotent(t *testing.T) {
 	updated, err := EnsureMirrorConfig(info)
 	require.NoError(t, err)
 	assert.False(t, updated, "second call should be a no-op")
+}
+
+func TestStripVolatileMetadata(t *testing.T) {
+	ts := metav1.Now()
+	list := &osconfigv1.ImageDigestMirrorSetList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "99999",
+		},
+		Items: []osconfigv1.ImageDigestMirrorSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "mirror-a",
+					ResourceVersion:   "12345",
+					UID:               types.UID("abc-def"),
+					Generation:        3,
+					CreationTimestamp: ts,
+					ManagedFields:     []metav1.ManagedFieldsEntry{{Manager: "test"}},
+				},
+				Spec: osconfigv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+						{Source: "quay.io/example"},
+					},
+				},
+			},
+		},
+	}
+
+	stripVolatileMetadata(list)
+
+	assert.Empty(t, list.ResourceVersion)
+	item := list.Items[0]
+	assert.Equal(t, "mirror-a", item.Name, "name must be preserved")
+	assert.Empty(t, item.ResourceVersion)
+	assert.Empty(t, string(item.UID))
+	assert.Zero(t, item.Generation)
+	assert.True(t, item.CreationTimestamp.IsZero())
+	assert.Nil(t, item.ManagedFields)
+	assert.Len(t, item.Spec.ImageDigestMirrors, 1, "spec must be preserved")
+}
+
+func TestEnsureMirrorConfigStableWithVolatileMetadata(t *testing.T) {
+	idms := osconfigv1.ImageDigestMirrorSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-mirror",
+			ResourceVersion: "100",
+			UID:             types.UID("uid-1"),
+			Generation:      1,
+		},
+		Spec: osconfigv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+				{
+					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+					Mirrors: []osconfigv1.ImageMirror{"mirror.local/openshift/release"},
+				},
+			},
+		},
+	}
+	info := newTestProvisioningInfo(idms)
+
+	updated, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.True(t, updated, "first call should create the ConfigMap")
+	firstHash := info.MirrorConfigHash
+
+	updated, err = EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.False(t, updated, "second call must be a no-op despite server-set metadata")
+	assert.Equal(t, firstHash, info.MirrorConfigHash, "hash must be stable across calls")
 }


### PR DESCRIPTION
The IDMS list returned by the API includes server-set metadata (resourceVersion, uid, generation, etc.) that changes on every read. Serializing these fields into the ConfigMap caused ApplyConfigMap to detect a diff on every reconciliation, returning updated=true and preventing the controller from ever progressing past the ConfigMap step to deploy metal3/BMO.

Strip volatile metadata before marshaling so the serialized YAML is stable across API reads. This fixes HA clusters with workers getting stuck with machine-api unavailable because BMO was never deployed.

Assisted-By: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized mirror configuration processing by ignoring server-generated metadata when saving and comparing configurations.
  * Prevented unnecessary configuration changes caused by volatile resource metadata.
  * Ensured repeated mirror configuration operations produce consistent results and stable hashes.
* **Tests**
  * Added coverage confirming that required names and specifications remain intact while transient metadata is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->