### PR TITLE
OCPBUGS-115068: Validate Provisioning fields passed to containers

### DIFF
--- a/api/v1alpha1/provisioning_validation.go
+++ b/api/v1alpha1/provisioning_validation.go
@@ -263,6 +263,16 @@ func validateExternalIPs(ips []string) []error {
 	return errs
 }
 
+func validateHTTPURLHost(field string, parsedURL *url.URL) error {
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("unsupported scheme %q in %s", parsedURL.Scheme, field)
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("%s must include a host", field)
+	}
+	return nil
+}
+
 func validatePreProvisioningOSDownloadURLs(urls PreProvisioningOSDownloadURLs) []error {
 	var errs []error
 	fields := []struct {
@@ -287,8 +297,8 @@ func validatePreProvisioningOSDownloadURLs(urls PreProvisioningOSDownloadURLs) [
 			errs = append(errs, fmt.Errorf("%s %q is not a valid URL", f.name, f.uri))
 			continue
 		}
-		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			errs = append(errs, fmt.Errorf("unsupported scheme %q in %s %s", parsedURL.Scheme, f.name, f.uri))
+		if err := validateHTTPURLHost(f.name, parsedURL); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errs
@@ -312,9 +322,8 @@ func validateProvisioningOSDownloadURL(uri string) []error {
 		// If it's not a valid URI lets just return.
 		return errs
 	}
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		errs = append(errs, fmt.Errorf("unsupported scheme %q in provisioningOSDownloadURL %s", parsedURL.Scheme, uri))
-		// Again it's not worth it if it's not http(s)
+	if err := validateHTTPURLHost("provisioningOSDownloadURL", parsedURL); err != nil {
+		errs = append(errs, err)
 		return errs
 	}
 	var sha256Checksum string

--- a/api/v1alpha1/provisioning_validation.go
+++ b/api/v1alpha1/provisioning_validation.go
@@ -20,9 +20,12 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
+	"unicode"
 
 	"k8s.io/apimachinery/pkg/util/errors"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -32,6 +35,10 @@ type EnabledFeatures struct {
 
 var (
 	log = ctrl.Log.WithName("provisioning_validation")
+
+	// Linux interface names are at most IFNAMSIZ-1 (15) characters and should
+	// look like a device name: letters, digits, dots, underscores, and hyphens.
+	provisioningInterfaceRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,14}$`)
 )
 
 // ValidateBaremetalProvisioningConfig validates the contents of the provisioning resource
@@ -63,6 +70,30 @@ func (prov *Provisioning) ValidateBaremetalProvisioningConfig(enabledFeatures En
 
 	if !enabledFeatures.ProvisioningNetwork[provisioningNetworkMode] {
 		return errors.NewAggregate(append(errs, fmt.Errorf("ProvisioningNetwork %s is not supported", provisioningNetworkMode)))
+	}
+
+	// Sanity-check fields that are passed through to containers as environment
+	// variables (OCPBUGS-115068). These checks always apply, including when
+	// network settings are omitted in Disabled mode.
+	if err := validateProvisioningInterface(prov.Spec.ProvisioningInterface); err != nil {
+		errs = append(errs, err)
+	}
+	if err := validateAdditionalNTPServers(prov.Spec.AdditionalNTPServers); err != nil {
+		errs = append(errs, err...)
+	}
+	if err := validateProvisioningMacAddresses(prov.Spec.ProvisioningMacAddresses); err != nil {
+		errs = append(errs, err...)
+	}
+	if err := validateExternalIPs(prov.Spec.ExternalIPs); err != nil {
+		errs = append(errs, err...)
+	}
+	if err := validatePreProvisioningOSDownloadURLs(prov.Spec.PreProvisioningOSDownloadURLs); err != nil {
+		errs = append(errs, err...)
+	}
+	if prov.Spec.UnsupportedConfigOverrides != nil {
+		if err := validateNoUnsafeCharacters("unsupportedConfigOverrides.ironicAgentImage", prov.Spec.UnsupportedConfigOverrides.IronicAgentImage); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// They all use provisioningOSDownloadURL
@@ -145,10 +176,133 @@ func (prov *Provisioning) getProvisioningNetworkMode() ProvisioningNetwork {
 	return provisioningNetworkMode
 }
 
+// validateNoUnsafeCharacters rejects spaces, newlines, and other control
+// characters that should not appear in values copied into container env vars.
+func validateNoUnsafeCharacters(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f || unicode.IsSpace(r) {
+			return fmt.Errorf("%s %q contains invalid whitespace or control characters", field, value)
+		}
+	}
+	return nil
+}
+
+func validateProvisioningInterface(name string) error {
+	if name == "" {
+		return nil
+	}
+	if err := validateNoUnsafeCharacters("provisioningInterface", name); err != nil {
+		return err
+	}
+	if !provisioningInterfaceRegexp.MatchString(name) {
+		return fmt.Errorf("provisioningInterface %q is not a valid interface name (letters, numbers, dots, underscores, and hyphens; max 15 characters)", name)
+	}
+	return nil
+}
+
+func validateAdditionalNTPServers(servers []string) []error {
+	var errs []error
+	for i, server := range servers {
+		field := fmt.Sprintf("additionalNTPServers[%d]", i)
+		if server == "" {
+			errs = append(errs, fmt.Errorf("%s must not be empty", field))
+			continue
+		}
+		if err := validateNoUnsafeCharacters(field, server); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if net.ParseIP(server) != nil {
+			continue
+		}
+		if msgs := k8svalidation.IsDNS1123Subdomain(strings.ToLower(server)); len(msgs) > 0 {
+			errs = append(errs, fmt.Errorf("%s %q is not a valid hostname or IP address", field, server))
+		}
+	}
+	return errs
+}
+
+func validateProvisioningMacAddresses(macs []string) []error {
+	var errs []error
+	for i, mac := range macs {
+		field := fmt.Sprintf("provisioningMacAddresses[%d]", i)
+		if mac == "" {
+			errs = append(errs, fmt.Errorf("%s must not be empty", field))
+			continue
+		}
+		if err := validateNoUnsafeCharacters(field, mac); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if _, err := net.ParseMAC(mac); err != nil {
+			errs = append(errs, fmt.Errorf("%s %q is not a valid MAC address", field, mac))
+		}
+	}
+	return errs
+}
+
+func validateExternalIPs(ips []string) []error {
+	var errs []error
+	for i, ip := range ips {
+		field := fmt.Sprintf("externalIPs[%d]", i)
+		if ip == "" {
+			errs = append(errs, fmt.Errorf("%s must not be empty", field))
+			continue
+		}
+		if err := validateNoUnsafeCharacters(field, ip); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if net.ParseIP(ip) == nil {
+			errs = append(errs, fmt.Errorf("%s %q is not a valid IP address", field, ip))
+		}
+	}
+	return errs
+}
+
+func validatePreProvisioningOSDownloadURLs(urls PreProvisioningOSDownloadURLs) []error {
+	var errs []error
+	fields := []struct {
+		name string
+		uri  string
+	}{
+		{"preProvisioningOSDownloadURLs.isoURL", urls.IsoURL},
+		{"preProvisioningOSDownloadURLs.kernelURL", urls.KernelURL},
+		{"preProvisioningOSDownloadURLs.initramfsURL", urls.InitramfsURL},
+		{"preProvisioningOSDownloadURLs.rootfsURL", urls.RootfsURL},
+	}
+	for _, f := range fields {
+		if f.uri == "" {
+			continue
+		}
+		if err := validateNoUnsafeCharacters(f.name, f.uri); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		parsedURL, err := url.ParseRequestURI(f.uri)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s %q is not a valid URL", f.name, f.uri))
+			continue
+		}
+		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+			errs = append(errs, fmt.Errorf("unsupported scheme %q in %s %s", parsedURL.Scheme, f.name, f.uri))
+		}
+	}
+	return errs
+}
+
 func validateProvisioningOSDownloadURL(uri string) []error {
 	var errs []error
 
 	if uri == "" {
+		return errs
+	}
+
+	if err := validateNoUnsafeCharacters("provisioningOSDownloadURL", uri); err != nil {
+		errs = append(errs, err)
 		return errs
 	}
 

--- a/api/v1alpha1/provisioning_validation_test.go
+++ b/api/v1alpha1/provisioning_validation_test.go
@@ -614,7 +614,7 @@ func (pb *provisioningBuilder) PreProvisioningOSDownloadURLs(value PreProvisioni
 }
 
 func (pb *provisioningBuilder) IronicAgentImage(value string) *provisioningBuilder {
-	pb.ProvisioningSpec.UnsupportedConfigOverrides = &UnsupportedConfigOverrides{IronicAgentImage: value}
+	pb.UnsupportedConfigOverrides = &UnsupportedConfigOverrides{IronicAgentImage: value}
 	return pb
 }
 
@@ -734,6 +734,12 @@ func TestValidateProvisioningFieldFormats(t *testing.T) {
 			spec:          managedProvisioning().PreProvisioningOSDownloadURLs(PreProvisioningOSDownloadURLs{IsoURL: "gopher://example.com/rhcos.iso"}).build(),
 			expectedError: true,
 			expectedMsg:   "preProvisioningOSDownloadURLs.isoURL",
+		},
+		{
+			name:          "InvalidPreProvisioningURLMissingHost",
+			spec:          managedProvisioning().PreProvisioningOSDownloadURLs(PreProvisioningOSDownloadURLs{IsoURL: "http:/rhcos.iso"}).build(),
+			expectedError: true,
+			expectedMsg:   "must include a host",
 		},
 		{
 			name:          "InvalidIronicAgentImageWithNewline",

--- a/api/v1alpha1/provisioning_validation_test.go
+++ b/api/v1alpha1/provisioning_validation_test.go
@@ -592,3 +592,175 @@ func (pb *provisioningBuilder) ProvisioningNetworkGateway(value string) *provisi
 	pb.ProvisioningSpec.ProvisioningNetworkGateway = value
 	return pb
 }
+
+func (pb *provisioningBuilder) AdditionalNTPServers(value []string) *provisioningBuilder {
+	pb.ProvisioningSpec.AdditionalNTPServers = value
+	return pb
+}
+
+func (pb *provisioningBuilder) ProvisioningMacAddresses(value []string) *provisioningBuilder {
+	pb.ProvisioningSpec.ProvisioningMacAddresses = value
+	return pb
+}
+
+func (pb *provisioningBuilder) ExternalIPs(value []string) *provisioningBuilder {
+	pb.ProvisioningSpec.ExternalIPs = value
+	return pb
+}
+
+func (pb *provisioningBuilder) PreProvisioningOSDownloadURLs(value PreProvisioningOSDownloadURLs) *provisioningBuilder {
+	pb.ProvisioningSpec.PreProvisioningOSDownloadURLs = value
+	return pb
+}
+
+func (pb *provisioningBuilder) IronicAgentImage(value string) *provisioningBuilder {
+	pb.ProvisioningSpec.UnsupportedConfigOverrides = &UnsupportedConfigOverrides{IronicAgentImage: value}
+	return pb
+}
+
+func allProvisioningNetworkFeatures() EnabledFeatures {
+	return EnabledFeatures{
+		ProvisioningNetwork: map[ProvisioningNetwork]bool{
+			ProvisioningNetworkManaged:   true,
+			ProvisioningNetworkUnmanaged: true,
+			ProvisioningNetworkDisabled:  true,
+		},
+	}
+}
+
+func TestValidateProvisioningFieldFormats(t *testing.T) {
+	baremetalCR := &Provisioning{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Provisioning",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testBaremetalProvisioningCR,
+		},
+	}
+
+	tCases := []struct {
+		name          string
+		spec          *ProvisioningSpec
+		expectedError bool
+		expectedMsg   string
+	}{
+		{
+			name:          "ValidInterfaceVariants",
+			spec:          managedProvisioning().ProvisioningInterface("br-ex").build(),
+			expectedError: false,
+		},
+		{
+			name:          "ValidVlanInterface",
+			spec:          managedProvisioning().ProvisioningInterface("eno1.100").build(),
+			expectedError: false,
+		},
+		{
+			name:          "InvalidInterfaceWithSpace",
+			spec:          managedProvisioning().ProvisioningInterface("eth 0").build(),
+			expectedError: true,
+			expectedMsg:   "provisioningInterface",
+		},
+		{
+			name:          "InvalidInterfaceWithNewline",
+			spec:          managedProvisioning().ProvisioningInterface("eth0\neth1").build(),
+			expectedError: true,
+			expectedMsg:   "provisioningInterface",
+		},
+		{
+			name:          "InvalidInterfaceWithShellMetacharacters",
+			spec:          managedProvisioning().ProvisioningInterface("eth0;id").build(),
+			expectedError: true,
+			expectedMsg:   "not a valid interface name",
+		},
+		{
+			name:          "InvalidInterfaceTooLong",
+			spec:          managedProvisioning().ProvisioningInterface("enx0011223344556").build(),
+			expectedError: true,
+			expectedMsg:   "not a valid interface name",
+		},
+		{
+			name:          "ValidNTPServers",
+			spec:          managedProvisioning().AdditionalNTPServers([]string{"192.168.1.1", "pool.ntp.org", "2001:db8::1"}).build(),
+			expectedError: false,
+		},
+		{
+			name:          "InvalidNTPServerNotHostOrIP",
+			spec:          managedProvisioning().AdditionalNTPServers([]string{"not_a_host"}).build(),
+			expectedError: true,
+			expectedMsg:   "additionalNTPServers[0]",
+		},
+		{
+			name:          "InvalidNTPServerWithNewline",
+			spec:          managedProvisioning().AdditionalNTPServers([]string{"pool.ntp.org\nmalicious"}).build(),
+			expectedError: true,
+			expectedMsg:   "additionalNTPServers[0]",
+		},
+		{
+			name:          "InvalidEmptyNTPServer",
+			spec:          managedProvisioning().AdditionalNTPServers([]string{""}).build(),
+			expectedError: true,
+			expectedMsg:   "additionalNTPServers[0] must not be empty",
+		},
+		{
+			name:          "ValidMacAddresses",
+			spec:          managedProvisioning().ProvisioningMacAddresses([]string{"00:11:22:33:44:55", "aa:bb:cc:dd:ee:ff"}).build(),
+			expectedError: false,
+		},
+		{
+			name:          "InvalidMacAddress",
+			spec:          managedProvisioning().ProvisioningMacAddresses([]string{"not-a-mac"}).build(),
+			expectedError: true,
+			expectedMsg:   "not a valid MAC address",
+		},
+		{
+			name:          "ValidExternalIPs",
+			spec:          managedProvisioning().ExternalIPs([]string{"192.0.2.10", "2001:db8::10"}).build(),
+			expectedError: false,
+		},
+		{
+			name:          "InvalidExternalIP",
+			spec:          managedProvisioning().ExternalIPs([]string{"not-an-ip"}).build(),
+			expectedError: true,
+			expectedMsg:   "externalIPs[0]",
+		},
+		{
+			name:          "ValidPreProvisioningURLs",
+			spec:          managedProvisioning().PreProvisioningOSDownloadURLs(PreProvisioningOSDownloadURLs{IsoURL: "https://example.com/rhcos.iso"}).build(),
+			expectedError: false,
+		},
+		{
+			name:          "InvalidPreProvisioningURLScheme",
+			spec:          managedProvisioning().PreProvisioningOSDownloadURLs(PreProvisioningOSDownloadURLs{IsoURL: "gopher://example.com/rhcos.iso"}).build(),
+			expectedError: true,
+			expectedMsg:   "preProvisioningOSDownloadURLs.isoURL",
+		},
+		{
+			name:          "InvalidIronicAgentImageWithNewline",
+			spec:          managedProvisioning().IronicAgentImage("quay.io/example/ironic-agent:latest\nmalicious").build(),
+			expectedError: true,
+			expectedMsg:   "unsupportedConfigOverrides.ironicAgentImage",
+		},
+		{
+			name:          "DisabledEmptyNetworkStillValidatesInterface",
+			spec:          disabledProvisioning().ProvisioningIP("").ProvisioningNetworkCIDR("").ProvisioningInterface("eth0;id").build(),
+			expectedError: true,
+			expectedMsg:   "not a valid interface name",
+		},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			baremetalCR.Spec = *tc.spec
+			err := baremetalCR.ValidateBaremetalProvisioningConfig(allProvisioningNetworkFeatures())
+			if !tc.expectedError && err != nil {
+				t.Errorf("unexpected errors: %v", err)
+				return
+			}
+			if tc.expectedError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reject malformed interface names, NTP servers, MACs, IPs, and control characters so those values are not copied unsanitized into metal3 env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for provisioning network configuration fields, including interface names, NTP servers, MAC addresses, external IPs, and download URLs.
  * Rejects values containing whitespace or control characters before they are passed to containers.
  * Ensures relevant fields are validated consistently, including when network provisioning is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->