### PR TITLE
OCPBUGS-115067: Use bcrypt DefaultCost for Ironic passwords

### DIFF
--- a/provisioning/baremetal_secrets.go
+++ b/provisioning/baremetal_secrets.go
@@ -81,7 +81,7 @@ func createIronicSecret(info *ProvisioningInfo, name string, username string) er
 	if err != nil {
 		return err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), 5) // Use same cost as htpasswd default
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return err
 	}

--- a/provisioning/baremetal_secrets_test.go
+++ b/provisioning/baremetal_secrets_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,7 +128,21 @@ func TestCreatePasswordSecret(t *testing.T) {
 				if apierrors.IsNotFound(err) {
 					t.Errorf("Error creating Ironic secret.")
 				}
-				assert.True(t, strings.Compare(string(secret.(*corev1.Secret).Data[ironicUsernameKey]), ironicUsername) == 0, "ironic password created incorrectly")
+				created := secret.(*corev1.Secret)
+				assert.Equal(t, ironicUsername, string(created.Data[ironicUsernameKey]), "ironic username created incorrectly")
+
+				htpasswd := string(created.Data[ironicHtpasswdKey])
+				username, hash, found := strings.Cut(htpasswd, ":")
+				require.True(t, found, "htpasswd should be username:hash")
+				assert.Equal(t, ironicUsername, username)
+				assert.True(t, strings.HasPrefix(hash, "$2y$"), "htpasswd hash should use the $2y$ bcrypt version")
+
+				cost, err := bcrypt.Cost([]byte(hash))
+				require.NoError(t, err)
+				assert.Equal(t, bcrypt.DefaultCost, cost, "htpasswd hash should use bcrypt.DefaultCost")
+
+				err = bcrypt.CompareHashAndPassword([]byte(hash), created.Data[ironicPasswordKey])
+				assert.NoError(t, err, "htpasswd hash should match the generated password")
 			}
 		})
 	}


### PR DESCRIPTION
The cost is already encoded in the hash, so matching Apache htpasswd's cost of 5 is unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the security of generated Ironic passwords by using the standard bcrypt cost.
  * Ensured generated password records use valid bcrypt formatting and correctly match the associated password.

* **Tests**
  * Added validation for the username, bcrypt version, cost, and password hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->