### PR TITLE
OCPBUGS-86888: Fix IDMS YAML serialization for oc image extract

### DIFF
--- a/provisioning/mirror_config.go
+++ b/provisioning/mirror_config.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"fmt"
@@ -64,7 +65,7 @@ func EnsureMirrorConfig(info *ProvisioningInfo) (bool, error) {
 
 	stripVolatileMetadata(idmsList)
 
-	idmsYAML, err := yaml.Marshal(idmsList)
+	idmsYAML, err := marshalIDMSMultiDoc(idmsList.Items)
 	if err != nil {
 		return false, fmt.Errorf("failed to serialize ImageDigestMirrorSets: %w", err)
 	}
@@ -94,6 +95,26 @@ func EnsureMirrorConfig(info *ProvisioningInfo) (bool, error) {
 		return false, fmt.Errorf("failed to apply mirror config ConfigMap: %w", err)
 	}
 	return updated, nil
+}
+
+// marshalIDMSMultiDoc serializes each ImageDigestMirrorSet as an individual
+// YAML document separated by "---". oc image extract --idms-file expects
+// top-level ImageDigestMirrorSet objects, not a Kubernetes List wrapper.
+func marshalIDMSMultiDoc(items []osconfigv1.ImageDigestMirrorSet) ([]byte, error) {
+	var buf bytes.Buffer
+	for i := range items {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		items[i].APIVersion = "config.openshift.io/v1"
+		items[i].Kind = "ImageDigestMirrorSet"
+		doc, err := yaml.Marshal(&items[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal ImageDigestMirrorSet %q: %w", items[i].Name, err)
+		}
+		buf.Write(doc)
+	}
+	return buf.Bytes(), nil
 }
 
 // stripVolatileMetadata removes server-set metadata fields (resourceVersion,

--- a/provisioning/mirror_config_test.go
+++ b/provisioning/mirror_config_test.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,6 +98,8 @@ func TestEnsureMirrorConfigWithIDMS(t *testing.T) {
 	assert.True(t, ok, "ConfigMap should contain idms.yaml key")
 	assert.Contains(t, yamlData, "quay.io/openshift-release-dev/ocp-v4.0-art-dev")
 	assert.Contains(t, yamlData, "mirror.local/openshift/release")
+	assert.Contains(t, yamlData, "kind: ImageDigestMirrorSet", "YAML must contain individual IDMS kind, not a List")
+	assert.NotContains(t, yamlData, "kind: ImageDigestMirrorSetList", "YAML must not be a List wrapper")
 	assert.NotEmpty(t, info.MirrorConfigHash, "hash should be set when IDMS resources exist")
 	assert.Len(t, info.MirrorConfigHash, 64, "hash should be a SHA-256 hex string")
 }
@@ -123,6 +126,61 @@ func TestEnsureMirrorConfigIdempotent(t *testing.T) {
 	updated, err := EnsureMirrorConfig(info)
 	require.NoError(t, err)
 	assert.False(t, updated, "second call should be a no-op")
+}
+
+func TestEnsureMirrorConfigMultipleIDMS(t *testing.T) {
+	idms1 := osconfigv1.ImageDigestMirrorSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mirror-a",
+		},
+		Spec: osconfigv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+				{
+					Source:  "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+					Mirrors: []osconfigv1.ImageMirror{"mirror.local/openshift/release"},
+				},
+			},
+		},
+	}
+	idms2 := osconfigv1.ImageDigestMirrorSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mirror-b",
+		},
+		Spec: osconfigv1.ImageDigestMirrorSetSpec{
+			ImageDigestMirrors: []osconfigv1.ImageDigestMirrors{
+				{
+					Source:  "registry.redhat.io/rhel9",
+					Mirrors: []osconfigv1.ImageMirror{"mirror.local/rhel9"},
+				},
+			},
+		},
+	}
+	info := newTestProvisioningInfo(idms1, idms2)
+
+	updated, err := EnsureMirrorConfig(info)
+	require.NoError(t, err)
+	assert.True(t, updated)
+
+	cm, err := info.Client.CoreV1().ConfigMaps(info.Namespace).Get(
+		t.Context(), mirrorConfigName, metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	yamlData := cm.Data["idms.yaml"]
+	assert.Contains(t, yamlData, "---", "multiple IDMS should be separated by YAML document separator")
+	assert.Contains(t, yamlData, "mirror-a")
+	assert.Contains(t, yamlData, "mirror-b")
+	assert.NotContains(t, yamlData, "kind: ImageDigestMirrorSetList")
+
+	docs := strings.Split(yamlData, "---")
+	nonEmpty := 0
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) != "" {
+			nonEmpty++
+			assert.Contains(t, doc, "kind: ImageDigestMirrorSet")
+		}
+	}
+	assert.Equal(t, 2, nonEmpty, "should have exactly 2 YAML documents")
 }
 
 func TestStripVolatileMetadata(t *testing.T) {


### PR DESCRIPTION
EnsureMirrorConfig was marshaling the entire ImageDigestMirrorSetList into the ConfigMap, producing a Kubernetes List without a Kind field. oc image extract --idms-file expects individual ImageDigestMirrorSet documents, not a List wrapper.

Serialize each IDMS item as a separate YAML document in a multi-doc stream, with explicit apiVersion and kind set on each entry.

Assisted-By: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mirror configuration output now uses separate YAML documents for each image mirror resource.
  * Generated resources include explicit API version and kind metadata.
  * Errors identify the specific mirror configuration that failed.

* **Tests**
  * Added coverage for single and multiple mirror resources, including document separation and resource details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->