### PR TITLE
OCPBUGS-114433: Increase firmware e2e timeouts and add HPE Mellanox NIC bastion mapping

### DIFF
--- a/tests-extension/openshift/test/e2e/host_firmware.go
+++ b/tests-extension/openshift/test/e2e/host_firmware.go
@@ -39,13 +39,13 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(initialBiosVersion).NotTo(o.BeEmpty(), "BIOS firmware version must not be empty")
 
-		nicComponent, initialNicVersion := getBastionNicComponent(oc, host)
+		nicComponent, initialNicVersion := getBastionNicComponent(oc, host, vendor)
 
 		e2e.Logf("Selected BMH: %s, Vendor: %s, BMC FW: %s, BIOS FW: %s, NIC: %s FW: %s", host, vendor, initialBmcVersion, initialBiosVersion, nicComponent, initialNicVersion)
 
 		bmcFwUrl := bastionBmcFirmwareURL(vendor, initialBmcVersion)
 		biosFwUrl := bastionBiosFirmwareURL(vendor, initialBiosVersion)
-		nicFwUrl := bastionNicFirmwareURL(initialNicVersion)
+		nicFwUrl := bastionNicFirmwareURL(vendor, initialNicVersion)
 
 		compat_otp.By("Update HFC CRD with BMC, BIOS and NIC firmware")
 		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"bmc","url":"%s"},{"component":"bios","url":"%s"},{"component":"%s","url":"%s"}]}]`, bmcFwUrl, biosFwUrl, nicComponent, nicFwUrl)
@@ -273,7 +273,7 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(initialBiosVersion).NotTo(o.BeEmpty(), "BIOS firmware version must not be empty")
 
-		nicComponent, initialNicVersion := getBastionNicComponent(oc, host)
+		nicComponent, initialNicVersion := getBastionNicComponent(oc, host, vendor)
 
 		e2e.Logf("Selected BMH: %s, Node: %s, Vendor: %s, BMC FW: %s, BIOS FW: %s, NIC: %s FW: %s", host, nodeName, vendor, initialBmcVersion, initialBiosVersion, nicComponent, initialNicVersion)
 
@@ -300,7 +300,7 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 
 		bmcFwUrl := bastionBmcFirmwareURL(vendor, initialBmcVersion)
 		biosFwUrl := bastionBiosFirmwareURL(vendor, initialBiosVersion)
-		nicFwUrl := bastionNicFirmwareURL(initialNicVersion)
+		nicFwUrl := bastionNicFirmwareURL(vendor, initialNicVersion)
 
 		compat_otp.By("Update HFC CRD with BMC, BIOS and NIC firmware")
 		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"bmc","url":"%s"},{"component":"bios","url":"%s"},{"component":"%s","url":"%s"}]}]`, bmcFwUrl, biosFwUrl, nicComponent, nicFwUrl)
@@ -427,7 +427,7 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(initialBiosVersion).NotTo(o.BeEmpty(), "BIOS firmware version must not be empty")
 
-		nicComponent, initialNicVersion := getBastionNicComponent(oc, host)
+		nicComponent, initialNicVersion := getBastionNicComponent(oc, host, vendor)
 
 		e2e.Logf("Selected BMH: %s, Node: %s, Vendor: %s, BMC FW: %s, BIOS FW: %s, NIC: %s FW: %s", host, nodeName, vendor, initialBmcVersion, initialBiosVersion, nicComponent, initialNicVersion)
 
