### PR TITLE
OCPBUGS-115207: Make HostPath VolumeMounts ReadOnly for image customization container

### DIFF
--- a/provisioning/image_customization.go
+++ b/provisioning/image_customization.go
@@ -65,10 +65,12 @@ var (
 	imageRegistriesVolumeMount = corev1.VolumeMount{
 		Name:      imageCustomizationVolume,
 		MountPath: containerRegistriesConfPath,
+		ReadOnly:  true,
 	}
 	caTrustDirVolumeMount = corev1.VolumeMount{
 		Name:      containerCATrustDirVolume,
 		MountPath: containerCATrustDirPath,
+		ReadOnly:  true,
 	}
 	ironicAgentPullSecretMount = corev1.VolumeMount{
 		Name:      ironicAgentPullSecret,
@@ -151,6 +153,9 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 		agentImage = info.ProvConfig.Spec.UnsupportedConfigOverrides.IronicAgentImage
 	}
 
+	readOnlyImageVolumeMount := imageVolumeMount
+	readOnlyImageVolumeMount.ReadOnly = true
+
 	container := corev1.Container{
 		Name:  "machine-image-customization-controller",
 		Image: images.ImageCustomizationController,
@@ -172,7 +177,7 @@ func createImageCustomizationContainer(images *Images, info *ProvisioningInfo, i
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			imageRegistriesVolumeMount,
-			imageVolumeMount,
+			readOnlyImageVolumeMount,
 			ironicAgentPullSecretMount,
 			caTrustDirVolumeMount,
 		},

--- a/provisioning/image_customization_test.go
+++ b/provisioning/image_customization_test.go
@@ -48,9 +48,11 @@ func TestNewImageCustomizationContainer(t *testing.T) {
 	ironicIP := "192.168.0.2"
 	ironicIP6 := "2001:db8::2"
 
+	readOnlyImageVolumeMount := imageVolumeMount
+	readOnlyImageVolumeMount.ReadOnly = true
 	expectedVolumeMounts := []corev1.VolumeMount{
 		imageRegistriesVolumeMount,
-		imageVolumeMount,
+		readOnlyImageVolumeMount,
 		ironicAgentPullSecretMount,
 		caTrustDirVolumeMount,
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Image customization container volume mounts are now read-only, helping prevent unintended changes to mounted image and certificate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->