### PR TITLE
OCPBUGS-105610: drop IRONIC_INSECURE from BMO

### DIFF
--- a/provisioning/baremetal_pod.go
+++ b/provisioning/baremetal_pod.go
@@ -71,6 +71,7 @@ const (
 	bmcCACertMountPath               = "/certs/ca/bmc"
 	bmcCACertConfigMapName           = "bmc-verify-ca"
 	bmcCACertVolume                  = "bmc-verify-ca"
+	ironicTlsCertHashAnnotation      = "baremetal.openshift.io/ironic-tls-cert-hash"
 )
 
 var podTemplateAnnotations = map[string]string{
@@ -818,6 +819,9 @@ func newMetal3PodTemplateSpec(info *ProvisioningInfo, labels *map[string]string)
 	}
 	if info.MirrorConfigHash != "" {
 		annotations[mirrorConfigHashAnnotation] = info.MirrorConfigHash
+	}
+	if info.TlsCertHash != "" {
+		annotations[ironicTlsCertHashAnnotation] = info.TlsCertHash
 	}
 
 	return &corev1.PodTemplateSpec{

--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -156,9 +157,11 @@ func EnsureAllSecrets(info *ProvisioningInfo) (bool, error) {
 		return false, errors.Wrap(err, "failed to create Ironic password")
 	}
 	// Generate/update TLS certificate
-	if err := createOrUpdateTlsSecret(info); err != nil {
+	certBytes, err := createOrUpdateTlsSecret(info)
+	if err != nil {
 		return false, errors.Wrap(err, "failed to create TLS certificate")
 	}
+	info.TlsCertHash = fmt.Sprintf("%x", sha256.Sum256(certBytes))
 	// Create a Secret for the Registry Pull Secret
 	if _, err := createRegistryPullSecret(info); err != nil {
 		return false, errors.Wrap(err, "failed to create Registry pull secret")
@@ -247,16 +250,17 @@ func buildTlsHosts(info *ProvisioningInfo) (sets.Set[string], error) {
 }
 
 // createOrUpdateTlsSecret creates a Secret for the Ironic TLS.
-// It updates the secret if the existing certificate is close to expiration.
-func createOrUpdateTlsSecret(info *ProvisioningInfo) error {
+// It updates the secret if the existing certificate is close to expiration or has stale SANs.
+// It returns the certificate bytes that are active in the cluster after the call.
+func createOrUpdateTlsSecret(info *ProvisioningInfo) ([]byte, error) {
 	hosts, err := buildTlsHosts(info)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cert, err := generateTlsCertificate(hosts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	secret := &corev1.Secret{
@@ -275,10 +279,14 @@ func createOrUpdateTlsSecret(info *ProvisioningInfo) error {
 	}
 
 	if err := controllerutil.SetControllerReference(info.ProvConfig, secret, info.Scheme); err != nil {
-		return err
+		return nil, err
 	}
 
-	return applySecret(info.Client.CoreV1(), info.EventRecorder, secret, func(existing *corev1.Secret) (bool, error) {
+	// existingCert captures the cert bytes from an existing, still-valid secret so
+	// we can return the cert that is actually active in the cluster (not the freshly
+	// generated one that was discarded).
+	var existingCert []byte
+	err = applySecret(info.Client.CoreV1(), info.EventRecorder, secret, func(existing *corev1.Secret) (bool, error) {
 		expired, err := isTlsCertificateExpired(existing.Data[corev1.TLSCertKey])
 		if err != nil {
 			return false, err
@@ -291,6 +299,17 @@ func createOrUpdateTlsSecret(info *ProvisioningInfo) error {
 		if err != nil {
 			return false, err
 		}
+		if sansMatch {
+			existingCert = existing.Data[corev1.TLSCertKey]
+		}
 		return !sansMatch, nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	if existingCert != nil {
+		return existingCert, nil
+	}
+	return cert.certificate, nil
 }

--- a/provisioning/baremetal_secrets_test.go
+++ b/provisioning/baremetal_secrets_test.go
@@ -169,7 +169,7 @@ func TestCreateAndUpdateTlsSecret(t *testing.T) {
 				EventRecorder: events.NewLoggingEventRecorder("tests", clock.RealClock{}),
 			}
 
-			err := createOrUpdateTlsSecret(info)
+			_, err := createOrUpdateTlsSecret(info)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -194,7 +194,7 @@ func TestCreateAndUpdateTlsSecret(t *testing.T) {
 				original = []byte(expiredTlsCertificate)
 			}
 
-			err = createOrUpdateTlsSecret(info)
+			_, err = createOrUpdateTlsSecret(info)
 			if err != nil {
 				t.Errorf("unexpected error when re-creating: %v", err)
 				return

--- a/provisioning/bmo_pod.go
+++ b/provisioning/bmo_pod.go
@@ -140,10 +140,6 @@ func createContainerBaremetalOperator(info *ProvisioningInfo) (corev1.Container,
 				Name:  ironicCertEnvVar,
 				Value: metal3TlsRootDir + "/ironic/" + corev1.TLSCertKey,
 			},
-			{
-				Name:  ironicInsecureEnvVar,
-				Value: "true",
-			},
 			buildEnvVar(deployKernelUrl, &info.ProvConfig.Spec),
 			{
 				Name:  ironicEndpoint,
@@ -225,6 +221,9 @@ func newBMOPodTemplateSpec(info *ProvisioningInfo, labels *map[string]string) (*
 	}
 
 	podAnnotations["openshift.io/required-scc"] = "hostnetwork-v2"
+	if info.TlsCertHash != "" {
+		podAnnotations[ironicTlsCertHashAnnotation] = info.TlsCertHash
+	}
 
 	nodeSelector := map[string]string{}
 	if !info.IsHyperShift {

--- a/provisioning/bmo_pod_test.go
+++ b/provisioning/bmo_pod_test.go
@@ -39,7 +39,6 @@ func TestNewBMOContainers(t *testing.T) {
 				envWithFieldValue("POD_NAME", "metadata.name"),
 				{Name: "OPERATOR_NAME", Value: "baremetal-operator"},
 				{Name: "IRONIC_CACERT_FILE", Value: "/certs/ironic/tls.crt"},
-				{Name: "IRONIC_INSECURE", Value: "true"},
 				{Name: "DEPLOY_KERNEL_URL", Value: "file:///shared/html/images/ironic-python-agent.kernel"},
 				{Name: "IRONIC_ENDPOINT", Value: "https://metal3-state.openshift-machine-api.svc.cluster.local:6385/v1/"},
 				{Name: "LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE", Value: "Never"},

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -54,4 +54,5 @@ type ProvisioningInfo struct {
 	ResourceCache           resourceapply.ResourceCache
 	IsHyperShift            bool
 	MirrorConfigHash        string
+	TlsCertHash             string
 }


### PR DESCRIPTION
It's no longer actually needed, having TLS validation is useful
hardening.

Stamp pods with a hash of the certificate so that they get restarted
whenever the certificate changes.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved TLS certificate tracking and validation for provisioning services.
  - Pod templates now record the active certificate hash to support certificate updates.
  - Removed the insecure TLS configuration from the BMO container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->