### PR TITLE
OCPBUGS-112613: Pass release image pullspec to machine-os-images

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - clusterversions
   - imagedigestmirrorsets
   - infrastructures
   - networks

--- a/controllers/provisioning_controller.go
+++ b/controllers/provisioning_controller.go
@@ -109,6 +109,7 @@ type ensureFunc func(*provisioning.ProvisioningInfo) (bool, error)
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=networks,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators;clusteroperators/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;infrastructures/status,verbs=get
@@ -460,6 +461,17 @@ func (r *ProvisioningReconciler) provisioningInfo(ctx context.Context, provConfi
 	}
 	enableBaremetalWebhook := provisioning.BaremetalWebhookDependenciesReady(r.OSClient)
 
+	releaseImage := ""
+	cv, err := r.OSClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to read ClusterVersion for release image: %w", err)
+		}
+		klog.Info("ClusterVersion not found; machine-os-images will not run oc adm release info")
+	} else {
+		releaseImage = cv.Status.Desired.Image
+	}
+
 	return &provisioning.ProvisioningInfo{
 		Client:                  r.KubeClient,
 		DynamicClient:           r.DynamicClient,
@@ -476,6 +488,7 @@ func (r *ProvisioningReconciler) provisioningInfo(ctx context.Context, provConfi
 		OSClient:                r.OSClient,
 		ResourceCache:           r.ResourceCache,
 		IsHyperShift:            isHyperShift,
+		ReleaseImage:            releaseImage,
 	}, nil
 }
 
@@ -758,6 +771,7 @@ func (r *ProvisioningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&osconfigv1.Proxy{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.APIServer{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&osconfigv1.ImageDigestMirrorSet{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
+		Watches(&osconfigv1.ClusterVersion{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton)).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(mapToProvisioningSingleton), builder.WithPredicates(pullSecretFilter)).
 		Complete(r)
 }

--- a/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
+++ b/manifests/0000_31_cluster-baremetal-operator_05_rbac.yaml
@@ -150,6 +150,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - clusterversions
   - imagedigestmirrorsets
   - infrastructures
   - networks

--- a/provisioning/machine_os_images.go
+++ b/provisioning/machine_os_images.go
@@ -32,6 +32,10 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 				Name:  "MACHINE_OS_IMAGES_IMAGE",
 				Value: info.Images.MachineOSImages,
 			},
+			{
+				Name:  "RELEASE_IMAGE",
+				Value: info.ReleaseImage,
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/provisioning/machine_os_images_test.go
+++ b/provisioning/machine_os_images_test.go
@@ -1,0 +1,26 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+)
+
+func TestCreateInitContainerMachineOSImagesReleaseImage(t *testing.T) {
+	releaseImage := "quay.io/openshift-release-dev/ocp-release@sha256:deadbeef"
+	info := &ProvisioningInfo{
+		Images:       &Images{MachineOSImages: expectedMachineOSImages},
+		ProvConfig:   &metal3iov1alpha1.Provisioning{},
+		NetworkStack: NetworkStackV4,
+		ReleaseImage: releaseImage,
+	}
+
+	c := createInitContainerMachineOSImages(info, "--pxe", imageVolumeMount, imageSharedDir)
+
+	assert.Equal(t, "machine-os-images", c.Name)
+	assert.Contains(t, c.Env, corev1.EnvVar{Name: "MACHINE_OS_IMAGES_IMAGE", Value: expectedMachineOSImages})
+	assert.Contains(t, c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE", Value: releaseImage})
+}

--- a/provisioning/provisioning_info.go
+++ b/provisioning/provisioning_info.go
@@ -55,4 +55,9 @@ type ProvisioningInfo struct {
 	IsHyperShift            bool
 	MirrorConfigHash        string
 	TlsCertHash             string
+	// ReleaseImage is the cluster release payload pullspec from
+	// ClusterVersion.status.desired.image. The machine-os-images init
+	// container uses it with oc adm release info --idms-file to detect a
+	// multi-arch payload. Empty when ClusterVersion is unavailable.
+	ReleaseImage string
 }


### PR DESCRIPTION
## Summary
- Pass `RELEASE_IMAGE` (`ClusterVersion.status.desired.image`) into the `machine-os-images` init container so `copy-metal` can run `oc adm release info --idms-file` and tell a multi-arch payload from single-arch CI.
- Add get/list/watch on `clusterversions` and watch ClusterVersion so metal3 rolls when the payload changes.
- Companion change: https://github.com/openshift/machine-os-images/pull/113

## Test plan
- [ ] Unit tests: `go test ./provisioning/ ./controllers/`
- [ ] Confirm the `machine-os-images` init container on metal3/ICC has `RELEASE_IMAGE` set to the cluster release pullspec
- [ ] Missing ClusterVersion leaves `RELEASE_IMAGE` empty (machine-os-images keeps the extract-and-skip path)
- [ ] With machine-os-images PR 113: single-arch payload skips aarch64 extract; multi-arch extract/checksum failure is fatal


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provisioning now uses the cluster’s desired release image when preparing machine OS images.
  - Machine OS image initialization supports release image detection for multi-architecture payloads.
  - The operator now observes cluster version changes and handles unavailable release information gracefully.

- **Tests**
  - Added coverage verifying that the release image is passed to the machine OS image container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->