@@ -454,7 +454,7 @@ var _ = g.Describe("[OTP][sig-baremetal] INSTALLER IPI for INSTALLER_DEDICATED j
 
 		bmcFwUrl := bastionBmcFirmwareURL(vendor, initialBmcVersion)
 		biosFwUrl := bastionBiosFirmwareURL(vendor, initialBiosVersion)
-		nicFwUrl := bastionNicFirmwareURL(initialNicVersion)
+		nicFwUrl := bastionNicFirmwareURL(vendor, initialNicVersion)
 
 		compat_otp.By("Update HFC CRD with BMC, BIOS and NIC firmware")
 		patchConfig := fmt.Sprintf(`[{"op": "replace", "path": "/spec/updates", "value": [{"component":"bmc","url":"%s"},{"component":"bios","url":"%s"},{"component":"%s","url":"%s"}]}]`, bmcFwUrl, biosFwUrl, nicComponent, nicFwUrl)

--- a/tests-extension/openshift/test/e2e/metal3_utils.go
+++ b/tests-extension/openshift/test/e2e/metal3_utils.go
@@ -59,7 +59,7 @@ func getWorkerBMH(oc *exutil.CLI) (host string, machineName string) {
 }
 
 func waitForBMHState(oc *exutil.CLI, bmhName string, bmhStatus string) {
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 90*time.Minute, true, func(ctx context.Context) (bool, error) {
 		out, err := oc.AsAdmin().Run("get").Args("-n", machineAPINamespace, "bmh", bmhName, "-o=jsonpath={.status.provisioning.state}").Output()
 		if err != nil {
 			return false, err
@@ -228,6 +228,8 @@ func bastionBmcFirmwareURL(vendor, currentVersion string) string {
 	case "HPE":
 		if strings.Contains(currentVersion, "iLO 5") {
 			switch currentVersion {
+			case "iLO 5 v3.02":
+				return bastionFirmwareBaseURL + "/ilo5_305.fwpkg"
 			case "iLO 5 v3.05":
 				return bastionFirmwareBaseURL + "/ilo5_321.fwpkg"
 			case "iLO 5 v3.21":
@@ -262,37 +264,50 @@ func bastionBiosFirmwareURL(vendor, currentVersion string) string {
 			e2e.Failf("Unsupported Dell BIOS version for bastion firmware: %s", currentVersion)
 		}
 	case "HPE":
-		switch currentVersion {
-		case "U46 v2.24":
-			return bastionFirmwareBaseURL + "/U46_2.64_04_01_2026.fwpkg"
-		case "U46 v2.64":
-			return bastionFirmwareBaseURL + "/U46_2.24_10_04_2024.fwpkg"
-		default:
-			e2e.Failf("Unsupported HPE BIOS version for bastion firmware: %s", currentVersion)
+		for _, ver := range []string{"U46 v2.24", "U46 v2.42"} {
+			if currentVersion == ver || strings.HasPrefix(currentVersion, ver+" ") {
+				return bastionFirmwareBaseURL + "/U46_2.64_04_01_2026.fwpkg"
+			}
 		}
+		if currentVersion == "U46 v2.64" || strings.HasPrefix(currentVersion, "U46 v2.64 ") {
+			return bastionFirmwareBaseURL + "/U46_2.24_10_04_2024.fwpkg"
+		}
+		e2e.Failf("Unsupported HPE BIOS version for bastion firmware: %s", currentVersion)
 	default:
 		e2e.Failf("Unsupported vendor for bastion BIOS firmware: %s", vendor)
 	}
 	return ""
 }
 
-var nicFirmwareArtifacts = map[string]string{
-	"16.35.80.02": "/Network_Firmware_XY16R_WN64_16.35.30.06_01.EXE",
-	"16.35.30.06": "/Network_Firmware_P5F14_WN64_16.35.80.02_A00.EXE",
+var nicFirmwareArtifacts = map[string]map[string]string{
+	"Dell Inc.": {
+		"16.35.80.02": "/Network_Firmware_XY16R_WN64_16.35.30.06_01.EXE",
+		"16.35.30.06": "/Network_Firmware_P5F14_WN64_16.35.80.02_A00.EXE",
+	},
+	// HPE ConnectX-6 Lx OCP3 (MCX631432AS-ADAI). 26.32.2004 is unpublished; 26.32.1010 is the HPE package.
+	"HPE": {
+		"26.32.2004": "/26_35_1012-MCX631432AS-ADA_Ax.pldm.fwpkg",
+		"26.32.1010": "/26_35_1012-MCX631432AS-ADA_Ax.pldm.fwpkg",
+		"26.35.1012": "/26_32_1010-MCX631432AS-ADA_Ax.pldm.fwpkg",
+	},
 }
 
-func bastionNicFirmwareURL(currentVersion string) string {
-	if artifact, ok := nicFirmwareArtifacts[currentVersion]; ok {
-		return bastionFirmwareBaseURL + artifact
+func bastionNicFirmwareURL(vendor, currentVersion string) string {
+	if artifacts, ok := nicFirmwareArtifacts[vendor]; ok {
+		if artifact, ok := artifacts[currentVersion]; ok {
+			return bastionFirmwareBaseURL + artifact
+		}
+		e2e.Failf("Unsupported %s NIC firmware version for bastion firmware: %s", vendor, currentVersion)
+		return ""
 	}
-	e2e.Failf("Unsupported NIC firmware version for bastion firmware: %s", currentVersion)
+	e2e.Failf("Unsupported vendor for bastion NIC firmware: %s", vendor)
 	return ""
 }
 
 func pollForFirmwareVersionChange(oc *exutil.CLI, host, component, initialVersion string) string {
 	jsonPath := fmt.Sprintf(`{.status.components[?(@.component=="%s")].currentVersion}`, component)
 	var currentVersion string
-	pollErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 		ver, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath="+jsonPath).Output()
 		if err != nil {
 			e2e.Logf("Transient error getting %s version: %v", component, err)
@@ -311,7 +326,7 @@ func pollForFirmwareVersionChange(oc *exutil.CLI, host, component, initialVersio
 	return currentVersion
 }
 
-func getBastionNicComponent(oc *exutil.CLI, host string) (string, string) {
+func getBastionNicComponent(oc *exutil.CLI, host, vendor string) (string, string) {
 	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("HostFirmwareComponents", "-n", machineAPINamespace, host, "-o=jsonpath={.status.components}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(output).NotTo(o.BeEmpty(), "HFC status components must not be empty")
@@ -323,12 +338,13 @@ func getBastionNicComponent(oc *exutil.CLI, host string) (string, string) {
 	err = json.Unmarshal([]byte(output), &components)
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to parse HFC status components")
 
+	artifacts := nicFirmwareArtifacts[vendor]
 	for _, c := range components {
-		if strings.HasPrefix(c.Component, "nic:") && nicFirmwareArtifacts[c.CurrentVersion] != "" {
+		if strings.HasPrefix(c.Component, "nic:") && artifacts[c.CurrentVersion] != "" {
 			e2e.Logf("Found supported NIC component: %s at version %s", c.Component, c.CurrentVersion)
 			return c.Component, c.CurrentVersion
 		}
 	}
-	e2e.Failf("No NIC component with supported firmware version found on host %s", host)
+	e2e.Failf("No NIC component with supported firmware version found on host %s vendor %s", host, vendor)
 	return "", ""
 }


### PR DESCRIPTION
## Summary
- Increase `waitForBMHState` timeout from 30 minutes to 90 minutes so DAY1 firmware e2e (OCP-75430) can finish deprovision, inspect, and reprovision.
- Increase `pollForFirmwareVersionChange` timeout from 5 minutes to 30 minutes. On HPE, batched BMC/BIOS/NIC apply after reboot took ~21 minutes for HFC status to refresh; the 5-minute poll failed a few seconds before versions appeared.
- Make NIC bastion URLs vendor-aware: keep Dell EXE mapping, add HPE ConnectX-6 Lx OCP3 (`26.32.2004`/`26.32.1010` ↔ `26.35.1012`).
- Match HPE BIOS versions that include a date suffix (`U46 v2.24 (10/04/2024)`), and map iLO 5 `v3.02` to the staged `ilo5_305.fwpkg`.
- Fixes [OCPBUGS-114433](https://issues.redhat.com/browse/OCPBUGS-114433).

## Test plan
- [x] Ran OCP-75430 (DAY1 BMC/BIOS/NIC firmware update) on a live Dell cluster; Ginkgo `SUCCESS! -- 1 Passed | 0 Failed`.
- [x] Ran OCP-78361 (DAY2 reboot annotation) on an HPE DL380 Gen10 Plus (`worker-03`). BMC `iLO 5 v3.02`→`v3.05`, BIOS `U46 v2.24`→`v2.64`, NIC `26.32.2004`→`26.35.1012`. Spec failed only because the 5-minute version poll expired ~6s before HFC updated; timeout is now 30 minutes.
- [x] Re-run 78361 on HPE after this poll-timeout change.
- [x] Confirm other tests that call `waitForBMHState` still complete within 90 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update validation across multiple hardware vendors.
  * Expanded HPE BIOS, BMC, and NIC firmware coverage, including additional supported firmware versions.
  * Improved vendor-specific NIC firmware selection for more reliable updates.
  * Reduced false failures during long-running firmware operations by allowing additional time for state transitions and version changes.
  * Improved firmware test reliability for extended hardware update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->